### PR TITLE
CDC #16 - User defined fields

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem 'faker', '~> 3.2.1'
 gem 'resource_api', git: 'https://github.com/performant-software/resource-api.git', tag: 'v0.5.3'
-
-#gem 'user_defined_fields', git: 'https://github.com/performant-software/user-defined-fields.git', tag: 'v0.1.7'
-gem 'user_defined_fields', path: '../user-defined-fields'
+gem 'user_defined_fields', git: 'https://github.com/performant-software/user-defined-fields.git', tag: 'v0.1.8'
 gem 'sqlite3'
 
 # Specify your gem's dependencies in core_data_connector.gemspec.

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,10 @@ source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem 'faker', '~> 3.2.1'
-gem 'resource_api', git: 'https://github.com/performant-software/resource-api.git', tag: 'v0.5.2'
-gem 'user_defined_fields', git: 'https://github.com/performant-software/user-defined-fields.git', tag: 'v0.1.7'
-
+#gem 'resource_api', git: 'https://github.com/performant-software/resource-api.git', tag: 'v0.5.2'
+gem 'resource_api', path: '../resource-api'
+#gem 'user_defined_fields', git: 'https://github.com/performant-software/user-defined-fields.git', tag: 'v0.1.7'
+gem 'user_defined_fields', path: '../user-defined-fields'
 gem 'sqlite3'
 
 # Specify your gem's dependencies in core_data_connector.gemspec.

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@ source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem 'faker', '~> 3.2.1'
-#gem 'resource_api', git: 'https://github.com/performant-software/resource-api.git', tag: 'v0.5.2'
-gem 'resource_api', path: '../resource-api'
+gem 'resource_api', git: 'https://github.com/performant-software/resource-api.git', tag: 'v0.5.3'
+
 #gem 'user_defined_fields', git: 'https://github.com/performant-software/user-defined-fields.git', tag: 'v0.1.7'
 gem 'user_defined_fields', path: '../user-defined-fields'
 gem 'sqlite3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,10 @@ GIT
       pundit (~> 2.3.1)
       rails (>= 7.0, < 8)
 
-PATH
-  remote: ../user-defined-fields
+GIT
+  remote: https://github.com/performant-software/user-defined-fields.git
+  revision: 4872b3f1e7c5d4ecf83aedc30202aab91589e5ed
+  tag: v0.1.8
   specs:
     user_defined_fields (0.1.0)
       rails (>= 6.0.3.2, < 8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,7 @@
-PATH
-  remote: ../resource-api
+GIT
+  remote: https://github.com/performant-software/resource-api.git
+  revision: f1092734efc2f1e86c9d7bd3a0c5b70e57c3b3ca
+  tag: v0.5.3
   specs:
     resource_api (0.1.0)
       pagy (~> 5.10)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,13 @@
-GIT
-  remote: https://github.com/performant-software/resource-api.git
-  revision: 74147118915f09b7e34b3552053820b9070efbd8
-  tag: v0.5.2
+PATH
+  remote: ../resource-api
   specs:
     resource_api (0.1.0)
       pagy (~> 5.10)
       pundit (~> 2.3.1)
       rails (>= 7.0, < 8)
 
-GIT
-  remote: https://github.com/performant-software/user-defined-fields.git
-  revision: 18e14d28d6daefa403699617e3807eb646a31bcc
-  tag: v0.1.7
+PATH
+  remote: ../user-defined-fields
   specs:
     user_defined_fields (0.1.0)
       rails (>= 6.0.3.2, < 8)

--- a/app/controllers/core_data_connector/organizations_controller.rb
+++ b/app/controllers/core_data_connector/organizations_controller.rb
@@ -3,6 +3,7 @@ module CoreDataConnector
     # Includes
     include NameableController
     include OwnableController
+    include UserDefinedFields::Queryable
 
     # Search attributes
     search_attributes :name

--- a/app/controllers/core_data_connector/people_controller.rb
+++ b/app/controllers/core_data_connector/people_controller.rb
@@ -3,8 +3,9 @@ module CoreDataConnector
     # Includes
     include NameableController
     include OwnableController
+    include UserDefinedFields::Queryable
 
     # Search attributes
-    search_attributes :last_name, :first_name, :middle_name
+    search_attributes :first_name, :middle_name, :last_name
   end
 end

--- a/app/controllers/core_data_connector/places_controller.rb
+++ b/app/controllers/core_data_connector/places_controller.rb
@@ -3,6 +3,7 @@ module CoreDataConnector
     # Includes
     include NameableController
     include OwnableController
+    include UserDefinedFields::Queryable
 
     # Search attributes
     search_attributes :name

--- a/app/controllers/core_data_connector/relationships_controller.rb
+++ b/app/controllers/core_data_connector/relationships_controller.rb
@@ -1,5 +1,8 @@
 module CoreDataConnector
   class RelationshipsController < ApplicationController
+    # Includes
+    include UserDefinedFields::Queryable
+
     protected
 
     def base_query

--- a/app/models/core_data_connector/organization.rb
+++ b/app/models/core_data_connector/organization.rb
@@ -4,11 +4,15 @@ module CoreDataConnector
     include Nameable
     include Ownable
     include Relateable
+    include UserDefinedFields::Fieldable
 
     # Relationships
     belongs_to :project_model
 
     # Delegates
     delegate :name, to: :primary_name
+
+    # User defined fields parent
+    resolve_defineable -> (organization) { organization.project_model }
   end
 end

--- a/app/models/core_data_connector/person.rb
+++ b/app/models/core_data_connector/person.rb
@@ -4,11 +4,15 @@ module CoreDataConnector
     include Nameable
     include Ownable
     include Relateable
+    include UserDefinedFields::Fieldable
 
     # Relationships
     belongs_to :project_model
 
     # Delegates
     delegate :first_name, :middle_name, :last_name, to: :primary_name
+
+    # User defined fields parent
+    resolve_defineable -> (person) { person.project_model }
   end
 end

--- a/app/models/core_data_connector/place.rb
+++ b/app/models/core_data_connector/place.rb
@@ -6,11 +6,15 @@ module CoreDataConnector
     include Nameable
     include Ownable
     include Relateable
+    include UserDefinedFields::Fieldable
 
     # Relationships
     belongs_to :project_model
 
     # Delegates
     delegate :name, to: :primary_name
+
+    # User defined fields parent
+    resolve_defineable -> (place) { place.project_model }
   end
 end

--- a/app/models/core_data_connector/project_model.rb
+++ b/app/models/core_data_connector/project_model.rb
@@ -34,6 +34,11 @@ module CoreDataConnector
       model_class&.safe_constantize&.model_name&.human
     end
 
+    # Returns the singular version of the name.
+    def name_singular
+      name&.singularize
+    end
+
     private
 
     # Returns a list of valid model class names.

--- a/app/models/core_data_connector/project_model_relationship.rb
+++ b/app/models/core_data_connector/project_model_relationship.rb
@@ -2,6 +2,7 @@ module CoreDataConnector
   class ProjectModelRelationship < ApplicationRecord
     # Includes
     include Sluggable
+    include UserDefinedFields::Defineable
 
     # Relationships
     belongs_to :primary_model, class_name: ProjectModel.to_s

--- a/app/models/core_data_connector/relationship.rb
+++ b/app/models/core_data_connector/relationship.rb
@@ -1,9 +1,17 @@
 module CoreDataConnector
   class Relationship < ApplicationRecord
+    # Includes
+    include UserDefinedFields::Fieldable
+
+    # Relationships
     belongs_to :project_model_relationship
     belongs_to :primary_record, polymorphic: true
     belongs_to :related_record, polymorphic: true
 
+    # Delegates
     delegate :project_id, to: :project_model_relationship
+
+    # User defined fields parent
+    resolve_defineable -> (relationship) { relationship.project_model_relationship }
   end
 end

--- a/app/policies/core_data_connector/organization_policy.rb
+++ b/app/policies/core_data_connector/organization_policy.rb
@@ -12,7 +12,7 @@ module CoreDataConnector
 
     # Allowed create/update attributes.
     def permitted_attributes
-      attrs = [:description]
+      attrs = [:description, user_defined: {}]
       attrs << ownable_attributes
       attrs << { organization_names_attributes: [:id, :name, :primary, :_destroy] }
       attrs

--- a/app/policies/core_data_connector/person_policy.rb
+++ b/app/policies/core_data_connector/person_policy.rb
@@ -12,7 +12,7 @@ module CoreDataConnector
 
     # Allowed create/update attributes.
     def permitted_attributes
-      attrs = [:biography]
+      attrs = [:biography, user_defined: {}]
       attrs << ownable_attributes
       attrs << { person_names_attributes: [:id, :first_name, :middle_name, :last_name, :primary, :_destroy] }
       attrs

--- a/app/policies/core_data_connector/place_policy.rb
+++ b/app/policies/core_data_connector/place_policy.rb
@@ -12,7 +12,7 @@ module CoreDataConnector
 
     # Allowed create/update attributes.
     def permitted_attributes
-      attrs = []
+      attrs = [user_defined: {}]
       attrs << ownable_attributes
       attrs << { place_names_attributes: [:id, :name, :primary, :_destroy] }
       attrs

--- a/app/policies/core_data_connector/project_model_policy.rb
+++ b/app/policies/core_data_connector/project_model_policy.rb
@@ -37,7 +37,7 @@ module CoreDataConnector
 
     def permitted_attributes
       [:project_id, :name, :model_class, :slug, *ProjectModel.permitted_params,
-       project_model_relationships_attributes: [:id, :related_model_id, :name, :multiple, :slug, :_destroy]]
+       project_model_relationships_attributes: [:id, :related_model_id, :name, :multiple, :slug, :_destroy, *ProjectModelRelationship.permitted_params]]
     end
 
     private

--- a/app/policies/core_data_connector/relationship_policy.rb
+++ b/app/policies/core_data_connector/relationship_policy.rb
@@ -11,32 +11,28 @@ module CoreDataConnector
     end
 
     def permitted_attributes
-      [:project_model_relationship_id, :primary_record_id, :primary_record_type, :related_record_id, :related_record_type]
+      [:project_model_relationship_id, :primary_record_id, :primary_record_type, :related_record_id, :related_record_type, user_defined: {}]
     end
 
     class Scope < BaseScope
       def resolve
         return scope.all if current_user.admin?
 
-        def resolve
-          return scope.all if current_user.admin?
-
-          if scope.is_a?(Class)
-            ownable_table = scope.arel_table
-          elsif scope.is_a?(ActiveRecord::Relation)
-            ownable_table = scope.klass.arel_table
-          end
-
-          scope
-            .where(
-              UserProject
-                .joins(project: [project_models: :project_model_relationships])
-                .where(ProjectModelRelationship.arel_table[:id].eq(ownable_table[:project_model_relationship_id]))
-                .where(user_id: current_user.id)
-                .arel
-                .exists
-            )
+        if scope.is_a?(Class)
+          ownable_table = scope.arel_table
+        elsif scope.is_a?(ActiveRecord::Relation)
+          ownable_table = scope.klass.arel_table
         end
+
+        scope
+          .where(
+            UserProject
+              .joins(project: [project_models: :project_model_relationships])
+              .where(ProjectModelRelationship.arel_table[:id].eq(ownable_table[:project_model_relationship_id]))
+              .where(user_id: current_user.id)
+              .arel
+              .exists
+          )
       end
     end
   end

--- a/app/serializers/core_data_connector/organizations_serializer.rb
+++ b/app/serializers/core_data_connector/organizations_serializer.rb
@@ -1,5 +1,7 @@
 module CoreDataConnector
   class OrganizationsSerializer < BaseSerializer
+    include UserDefinedFields::FieldableSerializer
+
     index_attributes :id, :name
     show_attributes :id, :name, :description, organization_names: [:id, :name, :primary]
   end

--- a/app/serializers/core_data_connector/people_serializer.rb
+++ b/app/serializers/core_data_connector/people_serializer.rb
@@ -1,5 +1,7 @@
 module CoreDataConnector
   class PeopleSerializer < BaseSerializer
+    include UserDefinedFields::FieldableSerializer
+
     index_attributes :id, :first_name, :middle_name, :last_name
     show_attributes :id, :first_name, :middle_name, :last_name, :biography, person_names: [:id, :first_name, :middle_name, :last_name, :primary]
   end

--- a/app/serializers/core_data_connector/places_serializer.rb
+++ b/app/serializers/core_data_connector/places_serializer.rb
@@ -1,5 +1,7 @@
 module CoreDataConnector
   class PlacesSerializer < BaseSerializer
+    include UserDefinedFields::FieldableSerializer
+
     index_attributes :id, :name
     show_attributes :id, :name, place_names: [:id, :name, :primary]
   end

--- a/app/serializers/core_data_connector/project_models_serializer.rb
+++ b/app/serializers/core_data_connector/project_models_serializer.rb
@@ -3,8 +3,11 @@ module CoreDataConnector
     # Includes
     include UserDefinedFields::DefineableSerializer
 
-    index_attributes :id, :project_id, :name, :model_class, :model_class_view, :slug
-    show_attributes :id, :project_id, :name, :model_class, :model_class_view, :slug,
-                    project_model_relationships: [:id, :related_model_id, :name, :multiple, :slug, related_model: ProjectModelsSerializer]
+    index_attributes :id, :project_id, :name, :name_singular, :model_class, :model_class_view, :slug
+
+    show_attributes :id, :project_id, :name, :name_singular, :model_class, :model_class_view, :slug,
+                    project_model_relationships: [:id, :related_model_id, :name, :multiple, :slug,
+                                                  related_model: ProjectModelsSerializer,
+                                                  user_defined_fields: UserDefinedFields::UserDefinedFieldsSerializer]
   end
 end

--- a/app/serializers/core_data_connector/relationships_serializer.rb
+++ b/app/serializers/core_data_connector/relationships_serializer.rb
@@ -1,5 +1,7 @@
 module CoreDataConnector
   class RelationshipsSerializer < BaseSerializer
+    include UserDefinedFields::FieldableSerializer
+
     index_attributes :id, :related_record_id, :related_record_type, related_record: FactorySerializer
     show_attributes :id, :related_record_id, :related_record_type, related_record: FactorySerializer
   end

--- a/db/migrate/20230918201537_add_user_defined_fields_to_core_data_connector_organizations.rb
+++ b/db/migrate/20230918201537_add_user_defined_fields_to_core_data_connector_organizations.rb
@@ -1,0 +1,11 @@
+class AddUserDefinedFieldsToCoreDataConnectorOrganizations < ActiveRecord::Migration[7.0]
+  def up
+    add_column :core_data_connector_organizations, :user_defined, :jsonb, default: {}
+    add_index :core_data_connector_organizations, :user_defined, using: :gin
+  end
+
+  def down
+    remove_index :core_data_connector_organizations, :user_defined
+    remove_column :core_data_connector_organizations, :user_defined
+  end
+end

--- a/db/migrate/20230918201546_add_user_defined_fields_to_core_data_connector_people.rb
+++ b/db/migrate/20230918201546_add_user_defined_fields_to_core_data_connector_people.rb
@@ -1,0 +1,11 @@
+class AddUserDefinedFieldsToCoreDataConnectorPeople < ActiveRecord::Migration[7.0]
+  def up
+    add_column :core_data_connector_people, :user_defined, :jsonb, default: {}
+    add_index :core_data_connector_people, :user_defined, using: :gin
+  end
+
+  def down
+    remove_index :core_data_connector_people, :user_defined
+    remove_column :core_data_connector_people, :user_defined
+  end
+end

--- a/db/migrate/20230918201552_add_user_defined_fields_to_core_data_connector_places.rb
+++ b/db/migrate/20230918201552_add_user_defined_fields_to_core_data_connector_places.rb
@@ -1,0 +1,11 @@
+class AddUserDefinedFieldsToCoreDataConnectorPlaces < ActiveRecord::Migration[7.0]
+  def up
+    add_column :core_data_connector_places, :user_defined, :jsonb, default: {}
+    add_index :core_data_connector_places, :user_defined, using: :gin
+  end
+
+  def down
+    remove_index :core_data_connector_places, :user_defined
+    remove_column :core_data_connector_places, :user_defined
+  end
+end

--- a/db/migrate/20230918201557_add_user_defined_fields_to_core_data_connector_relationships.rb
+++ b/db/migrate/20230918201557_add_user_defined_fields_to_core_data_connector_relationships.rb
@@ -1,0 +1,11 @@
+class AddUserDefinedFieldsToCoreDataConnectorRelationships < ActiveRecord::Migration[7.0]
+  def up
+    add_column :core_data_connector_relationships, :user_defined, :jsonb, default: {}
+    add_index :core_data_connector_relationships, :user_defined, using: :gin
+  end
+
+  def down
+    remove_index :core_data_connector_relationships, :user_defined
+    remove_column :core_data_connector_relationships, :user_defined
+  end
+end


### PR DESCRIPTION
This pull request installs the `user_defined_fields` gem into the Core Data Connector. Fields can be defined for `project_models` and `project_model_relationships` records. Data will be stored on `organizations`, `people`, `places`, and `relationships`.

**Note:** Before merging, this pull request has dependent PRs in the resource-api and user-defined-fields repositories.