### PR TITLE
CDC #79 - Annotation Page

### DIFF
--- a/app/serializers/core_data_connector/public/linked_open_data_serializer.rb
+++ b/app/serializers/core_data_connector/public/linked_open_data_serializer.rb
@@ -37,19 +37,6 @@ module CoreDataConnector
         }
       end
 
-      private
-
-      def render_annotation(item, index, target)
-        {
-          type: 'Annotation',
-          id: index,
-          created: DateTime.now.to_s,
-          motivation: 'linking',
-          target: target,
-          body: item
-        }
-      end
-
       def render_target(item)
         return {} if item.nil?
 
@@ -61,6 +48,19 @@ module CoreDataConnector
         end
 
         serialized
+      end
+
+      private
+
+      def render_annotation(item, index, target)
+        {
+          type: 'Annotation',
+          id: index,
+          created: DateTime.now.to_s,
+          motivation: 'linking',
+          target: target,
+          body: item
+        }
       end
 
       def resolve_target

--- a/app/serializers/core_data_connector/public/media_contents_serializer.rb
+++ b/app/serializers/core_data_connector/public/media_contents_serializer.rb
@@ -2,6 +2,7 @@ module CoreDataConnector
   module Public
     class MediaContentsSerializer < LinkedOpenDataSerializer
       index_attributes(:id) { |media_content|  "#{ENV['HOSTNAME']}/public/media_contents/#{media_content.uuid}" }
+      index_attributes(:record_id) { |media_content| media_content.id }
       index_attributes(:title) { |media_content| media_content.name }
       index_attributes(:type) { 'MediaContent' }
       index_attributes :content_url, :content_download_url, :content_iiif_url, :content_preview_url,

--- a/app/serializers/core_data_connector/public/organizations_serializer.rb
+++ b/app/serializers/core_data_connector/public/organizations_serializer.rb
@@ -2,6 +2,7 @@ module CoreDataConnector
   module Public
     class OrganizationsSerializer < LinkedOpenDataSerializer
       index_attributes(:id) { |organization|  "#{ENV['HOSTNAME']}/public/organizations/#{organization.uuid}" }
+      index_attributes(:record_id) { |organization| organization.id }
       index_attributes(:title) { |organization| organization.name }
       index_attributes(:type) { 'Organization' }
       index_attributes :description, user_defined: UserDefinedSerializer

--- a/app/serializers/core_data_connector/public/people_serializer.rb
+++ b/app/serializers/core_data_connector/public/people_serializer.rb
@@ -2,6 +2,7 @@ module CoreDataConnector
   module Public
     class PeopleSerializer < LinkedOpenDataSerializer
       index_attributes(:id) { |person| "#{ENV['HOSTNAME']}/public/people/#{person.uuid}" }
+      index_attributes(:record_id) { |person| person.id }
       index_attributes(:title) { |person| person.full_name }
       index_attributes(:type){ 'Person' }
       index_attributes :biography, user_defined: UserDefinedSerializer

--- a/app/serializers/core_data_connector/public/places_serializer.rb
+++ b/app/serializers/core_data_connector/public/places_serializer.rb
@@ -2,11 +2,13 @@ module CoreDataConnector
   module Public
     class PlacesSerializer < LinkedOpenDataSerializer
       index_attributes(:id) { |place| "#{ENV['HOSTNAME']}/public/places/#{place.uuid}" }
+      index_attributes(:record_id) { |place| place.id }
       index_attributes(:title) { |place| place.name }
       index_attributes(:type) { 'Place' }
       index_attributes user_defined: UserDefinedSerializer
 
       show_attributes(:@id) { |place| "#{ENV['HOSTNAME']}/public/places/#{place.uuid}" }
+      show_attributes(:record_id) { |place| place.id }
       show_attributes(:type) { 'Place' }
       show_attributes(:properties) { |place| { ccode: [], title: place.name } }
       show_attributes(:geometry) { |place| place.place_geometry&.to_geojson }
@@ -14,6 +16,7 @@ module CoreDataConnector
       show_attributes user_defined: UserDefinedSerializer
 
       target_attributes(:id) { |place| "#{ENV['HOSTNAME']}/public/places/#{place.uuid}" }
+      target_attributes(:record_id) { |place| place.id }
       target_attributes(:name) { |place| place.primary_name&.name }
       target_attributes(:type) { 'Place' }
     end

--- a/app/serializers/core_data_connector/public/taxonomies_serializer.rb
+++ b/app/serializers/core_data_connector/public/taxonomies_serializer.rb
@@ -2,6 +2,7 @@ module CoreDataConnector
   module Public
     class TaxonomiesSerializer < LinkedOpenDataSerializer
       index_attributes(:id) { |taxonomy| "#{ENV['HOSTNAME']}/public/taxonomies/#{taxonomy.uuid}" }
+      index_attributes(:record_id) { |taxonomy| taxonomy.id }
       index_attributes(:title) { |taxonomy| taxonomy.name }
       index_attributes(:type) { 'Taxonomy' }
     end


### PR DESCRIPTION
This pull request fixes a bug in the `linked_open_data_serializer` where the private `render_target` method was being called on an instance. The `render_target` method has been moved to public.

This pull request all adds the `record_id` attribute to all of the public serializers.