### PR TITLE
CDC #78 - Adding rack-cors dependency; Adding initializer for CORS

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,7 @@ PATH
       faker
       jwt (~> 2.7.1)
       jwt_auth
+      rack-cors (~> 2.0.1)
       rails (>= 6.0.3.2, < 8)
       resource_api
       rgeo-geojson (~> 2.1)
@@ -177,6 +178,8 @@ GEM
       activesupport (>= 3.0.0)
     racc (1.7.1)
     rack (2.2.8)
+    rack-cors (2.0.1)
+      rack (>= 2.0.0)
     rack-test (2.1.0)
       rack (>= 1.3)
     rails (7.0.7)

--- a/core_data_connector.gemspec
+++ b/core_data_connector.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activerecord-postgis-adapter', '~> 8.0'
   spec.add_dependency 'jwt', '~> 2.7.1'
   spec.add_dependency 'jwt_auth'
+  spec.add_dependency 'rack-cors', '~> 2.0.1'
   spec.add_dependency 'rgeo-geojson', '~> 2.1'
   spec.add_dependency 'resource_api'
   spec.add_dependency 'rubyzip', '~> 2.3.2'

--- a/lib/core_data_connector/engine.rb
+++ b/lib/core_data_connector/engine.rb
@@ -3,6 +3,15 @@ module CoreDataConnector
     isolate_namespace CoreDataConnector
     config.generators.api_only = true
 
+    initializer :rack_cors do |app|
+      app.config.app_middleware.insert_before 0, Rack::Cors do
+        allow do
+          origins '*'
+          resource '/core_data/public/*', methods: :get
+        end
+      end
+    end
+
     initializer :jwt_auth do
       JwtAuth.configure do |config|
         config.model_class = 'CoreDataConnector::User'


### PR DESCRIPTION
This pull request adds the `rack-cors` dependency and an initializer to enable CORS for the `/core_data/public` API endpoints.