### PR TITLE
CDC #39 - Typesense

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,7 @@ PATH
       resource_api
       rgeo-geojson (~> 2.1)
       triple_eye_effable
+      typesense (~> 0.14)
       user_defined_fields
 
 GEM
@@ -114,8 +115,11 @@ GEM
     crass (1.0.6)
     date (3.3.3)
     erubi (1.12.0)
+    ethon (0.16.0)
+      ffi (>= 1.15.0)
     faker (3.2.1)
       i18n (>= 1.8.11, < 2)
+    ffi (1.15.5)
     globalid (1.1.0)
       activesupport (>= 5.0)
     httparty (0.20.0)
@@ -153,6 +157,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.15.3-x86_64-darwin)
       racc (~> 1.4)
+    oj (3.14.3)
     pagy (5.10.1)
       activesupport
     pundit (2.3.1)
@@ -200,6 +205,11 @@ GEM
     sqlite3 (1.6.3-x86_64-darwin)
     thor (1.2.2)
     timeout (0.4.0)
+    typesense (0.14.1)
+      oj (~> 3.11)
+      typhoeus (~> 1.4)
+    typhoeus (1.4.0)
+      ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     websocket-driver (0.7.6)

--- a/app/models/core_data_connector/media_content.rb
+++ b/app/models/core_data_connector/media_content.rb
@@ -3,6 +3,7 @@ module CoreDataConnector
     # Includes
     include Ownable
     include Relateable
+    include Search::MediaContent
     include TripleEyeEffable::Resourceable
     include UserDefinedFields::Fieldable
 

--- a/app/models/core_data_connector/organization.rb
+++ b/app/models/core_data_connector/organization.rb
@@ -4,6 +4,7 @@ module CoreDataConnector
     include Nameable
     include Ownable
     include Relateable
+    include Search::Organization
     include UserDefinedFields::Fieldable
 
     # Delegates

--- a/app/models/core_data_connector/person.rb
+++ b/app/models/core_data_connector/person.rb
@@ -4,6 +4,7 @@ module CoreDataConnector
     include Nameable
     include Ownable
     include Relateable
+    include Search::Person
     include UserDefinedFields::Fieldable
 
     # Delegates

--- a/app/models/core_data_connector/place.rb
+++ b/app/models/core_data_connector/place.rb
@@ -6,6 +6,7 @@ module CoreDataConnector
     include Nameable
     include Ownable
     include Relateable
+    include Search::Place
     include UserDefinedFields::Fieldable
 
     # Relationships

--- a/app/services/core_data_connector/search/base.rb
+++ b/app/services/core_data_connector/search/base.rb
@@ -177,7 +177,7 @@ module CoreDataConnector
         }, as: :related_record, class_name: Relationship.to_s
 
         # Include the ID attribute as a string by default
-        search_attribute(:id) do
+        search_attribute(:record_id) do
           id.to_s
         end
 

--- a/app/services/core_data_connector/search/base.rb
+++ b/app/services/core_data_connector/search/base.rb
@@ -1,0 +1,283 @@
+module CoreDataConnector
+  module Search
+    module Base
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def apply_preloads(records, project_model_ids)
+          # Preload project_model
+          Preloader.new(
+            records: records,
+            associations: [
+              project_model: [:project, :user_defined_fields]
+            ]
+          ).call
+
+          # Preload any associations from the concrete class
+          if self.respond_to?(:preloads) && preloads.present?
+            Preloader.new(
+              records: records,
+              associations: preloads
+            ).call
+          end
+
+          # Preload primary relationships
+          Preloader.new(
+            records: records,
+            associations: [
+              media_content_relationships: [
+                related_record: [
+                  project_model: :user_defined_fields
+                ],
+                project_model_relationship: :user_defined_fields
+              ],
+              organization_relationships: [
+                related_record: [
+                  :primary_name,
+                  :organization_names,
+                  project_model: :user_defined_fields
+                ],
+                project_model_relationship: :user_defined_fields
+              ],
+              person_relationships: [
+                related_record: [
+                  :primary_name,
+                  :person_names,
+                  project_model: :user_defined_fields
+                ],
+                project_model_relationship: :user_defined_fields
+              ],
+              place_relationships: [
+                related_record: [
+                  :place_geometry,
+                  :primary_name,
+                  :place_names,
+                  project_model: :user_defined_fields
+                ],
+                project_model_relationship: :user_defined_fields
+              ]
+            ],
+            scope: (
+              Relationship
+                .joins(:project_model_relationship)
+                .where(core_data_connector_project_model_relationships: { primary_model_id: project_model_ids })
+            )
+          ).call
+
+          # Preload related relationships
+          Preloader.new(
+            records: records,
+            associations: [
+              media_content_related_relationships: [
+                primary_record: [
+                  project_model: :user_defined_fields
+                ],
+                project_model_relationship: :user_defined_fields
+              ],
+              organization_related_relationships: [
+                primary_record: [
+                  :primary_name,
+                  :organization_names,
+                  project_model: :user_defined_fields
+                ],
+                project_model_relationship: :user_defined_fields
+              ],
+              person_related_relationships: [
+                primary_record: [
+                  :primary_name,
+                  :person_names,
+                  project_model: :user_defined_fields
+                ],
+                project_model_relationship: :user_defined_fields
+              ],
+              place_related_relationships: [
+                primary_record: [
+                  :place_geometry,
+                  :primary_name,
+                  :place_names,
+                  project_model: :user_defined_fields
+                ],
+                project_model_relationship: :user_defined_fields
+              ]
+            ],
+            scope: (
+              Relationship
+                .joins(:project_model_relationship)
+                .where(core_data_connector_project_model_relationships: { related_model_id: project_model_ids })
+            )
+          ).call
+        end
+
+        def for_search(project_model_ids, &block)
+          # Base query
+          query = all_records_by_project_model(project_model_ids)
+
+          query.find_in_batches(batch_size: 1000) do |records|
+            # Apply the preloads for the current batch
+            apply_preloads records, project_model_ids
+
+            # Call the block for the current batch
+            block.call(records)
+          end
+        end
+
+        def search_attribute(*attrs, &block)
+          name, options = attrs
+
+          @attrs ||= []
+          @attrs << { name: name, block: block}.merge(options || {})
+        end
+
+        def search_attributes
+          @attrs
+        end
+      end
+
+      included do
+        # Primary relationships
+        has_many :media_content_relationships, -> {
+          where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::MediaContent.to_s })
+        }, as: :primary_record, class_name: Relationship.to_s
+
+        has_many :organization_relationships, -> {
+          where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::Organization.to_s })
+        }, as: :primary_record, class_name: Relationship.to_s
+
+        has_many :person_relationships, -> {
+          where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::Person.to_s })
+        }, as: :primary_record, class_name: Relationship.to_s
+
+        has_many :place_relationships, -> {
+          where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::Place.to_s })
+        }, as: :primary_record, class_name: Relationship.to_s
+
+        # Related relationships
+        has_many :media_content_related_relationships, -> {
+          joins(:project_model_relationship)
+            .where(Relationship.arel_table.name => { primary_record_type: CoreDataConnector::MediaContent.to_s })
+            .where(ProjectModelRelationship.arel_table.name => { allow_inverse: true })
+        }, as: :related_record, class_name: Relationship.to_s
+
+        has_many :organization_related_relationships, -> {
+          joins(:project_model_relationship)
+            .where(Relationship.arel_table.name => { primary_record_type: CoreDataConnector::Organization.to_s })
+            .where(ProjectModelRelationship.arel_table.name => { allow_inverse: true })
+        }, as: :related_record, class_name: Relationship.to_s
+
+        has_many :person_related_relationships, -> {
+          joins(:project_model_relationship)
+            .where(Relationship.arel_table.name => { primary_record_type: CoreDataConnector::Person.to_s })
+            .where(ProjectModelRelationship.arel_table.name => { allow_inverse: true })
+        }, as: :related_record, class_name: Relationship.to_s
+
+        has_many :place_related_relationships, -> {
+          joins(:project_model_relationship)
+            .where(Relationship.arel_table.name => { primary_record_type: CoreDataConnector::Place.to_s })
+            .where(ProjectModelRelationship.arel_table.name => { allow_inverse: true })
+        }, as: :related_record, class_name: Relationship.to_s
+
+        # Include the ID attribute as a string by default
+        search_attribute(:id) do
+          id.to_s
+        end
+
+        # Include the project model name as the record "type"
+        search_attribute(:type, facet: true) do
+          project_model.name
+        end
+
+        # Uses the specified attributes to create a JSON object. We'll skip relationships by default as to
+        # not create an infinite loop while serializing related records.
+        def to_search_json(skip_relationships = true)
+          hash = {}
+
+          # Add attributes defined by the concrete-class
+          self.class.search_attributes.each do |attr|
+            name = attr[:name]
+
+            # Extract the value for the attribute
+            if attr[:block].present?
+              value = instance_eval(&attr[:block])
+            else
+              value = self.send(attr[:name])
+            end
+
+            # Skip the property of the value is empty
+            next if value.nil?
+
+            # Add the name/value pair to the JSON
+            hash[name] = value
+
+            # If the attribute should be included as a facet, include the "_facet" attribute
+            hash["#{name}_facet".to_sym] = value if attr[:facet]
+          end
+
+          # Add user-defined fields
+          user_defined_fields = build_user_defined(self, project_model.user_defined_fields)
+          hash.merge!({ user_defined: user_defined_fields })
+
+          # Include related records
+          build_relationships hash unless skip_relationships
+
+          hash
+        end
+
+        private
+
+        def build_inverse_relationship(relationship, hash, key)
+          project_model_relationship = relationship.project_model_relationship
+
+          attributes = {
+            type: project_model_relationship.inverse_name,
+            user_defined: build_user_defined(relationship, project_model_relationship.user_defined_fields)
+          }
+
+          hash[key] ||= []
+          hash[key] << relationship.primary_record.to_search_json.merge(attributes)
+        end
+
+        def build_relationship(relationship, hash, key)
+          project_model_relationship = relationship.project_model_relationship
+
+          attributes = {
+            type: project_model_relationship.name,
+            user_defined: build_user_defined(relationship, project_model_relationship.user_defined_fields)
+          }
+
+          hash[key] ||= []
+          hash[key] << relationship.related_record.to_search_json.merge(attributes)
+        end
+
+        def build_relationships(hash)
+          media_content_relationships.each { |r| build_relationship(r, hash, :related_media) }
+          organization_relationships.each { |r| build_relationship(r, hash, :related_organizations) }
+          person_relationships.each { |r| build_relationship(r, hash, :related_people) }
+          place_relationships.each { |r| build_relationship(r, hash, :related_places) }
+
+          media_content_related_relationships.each { |r| build_inverse_relationship(r, hash, :related_media) }
+          organization_related_relationships.each { |r| build_inverse_relationship(r,hash, :related_organizations) }
+          person_related_relationships.each { |r| build_inverse_relationship(r, hash, :related_people) }
+          place_related_relationships.each { |r| build_inverse_relationship(r, hash, :related_places) }
+        end
+
+        def build_user_defined(record, user_defined_fields)
+          fields = []
+
+          user_defined_fields.each do |field|
+            value = record.user_defined[field.uuid]
+            next unless value.present?
+
+            hash = { label: field.column_name, value: value }
+
+            facet = %(Date Number Select Boolean).include?(field.data_type)
+            hash = hash.merge({ value_facet: value }) if facet
+
+            fields << hash
+          end
+
+          fields
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/search/media_content.rb
+++ b/app/services/core_data_connector/search/media_content.rb
@@ -1,0 +1,16 @@
+module CoreDataConnector
+  module Search
+    module MediaContent
+      extend ActiveSupport::Concern
+
+      included do
+        # Includes
+        include Base
+
+        # Search attributes
+        search_attribute :name
+      end
+
+    end
+  end
+end

--- a/app/services/core_data_connector/search/organization.rb
+++ b/app/services/core_data_connector/search/organization.rb
@@ -1,0 +1,30 @@
+module CoreDataConnector
+  module Search
+    module Organization
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def preloads
+          [:primary_name, :organization_names]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Search attributes
+        search_attribute :description
+
+        search_attribute(:name) do
+          primary_name.name
+        end
+
+        search_attribute(:names) do
+          organization_names.map(&:name)
+        end
+      end
+
+    end
+  end
+end

--- a/app/services/core_data_connector/search/person.rb
+++ b/app/services/core_data_connector/search/person.rb
@@ -1,0 +1,34 @@
+module CoreDataConnector
+  module Search
+    module Person
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def preloads
+          [:primary_name, :person_names]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Search attributes
+        search_attribute :biography
+
+        search_attribute(:name) do
+          create_name primary_name
+        end
+
+        search_attribute(:names) do
+          person_names.map { |n| create_name(n) }
+        end
+
+        def create_name(person_name)
+          [person_name.first_name, person_name.middle_name, person_name.last_name].compact.join(' ')
+        end
+
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/search/place.rb
+++ b/app/services/core_data_connector/search/place.rb
@@ -1,0 +1,32 @@
+module CoreDataConnector
+  module Search
+    module Place
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def preloads
+          [:primary_name, :place_names, :place_geometry]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Search attributes
+        search_attribute(:name) do
+          primary_name.name
+        end
+
+        search_attribute(:names) do
+          place_names.map(&:name)
+        end
+
+        search_attribute(:geometry) do
+          Geometry.to_geojson(place_geometry&.geometry)
+        end
+      end
+
+    end
+  end
+end

--- a/core_data_connector.gemspec
+++ b/core_data_connector.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'resource_api'
   spec.add_dependency 'user_defined_fields'
   spec.add_dependency 'triple_eye_effable'
+  spec.add_dependency 'typesense', '~> 0.14'
 end

--- a/lib/tasks/typesense.rake
+++ b/lib/tasks/typesense.rake
@@ -1,0 +1,60 @@
+require_relative '../typesense/helper'
+require_relative '../typesense/options'
+
+namespace :typesense do
+  desc 'Creates a new Typesense collection'
+  task create: :environment do
+    options = Typesense::Options.parse(ARGV) do |opts|
+      opts.banner = 'Usage: typesense:create -- --host --port --protocol --api-key --collection-name'
+    end
+
+    helper = Typesense::Helper.new(
+      host: options[:host],
+      port: options[:port],
+      protocol: options[:protocol],
+      api_key: options[:api_key],
+      collection_name: options[:collection_name]
+    )
+
+    helper.create
+  end
+
+  desc 'Deletes the Typesense collection'
+  task delete: :environment do
+    options = Typesense::Options.parse(ARGV) do |opts|
+      opts.banner = 'Usage: typesense:delete -- --host --port --protocol --api-key --collection-name'
+    end
+
+    helper = Typesense::Helper.new(
+      host: options[:host],
+      port: options[:port],
+      protocol: options[:protocol],
+      api_key: options[:api_key],
+      collection_name: options[:collection_name]
+    )
+
+    begin
+      helper.delete
+    rescue
+      # Do nothing, collection doesn't exist yet
+    end
+  end
+
+  desc 'Index documents into Typesense'
+  task index: :environment do
+    options = Typesense::Options.parse(ARGV) do |opts, options|
+      opts.banner = 'Usage: typesense:index -- --host --port --protocol --api-key --collection-name --project-models'
+      opts.on('-m', '--project-models ARG', Array) { |ids| options[:project_model_ids] = ids.map(&:to_i) }
+    end
+
+    helper = Typesense::Helper.new(
+      host: options[:host],
+      port: options[:port],
+      protocol: options[:protocol],
+      api_key: options[:api_key],
+      collection_name: options[:collection_name]
+    )
+
+    helper.index options[:project_model_ids]
+  end
+end

--- a/lib/typesense/helper.rb
+++ b/lib/typesense/helper.rb
@@ -1,0 +1,61 @@
+require 'typesense'
+
+module Typesense
+  class Helper
+    attr_reader :client, :collection_name
+
+    def initialize(host:, port:, protocol:, api_key:, collection_name:)
+      @client = Client.new(
+        nodes: [
+          {
+            host: host || 'localhost',
+            port: port|| 8108,
+            protocol: protocol || 'http'
+          }
+        ],
+        api_key: api_key || 'xyz',
+        num_retries: 10,
+        healthcheck_interval_seconds: 1,
+        retry_interval_seconds: 0.01,
+        connection_timeout_seconds: 10,
+        logger: Logger.new($stdout),
+        log_level: Logger::INFO
+      )
+
+      @collection_name = collection_name
+    end
+
+    def create
+      schema = {
+        name: collection_name,
+        enable_nested_fields: true,
+        fields: [{
+          name: '.*_facet',
+          type: 'auto',
+          facet: true
+        }, {
+          name: '.*',
+          type: 'auto'
+        }]
+      }
+
+      client.collections.create(schema)
+    end
+
+    def delete
+      client.collections[collection_name].delete
+    end
+
+    def index(project_model_ids)
+      project_models = CoreDataConnector::ProjectModel.where(id: project_model_ids)
+      klass = project_models.first.model_class.constantize
+
+      collection = client.collections[collection_name]
+
+      klass.for_search(project_model_ids) do |records|
+        documents = records.map { |r| r.to_search_json(false) }
+        collection.documents.import(documents, action: 'upsert')
+      end
+    end
+  end
+end

--- a/lib/typesense/options.rb
+++ b/lib/typesense/options.rb
@@ -1,0 +1,22 @@
+module Typesense
+  class Options
+    def self.parse(args, &block)
+      options = {}
+
+      opts = OptionParser.new
+
+      block.call(opts, options) if block.present?
+
+      opts.on('-h', '--host ARG', String) { |host| options[:host] = host }
+      opts.on('-p', '--port ARG', Integer) { |port| options[:port] = port }
+      opts.on('-r', '--protocol ARG', String) { |protocol| options[:protocol] = protocol }
+      opts.on('-a', '--api-key ARG', String) { |api_key| options[:api_key] = api_key }
+      opts.on('-c', '--collection-name ARG', String) { |collection| options[:collection_name] = collection }
+
+      args = opts.order!(args) {}
+      opts.parse!(args)
+
+      options
+    end
+  end
+end


### PR DESCRIPTION
This pull request implements the ability to index an arbitrary set of data into a Typesense collection. One or more models can be specified along with Typesense connection information:

```
bundle exec rake typesense:create -h [host] -p [port] -r [protocol] -a [api-key] -c [collection-name]
```

```
bundle exec rake typesense:delete -h [host] -p [port] -r [protocol] -a [api-key] -c [collection-name]
```

```
bundle exec rake typesense:index -h [host] -p [port] -r [protocol] -a [api-key] -c [collection-name] -m [project-model-ids]
```