### PR TITLE
Add sources and refactor `nameable` to support polymorphic shared name tables

### DIFF
--- a/app/controllers/concerns/core_data_connector/nameable_controller.rb
+++ b/app/controllers/concerns/core_data_connector/nameable_controller.rb
@@ -9,11 +9,41 @@ module CoreDataConnector
       # Preloads
       preloads :primary_name
 
+      search_methods :search_by_name
+
       def resolve_search_attribute(attr)
-        name_class = "#{item_class.to_s}Name".classify.constantize
+        name_class = "CoreDataConnector::#{item_class.get_names_table.to_s.classify}".constantize
+
         return super unless name_class.column_names.include?(attr.to_s)
 
         "#{name_class.table_name}.#{attr.to_s}"
+      end
+
+      def search_by_name(query)
+        return query if params[:search].blank?
+
+        name_class = "CoreDataConnector::#{item_class.get_names_table.to_s.classify}".constantize
+        
+        is_polymorphic = !!name_class.reflect_on_all_associations(:belongs_to).find { |a| a.name == :name}
+
+        return query if !is_polymorphic
+
+        or_query = item_class
+          .where(
+            Name
+              .joins(item_class.get_names_table)
+              .where(name_class.arel_table[:primary].eq(true))
+              .where(name_class.arel_table[:nameable_id].eq(item_class.arel_table[:id]))
+              .where(name_class.arel_table[:nameable_type].eq(item_class.to_s))
+              .where('core_data_connector_names.name ILIKE ?', "%#{params[:search]}%")
+              .arel.exists
+            )
+
+        if query == item_class.all
+          query.merge(or_query)
+        else
+          query.or(or_query)
+        end
       end
     end
   end

--- a/app/controllers/core_data_connector/instances_controller.rb
+++ b/app/controllers/core_data_connector/instances_controller.rb
@@ -1,0 +1,9 @@
+module CoreDataConnector
+  class InstancesController < ApplicationController
+    include NameableController
+    include OwnableController
+    include UserDefinedFields::Queryable
+
+    preloads source_titles: :name
+  end
+end

--- a/app/controllers/core_data_connector/instances_controller.rb
+++ b/app/controllers/core_data_connector/instances_controller.rb
@@ -5,5 +5,7 @@ module CoreDataConnector
     include UserDefinedFields::Queryable
 
     preloads source_titles: :name
+
+    joins primary_name: :name
   end
 end

--- a/app/controllers/core_data_connector/items_controller.rb
+++ b/app/controllers/core_data_connector/items_controller.rb
@@ -1,0 +1,9 @@
+module CoreDataConnector
+  class ItemsController < ApplicationController
+    include NameableController
+    include OwnableController
+    include UserDefinedFields::Queryable
+
+    preloads source_titles: :name
+  end
+end

--- a/app/controllers/core_data_connector/items_controller.rb
+++ b/app/controllers/core_data_connector/items_controller.rb
@@ -5,5 +5,7 @@ module CoreDataConnector
     include UserDefinedFields::Queryable
 
     preloads source_titles: :name
+
+    joins primary_name: :name
   end
 end

--- a/app/controllers/core_data_connector/names_controller.rb
+++ b/app/controllers/core_data_connector/names_controller.rb
@@ -17,23 +17,15 @@ module CoreDataConnector
       queries = nameable_models.map do |nm|
         model_name = "CoreDataConnector::#{nm.to_s.classify}".constantize
 
-        CoreDataConnector::SourceTitle
+        SourceTitle
           .joins(nm => :project_model)
-          .where(
-            CoreDataConnector::ProjectModel.arel_table[:project_id].eq(params[:project_id])
-            )
-          .where(CoreDataConnector::SourceTitle.arel_table[:nameable_type].eq(model_name))
-          .where(CoreDataConnector::SourceTitle.arel_table[:name_id].eq(CoreDataConnector::Name.arel_table[:id]))
+          .where(ProjectModel.arel_table[:project_id].eq(params[:project_id]))
+          .where(SourceTitle.arel_table[:nameable_type].eq(model_name))
+          .where(SourceTitle.arel_table[:name_id].eq(Name.arel_table[:id]))
       end
 
       raw_sql = <<-SQL.squish
-        EXISTS (
-          #{queries[0].to_sql}
-          UNION
-          #{queries[1].to_sql}
-          UNION
-          #{queries[2].to_sql}
-        )
+        EXISTS (#{queries.map(&:to_sql).join(' UNION ')})
       SQL
 
       query

--- a/app/controllers/core_data_connector/names_controller.rb
+++ b/app/controllers/core_data_connector/names_controller.rb
@@ -1,0 +1,33 @@
+module CoreDataConnector
+  class NamesController < ApplicationController
+    # Search attributes
+    search_attributes :name
+
+    def base_query
+      query = super
+
+      return query.none unless params[:project_id] && params[:nameable_model]
+
+      nameable_model = "CoreDataConnector::#{params[:nameable_model].classify}".constantize
+      polymorphic_table_class = "CoreDataConnector::#{nameable_model.get_names_table.to_s.classify}".constantize
+
+      query
+        .where(
+          polymorphic_table_class
+            .where(polymorphic_table_class.arel_table[:name_id].eq(CoreDataConnector::Name.arel_table[:id]))
+            .arel
+            .exists
+        )
+        .where(
+          nameable_model
+            .joins(nameable_model.get_names_table.to_sym => :name)
+            .joins(:project_model)
+            .where(
+              CoreDataConnector::ProjectModel.arel_table[:project_id].eq(params[:project_id])
+            )
+            .arel
+            .exists
+        )
+    end
+  end
+end

--- a/app/controllers/core_data_connector/names_controller.rb
+++ b/app/controllers/core_data_connector/names_controller.rb
@@ -8,23 +8,21 @@ module CoreDataConnector
 
       return query.none unless params[:project_id] && params[:nameable_model]
 
+      nameable_table = params[:nameable_model].to_sym
       nameable_model = "CoreDataConnector::#{params[:nameable_model].classify}".constantize
-      polymorphic_table_class = "CoreDataConnector::#{nameable_model.get_names_table.to_s.classify}".constantize
+
+      polymorphic_table = nameable_model.get_names_table
+      polymorphic_table_class = "CoreDataConnector::#{polymorphic_table.to_s.classify}".constantize
 
       query
         .where(
           polymorphic_table_class
-            .where(polymorphic_table_class.arel_table[:name_id].eq(CoreDataConnector::Name.arel_table[:id]))
-            .arel
-            .exists
-        )
-        .where(
-          nameable_model
-            .joins(nameable_model.get_names_table.to_sym => :name)
-            .joins(:project_model)
+            .joins(nameable_table.to_s.singularize.to_sym => :project_model)
             .where(
               CoreDataConnector::ProjectModel.arel_table[:project_id].eq(params[:project_id])
-            )
+              )
+            .where(polymorphic_table_class.arel_table[:nameable_type].eq(nameable_model.to_s))
+            .where(polymorphic_table_class.arel_table[:name_id].eq(CoreDataConnector::Name.arel_table[:id]))
             .arel
             .exists
         )

--- a/app/controllers/core_data_connector/relationships_controller.rb
+++ b/app/controllers/core_data_connector/relationships_controller.rb
@@ -100,6 +100,26 @@ module CoreDataConnector
       or_query = nil
 
       case model_class
+      when Instance.to_s
+        or_query = Instance.where(
+          Name
+            .joins(:source_titles)
+            .where(SourceTitle.arel_table[:primary].eq(true))
+            .where(SourceTitle.arel_table[:nameable_id].eq(Instance.arel_table[:id]))
+            .where(SourceTitle.arel_table[:nameable_type].eq(Instance.to_s))
+            .where('core_data_connector_names.name ILIKE ?', "%#{params[:search]}%")
+            .arel.exists
+          )
+      when Item.to_s
+        or_query = Item.where(
+          Name
+            .joins(:source_titles)
+            .where(SourceTitle.arel_table[:primary].eq(true))
+            .where(SourceTitle.arel_table[:nameable_id].eq(Item.arel_table[:id]))
+            .where(SourceTitle.arel_table[:nameable_type].eq(Item.to_s))
+            .where('core_data_connector_names.name ILIKE ?', "%#{params[:search]}%")
+            .arel.exists
+          )
       when MediaContent.to_s
         attribute = "#{MediaContent.arel_table.name}.#{MediaContent.arel_table[:name].name}"
         or_query = resolve_search_query(attribute)

--- a/app/controllers/core_data_connector/relationships_controller.rb
+++ b/app/controllers/core_data_connector/relationships_controller.rb
@@ -40,9 +40,9 @@ module CoreDataConnector
       # For sorting, left join the polymorphic model we're currently looking at.
       case model_class
       when Instance.to_s
-        query = query.joins(params[:inverse] ? :inverse_related_instance : :related_instance)
+        query = query.joins(params[:inverse] ? { inverse_related_instance: [primary_name: :name] } : { related_instance: [primary_name: :name] })
       when Item.to_s
-        query = query.joins(params[:inverse] ? :inverse_related_item : :related_item)
+        query = query.joins(params[:inverse] ? { inverse_related_item: [primary_name: :name] } : { related_item: [primary_name: :name] })
       when MediaContent.to_s
         query = query.joins(params[:inverse] ? :inverse_related_media_content : :related_media_content)
       when Organization.to_s
@@ -54,7 +54,7 @@ module CoreDataConnector
       when Taxonomy.to_s
         query = query.joins(params[:inverse] ? :inverse_related_taxonomy : :related_taxonomy)
       when Work.to_s
-        query = query.joins(params[:inverse] ? :inverse_related_work : :related_work)
+        query = query.joins(params[:inverse] ? { inverse_related_work: [primary_name: :name] } : { related_work: [primary_name: :name] })
       end
 
       query

--- a/app/controllers/core_data_connector/works_controller.rb
+++ b/app/controllers/core_data_connector/works_controller.rb
@@ -1,0 +1,9 @@
+module CoreDataConnector
+  class WorksController < ApplicationController
+    include NameableController
+    include OwnableController
+    include UserDefinedFields::Queryable
+
+    preloads source_titles: :name
+  end
+end

--- a/app/controllers/core_data_connector/works_controller.rb
+++ b/app/controllers/core_data_connector/works_controller.rb
@@ -5,5 +5,7 @@ module CoreDataConnector
     include UserDefinedFields::Queryable
 
     preloads source_titles: :name
+
+    joins primary_name: :name
   end
 end

--- a/app/models/concerns/core_data_connector/nameable.rb
+++ b/app/models/concerns/core_data_connector/nameable.rb
@@ -2,20 +2,35 @@ module CoreDataConnector
   module Nameable
     extend ActiveSupport::Concern
 
+    class_methods do
+      def name_table(name, options = nil)
+        if options && options[:polymorphic]
+          self.send(:has_many, name.to_sym, as: :nameable, dependent: :destroy)
+          has_one :primary_name, -> { where(primary: true) }, class_name: name.to_s.classify, as: :nameable
+        else
+          self.send(:has_many, name.to_sym, dependent: :destroy)
+          has_one :primary_name, -> { where(primary: true) }, class_name: name.to_s.classify
+        end
+
+        # Nested attributes
+        self.send(:accepts_nested_attributes_for, name.to_sym, allow_destroy: true)
+
+        @names_table = name
+      end
+
+      def get_names_table
+        @names_table
+      end
+    end
+
     included do
-      has_many "#{self.model_name.param_key}_names".to_sym, dependent: :destroy
-      has_one :primary_name, -> { where(primary: true) }, class_name: "#{self.name}Name"
-
-      # Nested attributes
-      accepts_nested_attributes_for "#{self.model_name.param_key}_names".to_sym, allow_destroy: true
-
       # Validations
       validate :validate_names
 
       private
 
       def has_primary_name?
-        names = self.send("#{self.class.model_name.param_key}_names".to_sym)
+        names = self.send(self.class.get_names_table)
         names.select{ |n| n.primary? }.present?
       end
 

--- a/app/models/core_data_connector/instance.rb
+++ b/app/models/core_data_connector/instance.rb
@@ -1,0 +1,11 @@
+module CoreDataConnector
+  class Instance < ApplicationRecord
+    include Nameable
+    include Ownable
+    include Relateable
+    include UserDefinedFields::Fieldable
+    include Search::Instance
+
+    name_table :source_titles, polymorphic: true
+  end
+end

--- a/app/models/core_data_connector/item.rb
+++ b/app/models/core_data_connector/item.rb
@@ -1,0 +1,11 @@
+module CoreDataConnector
+  class Item < ApplicationRecord
+    include Nameable
+    include Ownable
+    include Relateable
+    include UserDefinedFields::Fieldable
+    include Search::Item
+
+    name_table :source_titles, polymorphic: true
+  end
+end

--- a/app/models/core_data_connector/name.rb
+++ b/app/models/core_data_connector/name.rb
@@ -1,0 +1,9 @@
+module CoreDataConnector
+  class Name < ApplicationRecord
+    has_many :source, through: :source_titles, source: :nameable, source_type: 'Instance'
+    has_many :source, through: :source_titles, source: :nameable, source_type: 'Item'
+    has_many :source, through: :source_titles, source: :nameable, source_type: 'Work'
+
+    has_many :source_titles
+  end
+end

--- a/app/models/core_data_connector/name.rb
+++ b/app/models/core_data_connector/name.rb
@@ -1,9 +1,5 @@
 module CoreDataConnector
   class Name < ApplicationRecord
-    has_many :source, through: :source_titles, source: :nameable, source_type: 'Instance'
-    has_many :source, through: :source_titles, source: :nameable, source_type: 'Item'
-    has_many :source, through: :source_titles, source: :nameable, source_type: 'Work'
-
     has_many :source_titles
   end
 end

--- a/app/models/core_data_connector/organization.rb
+++ b/app/models/core_data_connector/organization.rb
@@ -10,6 +10,8 @@ module CoreDataConnector
     # Delegates
     delegate :name, to: :primary_name
 
+    name_table :organization_names
+
     # User defined fields parent
     resolve_defineable -> (organization) { organization.project_model }
   end

--- a/app/models/core_data_connector/person.rb
+++ b/app/models/core_data_connector/person.rb
@@ -10,6 +10,8 @@ module CoreDataConnector
     # Delegates
     delegate :first_name, :middle_name, :last_name, to: :primary_name
 
+    name_table :person_names
+
     # User defined fields parent
     resolve_defineable -> (person) { person.project_model }
 

--- a/app/models/core_data_connector/place.rb
+++ b/app/models/core_data_connector/place.rb
@@ -15,6 +15,8 @@ module CoreDataConnector
     # Nested attributes
     accepts_nested_attributes_for :place_geometry, allow_destroy: true
 
+    name_table :place_names
+
     # Delegates
     delegate :name, to: :primary_name
 

--- a/app/models/core_data_connector/project_model.rb
+++ b/app/models/core_data_connector/project_model.rb
@@ -7,12 +7,15 @@ module CoreDataConnector
     # Relationships
     belongs_to :project
 
+    has_many :instances, dependent: :destroy
+    has_many :items, dependent: :destroy
     has_many :organizations, dependent: :destroy
     has_many :people, dependent: :destroy
     has_many :places, dependent: :destroy
     has_many :project_model_accesses, dependent: :destroy
     has_many :project_model_shares, dependent: :destroy
     has_many :taxonomies, dependent: :destroy
+    has_many :works, dependent: :destroy
 
     has_many :project_model_relationships, dependent: :destroy, foreign_key: :primary_model_id
     has_many :related_project_model_relationships, dependent: :destroy, class_name: ProjectModelRelationship.to_s, foreign_key: :related_model_id

--- a/app/models/core_data_connector/relationship.rb
+++ b/app/models/core_data_connector/relationship.rb
@@ -8,17 +8,23 @@ module CoreDataConnector
     belongs_to :primary_record, polymorphic: true
     belongs_to :related_record, polymorphic: true
 
+    belongs_to :related_instance, -> { where(Relationship.arel_table.name => { related_record_type: Instance.to_s }) }, class_name: Instance.to_s, foreign_key: :related_record_id, optional: true
+    belongs_to :related_item, -> { where(Relationship.arel_table.name => { related_record_type: Item.to_s }) }, class_name: Item.to_s, foreign_key: :related_record_id, optional: true
     belongs_to :related_media_content, -> { where(Relationship.arel_table.name => { related_record_type: MediaContent.to_s }) }, class_name: MediaContent.to_s, foreign_key: :related_record_id, optional: true
     belongs_to :related_organization, -> { where(Relationship.arel_table.name => { related_record_type: Organization.to_s }) }, class_name: Organization.to_s, foreign_key: :related_record_id, optional: true
     belongs_to :related_person, -> { where(Relationship.arel_table.name => { related_record_type: Person.to_s }) }, class_name: Person.to_s, foreign_key: :related_record_id, optional: true
     belongs_to :related_place, -> { where(Relationship.arel_table.name => { related_record_type: Place.to_s }) }, class_name: Place.to_s, foreign_key: :related_record_id, optional: true
     belongs_to :related_taxonomy, -> { where(Relationship.arel_table.name => { related_record_type: Taxonomy.to_s }) }, class_name: Taxonomy.to_s, foreign_key: :related_record_id, optional: true
+    belongs_to :related_work, -> { where(Relationship.arel_table.name => { related_record_type: Work.to_s }) }, class_name: Work.to_s, foreign_key: :related_record_id, optional: true
 
+    belongs_to :inverse_related_instance, -> { where(Relationship.arel_table.name => { primary_record_type: Instance.to_s }) }, class_name: Instance.to_s, foreign_key: :primary_record_id, optional: true
+    belongs_to :inverse_related_item, -> { where(Relationship.arel_table.name => { primary_record_type: Item.to_s }) }, class_name: Item.to_s, foreign_key: :primary_record_id, optional: true
     belongs_to :inverse_related_media_content, -> { where(Relationship.arel_table.name => { primary_record_type: MediaContent.to_s }) }, class_name: MediaContent.to_s, foreign_key: :primary_record_id, optional: true
     belongs_to :inverse_related_organization, -> { where(Relationship.arel_table.name => { primary_record_type: Organization.to_s }) }, class_name: Organization.to_s, foreign_key: :primary_record_id, optional: true
     belongs_to :inverse_related_person, -> { where(Relationship.arel_table.name => { primary_record_type: Person.to_s }) }, class_name: Person.to_s, foreign_key: :primary_record_id, optional: true
     belongs_to :inverse_related_place, -> { where(Relationship.arel_table.name => { primary_record_type: Place.to_s }) }, class_name: Place.to_s, foreign_key: :primary_record_id, optional: true
     belongs_to :inverse_related_taxonomy, -> { where(Relationship.arel_table.name => { primary_record_type: Taxonomy.to_s }) }, class_name: Taxonomy.to_s, foreign_key: :primary_record_id, optional: true
+    belongs_to :inverse_related_work, -> { where(Relationship.arel_table.name => { primary_record_type: Work.to_s }) }, class_name: Work.to_s, foreign_key: :primary_record_id, optional: true
 
     # Delegates
     delegate :project_id, to: :project_model_relationship

--- a/app/models/core_data_connector/source_title.rb
+++ b/app/models/core_data_connector/source_title.rb
@@ -3,6 +3,10 @@ module CoreDataConnector
     belongs_to :name
     belongs_to :nameable, polymorphic: true
 
+    belongs_to :instance, foreign_key: :nameable_id, optional: true
+    belongs_to :item, foreign_key: :nameable_id, optional: true
+    belongs_to :work, foreign_key: :nameable_id, optional: true
+
     accepts_nested_attributes_for :name
   end
 end

--- a/app/models/core_data_connector/source_title.rb
+++ b/app/models/core_data_connector/source_title.rb
@@ -1,0 +1,8 @@
+module CoreDataConnector
+  class SourceTitle < ApplicationRecord
+    belongs_to :name
+    belongs_to :nameable, polymorphic: true
+
+    accepts_nested_attributes_for :name
+  end
+end

--- a/app/models/core_data_connector/work.rb
+++ b/app/models/core_data_connector/work.rb
@@ -1,0 +1,11 @@
+module CoreDataConnector
+  class Work < ApplicationRecord
+    include Nameable
+    include Ownable
+    include Relateable
+    include UserDefinedFields::Fieldable
+    include Search::Work
+
+    name_table :source_titles, polymorphic: true
+  end
+end

--- a/app/policies/core_data_connector/instance_policy.rb
+++ b/app/policies/core_data_connector/instance_policy.rb
@@ -1,0 +1,28 @@
+module CoreDataConnector
+  class InstancePolicy < BasePolicy
+    include OwnablePolicy
+
+    attr_reader :current_user, :instance, :project_model_id, :project_id
+
+    def initialize(current_user, instance)
+      @current_user = current_user
+      @instance = instance
+
+      @project_model_id = instance&.project_model_id
+      @project_id = instance&.project_id
+    end
+
+    # Allowed create/update attributes.
+    def permitted_attributes
+      [ *ownable_attributes,
+        user_defined: {},
+        source_titles_attributes: [:id, :primary, :name_id, :_destroy, name_attributes: [:id, :name]]
+      ]
+    end
+
+    # Include default ownable scope.
+    class Scope < BaseScope
+      include OwnableScope
+    end
+  end
+end

--- a/app/policies/core_data_connector/item_policy.rb
+++ b/app/policies/core_data_connector/item_policy.rb
@@ -1,0 +1,28 @@
+module CoreDataConnector
+  class ItemPolicy < BasePolicy
+    include OwnablePolicy
+
+    attr_reader :current_user, :item, :project_model_id, :project_id
+
+    def initialize(current_user, item)
+      @current_user = current_user
+      @item = item
+
+      @project_model_id = item&.project_model_id
+      @project_id = item&.project_id
+    end
+
+    # Allowed create/update attributes.
+    def permitted_attributes
+      [ *ownable_attributes,
+        user_defined: {},
+        source_titles_attributes: [:id, :primary, :name_id, :_destroy, name_attributes: [:id, :name]]
+      ]
+    end
+
+    # Include default ownable scope.
+    class Scope < BaseScope
+      include OwnableScope
+    end
+  end
+end

--- a/app/policies/core_data_connector/work_policy.rb
+++ b/app/policies/core_data_connector/work_policy.rb
@@ -1,0 +1,28 @@
+module CoreDataConnector
+  class WorkPolicy < BasePolicy
+    include OwnablePolicy
+
+    attr_reader :current_user, :work, :project_model_id, :project_id
+
+    def initialize(current_user, work)
+      @current_user = current_user
+      @work = work
+
+      @project_model_id = work&.project_model_id
+      @project_id = work&.project_id
+    end
+
+    # Allowed create/update attributes.
+    def permitted_attributes
+      [ *ownable_attributes,
+        user_defined: {},
+        source_titles_attributes: [:id, :primary, :name_id, :_destroy, name_attributes: [:id, :name]]
+      ]
+    end
+
+    # Include default ownable scope.
+    class Scope < BaseScope
+      include OwnableScope
+    end
+  end
+end

--- a/app/serializers/core_data_connector/instances_serializer.rb
+++ b/app/serializers/core_data_connector/instances_serializer.rb
@@ -1,0 +1,8 @@
+module CoreDataConnector
+  class InstancesSerializer < BaseSerializer
+    include OwnableSerializer
+
+    index_attributes :id, primary_name: SourceTitlesSerializer, source_titles: SourceTitlesSerializer
+    show_attributes :id, primary_name: SourceTitlesSerializer, source_titles: SourceTitlesSerializer
+  end
+end

--- a/app/serializers/core_data_connector/items_serializer.rb
+++ b/app/serializers/core_data_connector/items_serializer.rb
@@ -1,0 +1,8 @@
+module CoreDataConnector
+  class ItemsSerializer < BaseSerializer
+    include OwnableSerializer
+
+    index_attributes :id, primary_name: SourceTitlesSerializer, source_titles: SourceTitlesSerializer
+    show_attributes :id, primary_name: SourceTitlesSerializer, source_titles: SourceTitlesSerializer
+  end
+end

--- a/app/serializers/core_data_connector/names_serializer.rb
+++ b/app/serializers/core_data_connector/names_serializer.rb
@@ -1,0 +1,6 @@
+module CoreDataConnector
+  class NamesSerializer < BaseSerializer
+    index_attributes :id, :name
+    show_attributes :id, :name
+  end
+end

--- a/app/serializers/core_data_connector/source_titles_serializer.rb
+++ b/app/serializers/core_data_connector/source_titles_serializer.rb
@@ -1,0 +1,6 @@
+module CoreDataConnector
+  class SourceTitlesSerializer < BaseSerializer
+    index_attributes :id, :primary, name: NamesSerializer
+    show_attributes :id, :primary, name: NamesSerializer
+  end
+end

--- a/app/serializers/core_data_connector/works_serializer.rb
+++ b/app/serializers/core_data_connector/works_serializer.rb
@@ -1,0 +1,8 @@
+module CoreDataConnector
+  class WorksSerializer < BaseSerializer
+    include OwnableSerializer
+
+    index_attributes :id, primary_name: SourceTitlesSerializer, source_titles: SourceTitlesSerializer
+    show_attributes :id, primary_name: SourceTitlesSerializer, source_titles: SourceTitlesSerializer
+  end
+end

--- a/app/services/core_data_connector/search/base.rb
+++ b/app/services/core_data_connector/search/base.rb
@@ -25,6 +25,20 @@ module CoreDataConnector
           Preloader.new(
             records: records,
             associations: [
+              instance_relationships: [
+                related_record: [
+                  primary_name: :name,
+                  source_titles: :name,
+                  project_model: :user_defined_fields
+                ]
+              ],
+              item_relationships: [
+                related_record: [
+                  primary_name: :name,
+                  source_titles: :name,
+                  project_model: :user_defined_fields
+                ]
+              ],
               media_content_relationships: [
                 related_record: [
                   project_model: :user_defined_fields
@@ -62,6 +76,14 @@ module CoreDataConnector
                   project_model: :user_defined_fields
                 ],
                 project_model_relationship: :user_defined_fields
+              ],
+              work_relationships: [
+                related_record: [
+                  primary_name: :name,
+                  source_titles: :name,
+                  project_model: :user_defined_fields
+                ],
+                project_model_relationship: :user_defined_fields
               ]
             ],
             scope: (
@@ -75,6 +97,22 @@ module CoreDataConnector
           Preloader.new(
             records: records,
             associations: [
+              instance_related_relationships: [
+                primary_record: [
+                  primary_name: :name,
+                  source_titles: :name,
+                  project_model: :user_defined_fields
+                ],
+                project_model_relationship: :user_defined_fields
+              ],
+              item_related_relationships: [
+                primary_record: [
+                  primary_name: :name,
+                  source_titles: :name,
+                  project_model: :user_defined_fields
+                ],
+                project_model_relationship: :user_defined_fields
+              ],
               media_content_related_relationships: [
                 primary_record: [
                   project_model: :user_defined_fields
@@ -112,7 +150,15 @@ module CoreDataConnector
                   project_model: :user_defined_fields
                 ],
                 project_model_relationship: :user_defined_fields
-              ]
+              ],
+              work_related_relationships: [
+                primary_record: [
+                  primary_name: :name,
+                  source_titles: :name,
+                  project_model: :user_defined_fields
+                ],
+                project_model_relationship: :user_defined_fields
+              ],
             ],
             scope: (
               Relationship
@@ -152,6 +198,14 @@ module CoreDataConnector
 
       included do
         # Primary relationships
+        has_many :instance_relationships, -> {
+          where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::Instance.to_s })
+        }, as: :primary_record, class_name: Relationship.to_s
+
+        has_many :item_relationships, -> {
+          where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::Item.to_s })
+        }, as: :primary_record, class_name: Relationship.to_s
+
         has_many :media_content_relationships, -> {
           where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::MediaContent.to_s })
         }, as: :primary_record, class_name: Relationship.to_s
@@ -172,7 +226,23 @@ module CoreDataConnector
           where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::Taxonomy.to_s })
         }, as: :primary_record, class_name: Relationship.to_s
 
+        has_many :work_relationships, -> {
+          where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::Work.to_s })
+        }, as: :primary_record, class_name: Relationship.to_s
+
         # Related relationships
+        has_many :instance_related_relationships, -> {
+          joins(:project_model_relationship)
+            .where(Relationship.arel_table.name => { primary_record_type: CoreDataConnector::Instance.to_s })
+            .where(ProjectModelRelationship.arel_table.name => { allow_inverse: true })
+        }, as: :related_record, class_name: Relationship.to_s
+
+        has_many :item_related_relationships, -> {
+          joins(:project_model_relationship)
+            .where(Relationship.arel_table.name => { primary_record_type: CoreDataConnector::Item.to_s })
+            .where(ProjectModelRelationship.arel_table.name => { allow_inverse: true })
+        }, as: :related_record, class_name: Relationship.to_s
+
         has_many :media_content_related_relationships, -> {
           joins(:project_model_relationship)
             .where(Relationship.arel_table.name => { primary_record_type: CoreDataConnector::MediaContent.to_s })
@@ -200,6 +270,12 @@ module CoreDataConnector
         has_many :taxonomy_related_relationships, -> {
           joins(:project_model_relationship)
             .where(Relationship.arel_table.name => { primary_record_type: CoreDataConnector::Taxonomy.to_s })
+            .where(ProjectModelRelationship.arel_table.name => { allow_inverse: true })
+        }, as: :related_record, class_name: Relationship.to_s
+
+        has_many :work_related_relationships, -> {
+          joins(:project_model_relationship)
+            .where(Relationship.arel_table.name => { primary_record_type: CoreDataConnector::Work.to_s })
             .where(ProjectModelRelationship.arel_table.name => { allow_inverse: true })
         }, as: :related_record, class_name: Relationship.to_s
 

--- a/app/services/core_data_connector/search/instance.rb
+++ b/app/services/core_data_connector/search/instance.rb
@@ -1,0 +1,27 @@
+module CoreDataConnector
+  module Search
+    module Instance
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def preloads
+          [:primary_name, source_titles: :name]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        search_attribute(:name) do
+          primary_name.name.name
+        end
+
+        search_attribute(:names) do
+          source_titles.map { |st| st.name.name }
+        end
+      end
+
+    end
+  end
+end

--- a/app/services/core_data_connector/search/item.rb
+++ b/app/services/core_data_connector/search/item.rb
@@ -1,0 +1,27 @@
+module CoreDataConnector
+  module Search
+    module Item
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def preloads
+          [:primary_name, source_titles: :name]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        search_attribute(:name) do
+          primary_name.name.name
+        end
+
+        search_attribute(:names) do
+          source_titles.map { |st| st.name.name }
+        end
+      end
+
+    end
+  end
+end

--- a/app/services/core_data_connector/search/work.rb
+++ b/app/services/core_data_connector/search/work.rb
@@ -1,0 +1,27 @@
+module CoreDataConnector
+  module Search
+    module Work
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def preloads
+          [:primary_name, source_titles: :name]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        search_attribute(:name) do
+          primary_name.name.name
+        end
+
+        search_attribute(:names) do
+          source_titles.map { |st| st.name.name }
+        end
+      end
+
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,10 @@
 CoreDataConnector::Engine.routes.draw do
   mount JwtAuth::Engine => '/auth'
 
+  resources :instances
+  resources :items
   resources :media_contents
+  resources :names, only: :index
   resources :organizations
   resources :people
   resources :places
@@ -18,6 +21,7 @@ CoreDataConnector::Engine.routes.draw do
   resources :taxonomies
   resources :user_projects
   resources :users
+  resources :works
 
   namespace :public, only: [:index, :show] do
     resources :people, only: :show

--- a/db/migrate/20231115163827_create_core_data_connector_works.rb
+++ b/db/migrate/20231115163827_create_core_data_connector_works.rb
@@ -1,0 +1,10 @@
+class CreateCoreDataConnectorWorks < ActiveRecord::Migration[7.0]
+  def change
+    create_table :core_data_connector_works do |t|
+      t.references :project_model
+      t.uuid :uuid, default: 'gen_random_uuid()', null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231115163842_create_core_data_connector_instances.rb
+++ b/db/migrate/20231115163842_create_core_data_connector_instances.rb
@@ -1,0 +1,10 @@
+class CreateCoreDataConnectorInstances < ActiveRecord::Migration[7.0]
+  def change
+    create_table :core_data_connector_instances do |t|
+      t.references :project_model
+      t.uuid :uuid, default: 'gen_random_uuid()', null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231115163846_create_core_data_connector_items.rb
+++ b/db/migrate/20231115163846_create_core_data_connector_items.rb
@@ -1,0 +1,10 @@
+class CreateCoreDataConnectorItems < ActiveRecord::Migration[7.0]
+  def change
+    create_table :core_data_connector_items do |t|
+      t.references :project_model
+      t.uuid :uuid, default: 'gen_random_uuid()', null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231128201239_create_core_data_connector_names.rb
+++ b/db/migrate/20231128201239_create_core_data_connector_names.rb
@@ -1,0 +1,9 @@
+class CreateCoreDataConnectorNames < ActiveRecord::Migration[7.0]
+  def change
+    create_table :core_data_connector_names do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231129192431_create_core_data_connector_source_titles.rb
+++ b/db/migrate/20231129192431_create_core_data_connector_source_titles.rb
@@ -1,0 +1,11 @@
+class CreateCoreDataConnectorSourceTitles < ActiveRecord::Migration[7.0]
+  def change
+    create_table :core_data_connector_source_titles do |t|
+      t.references :nameable, polymorphic: true
+      t.references :name
+      t.boolean :primary
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231208205047_add_user_defined_fields_to_core_data_connector_instances.rb
+++ b/db/migrate/20231208205047_add_user_defined_fields_to_core_data_connector_instances.rb
@@ -1,0 +1,11 @@
+class AddUserDefinedFieldsToCoreDataConnectorInstances < ActiveRecord::Migration[7.0]
+  def up
+    add_column :core_data_connector_instances, :user_defined, :jsonb, default: {}
+    add_index :core_data_connector_instances, :user_defined, using: :gin
+  end
+
+  def down
+    remove_index :core_data_connector_instances, :user_defined
+    remove_column :core_data_connector_instances, :user_defined
+  end
+end

--- a/db/migrate/20231208205052_add_user_defined_fields_to_core_data_connector_items.rb
+++ b/db/migrate/20231208205052_add_user_defined_fields_to_core_data_connector_items.rb
@@ -1,0 +1,11 @@
+class AddUserDefinedFieldsToCoreDataConnectorItems < ActiveRecord::Migration[7.0]
+  def up
+    add_column :core_data_connector_items, :user_defined, :jsonb, default: {}
+    add_index :core_data_connector_items, :user_defined, using: :gin
+  end
+
+  def down
+    remove_index :core_data_connector_items, :user_defined
+    remove_column :core_data_connector_items, :user_defined
+  end
+end

--- a/db/migrate/20231208205056_add_user_defined_fields_to_core_data_connector_works.rb
+++ b/db/migrate/20231208205056_add_user_defined_fields_to_core_data_connector_works.rb
@@ -1,0 +1,11 @@
+class AddUserDefinedFieldsToCoreDataConnectorWorks < ActiveRecord::Migration[7.0]
+  def up
+    add_column :core_data_connector_works, :user_defined, :jsonb, default: {}
+    add_index :core_data_connector_works, :user_defined, using: :gin
+  end
+
+  def down
+    remove_index :core_data_connector_works, :user_defined
+    remove_column :core_data_connector_works, :user_defined
+  end
+end

--- a/lib/typesense/helper.rb
+++ b/lib/typesense/helper.rb
@@ -35,6 +35,14 @@ module Typesense
           facet: false,
           optional: true
         }, {
+          name: 'related_instances.*',
+          type: 'auto',
+          facet: true
+        }, {
+          name: 'related_items.*',
+          type: 'auto',
+          facet: true
+        }, {
           name: 'related_media_contents.*',
           type: 'auto',
           facet: true
@@ -48,6 +56,10 @@ module Typesense
           facet: true
         }, {
           name: 'related_places.*',
+          type: 'auto',
+          facet: true
+        }, {
+          name: 'related_works.*',
           type: 'auto',
           facet: true
         }, {


### PR DESCRIPTION
# Summary

Accompanies https://github.com/performant-software/core-data-cloud/pull/58 on the frontend.

- adds three new `Ownable`, `Relatable`, and UDF-enabled models: `Work`, `Item`, and `Instance`
- refactors `nameable` to allow a `polymorphic` boolean configuration option that shares a polymorphic M2M table between multiple models
  - enables this for the three source models, to share their titles via `source_titles`
- adds a new `Name` model and associated logic where polymorphic `nameable` names will be stored
- updates the Search concern for the new models