### PR TITLE
CDC #87 - Resource IDs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem 'faker', '~> 3.2.1'
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.2'
-#gem 'resource_api', git: 'https://github.com/performant-software/resource-api.git', tag: 'v0.5.6'
-gem 'resource_api', path: '../resource-api'
+gem 'resource_api', git: 'https://github.com/performant-software/resource-api.git', tag: 'v0.5.7'
 gem 'user_defined_fields', git: 'https://github.com/performant-software/user-defined-fields.git', tag: 'v0.1.8'
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.1.9'
 gem 'sqlite3'

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,8 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem 'faker', '~> 3.2.1'
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.2'
-gem 'resource_api', git: 'https://github.com/performant-software/resource-api.git', tag: 'v0.5.6'
+#gem 'resource_api', git: 'https://github.com/performant-software/resource-api.git', tag: 'v0.5.6'
+gem 'resource_api', path: '../resource-api'
 gem 'user_defined_fields', git: 'https://github.com/performant-software/user-defined-fields.git', tag: 'v0.1.8'
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.1.9'
 gem 'sqlite3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,16 +8,6 @@ GIT
       rails (~> 7.0.7)
 
 GIT
-  remote: https://github.com/performant-software/resource-api.git
-  revision: 4ebb021cb1c411e8796bb9a201867333fea3634f
-  tag: v0.5.6
-  specs:
-    resource_api (0.1.0)
-      pagy (~> 5.10)
-      pundit (~> 2.3.1)
-      rails (>= 7.0, < 8)
-
-GIT
   remote: https://github.com/performant-software/triple-eye-effable.git
   revision: 3f914d1035654e260bdc2902e7f0d7909d9e8b49
   tag: v0.1.9
@@ -34,6 +24,14 @@ GIT
     user_defined_fields (0.1.0)
       rails (>= 6.0.3.2, < 8)
       resource_api
+
+PATH
+  remote: ../resource-api
+  specs:
+    resource_api (0.1.0)
+      pagy (~> 5.10)
+      pundit (~> 2.3.1)
+      rails (>= 7.0, < 8)
 
 PATH
   remote: .

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,16 @@ GIT
       rails (~> 7.0.7)
 
 GIT
+  remote: https://github.com/performant-software/resource-api.git
+  revision: 1e4ff2138e74b8e4c3c1a9b1795f2bf0237ae945
+  tag: v0.5.7
+  specs:
+    resource_api (0.1.0)
+      pagy (~> 5.10)
+      pundit (~> 2.3.1)
+      rails (>= 7.0, < 8)
+
+GIT
   remote: https://github.com/performant-software/triple-eye-effable.git
   revision: 3f914d1035654e260bdc2902e7f0d7909d9e8b49
   tag: v0.1.9
@@ -24,14 +34,6 @@ GIT
     user_defined_fields (0.1.0)
       rails (>= 6.0.3.2, < 8)
       resource_api
-
-PATH
-  remote: ../resource-api
-  specs:
-    resource_api (0.1.0)
-      pagy (~> 5.10)
-      pundit (~> 2.3.1)
-      rails (>= 7.0, < 8)
 
 PATH
   remote: .

--- a/app/controllers/concerns/core_data_connector/public/unauthenticateable_controller.rb
+++ b/app/controllers/concerns/core_data_connector/public/unauthenticateable_controller.rb
@@ -9,6 +9,12 @@ module CoreDataConnector
 
         # No Pundit authorization
         before_action :bypass_authorization
+
+        protected
+
+        def find_record(query)
+          query.find_by_uuid(params[:id])
+        end
       end
 
     end

--- a/app/services/core_data_connector/search/base.rb
+++ b/app/services/core_data_connector/search/base.rb
@@ -279,6 +279,8 @@ module CoreDataConnector
             .where(ProjectModelRelationship.arel_table.name => { allow_inverse: true })
         }, as: :related_record, class_name: Relationship.to_s
 
+        search_attribute :uuid
+
         # Include the ID attribute as a string by default
         search_attribute(:record_id) do
           id.to_s


### PR DESCRIPTION
This pull request updates the `unauthenticateable` concern to override the `find_record` method to lookup records in the database by `uuid` instead of database ID. This includes updating the `resource_api` gem to the latest version.

It also refactors the `relateable_controller` concern to avoid multiple queries for the same record for nested resources (i.e. `/places/:uuid/people`.