### PR TITLE
CDC #89 - Manifest URL Updating "triple_eye_effable" gem to latest version; Adding…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'faker', '~> 3.2.1'
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.2'
 gem 'resource_api', git: 'https://github.com/performant-software/resource-api.git', tag: 'v0.5.6'
 gem 'user_defined_fields', git: 'https://github.com/performant-software/user-defined-fields.git', tag: 'v0.1.8'
-gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.1.9'
+gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.1.10'
 gem 'sqlite3'
 
 # Specify your gem's dependencies in core_data_connector.gemspec.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,8 +19,8 @@ GIT
 
 GIT
   remote: https://github.com/performant-software/triple-eye-effable.git
-  revision: 3f914d1035654e260bdc2902e7f0d7909d9e8b49
-  tag: v0.1.9
+  revision: b4f90692c66391133383ce26f36458fde376710c
+  tag: v0.1.10
   specs:
     triple_eye_effable (0.1.0)
       httparty (~> 0.20.0)

--- a/app/serializers/core_data_connector/public/media_contents_serializer.rb
+++ b/app/serializers/core_data_connector/public/media_contents_serializer.rb
@@ -6,7 +6,7 @@ module CoreDataConnector
       index_attributes(:title) { |media_content| media_content.name }
       index_attributes(:type) { 'MediaContent' }
       index_attributes :content_url, :content_download_url, :content_iiif_url, :content_preview_url,
-                       :content_thumbnail_url, user_defined: UserDefinedSerializer
+                       :content_thumbnail_url, :manifest_url, user_defined: UserDefinedSerializer
     end
   end
 end


### PR DESCRIPTION
This pull request updates the `triple_eye_effable` gem to the latest version and adds the `manifest_url` attribute to `public/media_contents_serializer`. This will enable the manifest URL to be accessible from the `/public/places/:id/media_contents` API endpoint.