### PR TITLE
Source imports

### DIFF
--- a/app/services/core_data_connector/import/importer.rb
+++ b/app/services/core_data_connector/import/importer.rb
@@ -4,6 +4,12 @@ module CoreDataConnector
       attr_reader :importers
 
       IMPORTERS = [{
+        importer_class: Instances,
+        filename: 'instances.csv'
+      }, {
+        importer_class: Items,
+        filename: 'items.csv'
+      }, {
         importer_class: Organizations,
         filename: 'organizations.csv'
       }, {
@@ -15,6 +21,9 @@ module CoreDataConnector
       }, {
         importer_class: Relationships,
         filename: 'relationships.csv'
+      }, {
+        importer_class: Works,
+        filename: 'works.csv'
       }]
 
       def initialize(directory)

--- a/app/services/core_data_connector/import/instances.rb
+++ b/app/services/core_data_connector/import/instances.rb
@@ -1,0 +1,110 @@
+module CoreDataConnector
+  module Import
+    class Instances < Base
+      def cleanup
+        super
+
+        execute <<-SQL.squish
+          UPDATE
+          core_data_connector_instances
+            SET z_instance_id = NULL
+        SQL
+      end
+
+      def load
+        super
+
+        execute <<-SQL.squish
+          UPDATE core_data_connector_instances instances
+             SET z_instance_id = z_instances.id,
+                 user_defined = z_instances.user_defined,
+                 updated_at = current_timestamp
+            FROM #{table_name} z_instances
+           WHERE z_instances.instance_id = instances.id
+        SQL
+
+        execute <<-SQL.squish
+        WITH
+
+        insert_instances AS (
+          INSERT INTO core_data_connector_instances (
+            project_model_id,
+            uuid,
+            z_instance_id,
+            user_defined,
+            created_at,
+            updated_at
+          )
+          SELECT z_instances.project_model_id, 
+                 z_instances.uuid, 
+                 z_instances.id, 
+                 z_instances.description, 
+                 z_instances.user_defined, 
+                 current_timestamp, 
+                 current_timestamp
+          FROM #{table_name} z_instances
+          WHERE z_instances.instance_id IS NULL
+          RETURNING id AS instance_id, z_instance_id
+
+        ),
+
+        insert_names AS (
+          INSERT INTO core_data_connector_names
+            (name, created_at, updated_at)
+          SELECT insert_instances.name, current_timestamp, current_timestamp
+          FROM insert_instances
+          JOIN #{table_name} z_instances ON z_instances.id = insert_instances.z_instance_id
+          RETURNING id
+        )
+
+        INSERT INTO core_data_connector_source_titles
+          (nameable_type, nameable_id, name_id, primary, created_at, updated_at)
+          VALUES
+          (
+            "CoreDataConnector::Instance",
+            insert_instances.instance_id,
+            insert_names.id,
+            TRUE,
+            current_timestamp,
+            current_timestamp
+          )
+        SQL
+      end
+
+      def transform
+        super
+
+        execute <<-SQL.squish
+          UPDATE #{table_name} z_instances
+            SET instance_id = instances.id
+            FROM core_data_connector_instances instances
+            WHERE instances.uuid = z_instances.uuid
+        SQL
+      end
+
+      protected
+
+      def column_names
+        [{
+          name: 'project_model_id',
+          type: 'INTEGER',
+          copy: true
+        }, {
+          name: 'uuid',
+          type: 'UUID',
+          copy: true
+        }, {
+          name: 'name',
+          type: 'VARCHAR',
+          copy: true
+        }, {
+          name: 'instance_id',
+          type: 'INTEGER'
+        }, {
+          name: 'user_defined',
+          type: 'JSONB'
+        }]
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import/instances.rb
+++ b/app/services/core_data_connector/import/instances.rb
@@ -5,12 +5,12 @@ module CoreDataConnector
         super
 
         execute <<-SQL.squish
-          WITH update_instances AS (
-            UPDATE
-            core_data_connector_instances
-              SET z_instance_id = NULL
-          )
+          UPDATE
+          core_data_connector_instances
+            SET z_instance_id = NULL
+        SQL
 
+        execute <<-SQL.squish
           UPDATE
           core_data_connector_names
             SET z_source_id = NULL,
@@ -34,6 +34,7 @@ module CoreDataConnector
         WITH
 
         insert_instances AS (
+
           INSERT INTO core_data_connector_instances (
             project_model_id,
             uuid,
@@ -48,32 +49,39 @@ module CoreDataConnector
                  z_instances.user_defined, 
                  current_timestamp, 
                  current_timestamp
-          FROM #{table_name} z_instances
-          WHERE z_instances.instance_id IS NULL
+            FROM #{table_name} z_instances
+            WHERE z_instances.instance_id IS NULL
           RETURNING id AS instance_id, z_instance_id
 
         ),
 
         insert_names AS (
+
           INSERT INTO core_data_connector_names
             ("name", z_source_id, z_source_type, created_at, updated_at)
-          SELECT z_instances.name,
-                 insert_instances.instance_id,
-                 'CoreDataConnector::Instance',
-                 current_timestamp,
-                 current_timestamp
-          FROM insert_instances
-          JOIN #{table_name} z_instances ON z_instances.id = insert_instances.z_instance_id
+            SELECT z_instances.name,
+                   insert_instances.instance_id,
+                   'CoreDataConnector::Instance',
+                   current_timestamp,
+                   current_timestamp
+              FROM insert_instances
+              JOIN #{table_name} z_instances ON z_instances.id = insert_instances.z_instance_id
           RETURNING id AS name_id, z_source_id, z_source_type, "name"
+
         )
 
         INSERT INTO core_data_connector_source_titles
           (nameable_type, nameable_id, name_id, "primary", created_at, updated_at)
-          SELECT 'CoreDataConnector::Instance', insert_instances.instance_id, insert_names.name_id, TRUE, current_timestamp, current_timestamp
-          FROM insert_instances
-          JOIN insert_names
-            ON insert_names.z_source_id = insert_instances.instance_id
-            AND insert_names.z_source_type = 'CoreDataConnector::Instance'
+          SELECT 'CoreDataConnector::Instance',
+                 insert_instances.instance_id,
+                 insert_names.name_id,
+                 TRUE,
+                 current_timestamp,
+                 current_timestamp
+            FROM insert_instances
+            JOIN insert_names
+              ON insert_names.z_source_id = insert_instances.instance_id
+             AND insert_names.z_source_type = 'CoreDataConnector::Instance'
         SQL
       end
 
@@ -82,9 +90,9 @@ module CoreDataConnector
 
         execute <<-SQL.squish
           UPDATE #{table_name} z_instances
-            SET instance_id = instances.id
+             SET instance_id = instances.id
             FROM core_data_connector_instances instances
-            WHERE instances.uuid = z_instances.uuid
+           WHERE instances.uuid = z_instances.uuid
         SQL
       end
 

--- a/app/services/core_data_connector/import/instances.rb
+++ b/app/services/core_data_connector/import/instances.rb
@@ -5,14 +5,12 @@ module CoreDataConnector
         super
 
         execute <<-SQL.squish
-          UPDATE
-          core_data_connector_instances
+          UPDATE core_data_connector_instances
             SET z_instance_id = NULL
         SQL
 
         execute <<-SQL.squish
-          UPDATE
-          core_data_connector_names
+          UPDATE core_data_connector_names
             SET z_source_id = NULL,
                 z_source_type = NULL
         SQL

--- a/app/services/core_data_connector/import/instances.rb
+++ b/app/services/core_data_connector/import/instances.rb
@@ -57,31 +57,42 @@ module CoreDataConnector
 
         insert_names AS (
 
-          INSERT INTO core_data_connector_names
-            ("name", z_source_id, z_source_type, created_at, updated_at)
-            SELECT z_instances.name,
-                   insert_instances.instance_id,
-                   'CoreDataConnector::Instance',
-                   current_timestamp,
-                   current_timestamp
-              FROM insert_instances
-              JOIN #{table_name} z_instances ON z_instances.id = insert_instances.z_instance_id
-          RETURNING id AS name_id, z_source_id, z_source_type, "name"
-
-        )
-
-        INSERT INTO core_data_connector_source_titles
-          (nameable_type, nameable_id, name_id, "primary", created_at, updated_at)
-          SELECT 'CoreDataConnector::Instance',
+          INSERT INTO core_data_connector_names (
+            name,
+            z_source_id,
+            z_source_type,
+            created_at,
+            updated_at
+          )
+          SELECT z_instances.name,
                  insert_instances.instance_id,
-                 insert_names.name_id,
-                 TRUE,
+                 'CoreDataConnector::Instance',
                  current_timestamp,
                  current_timestamp
             FROM insert_instances
-            JOIN insert_names
-              ON insert_names.z_source_id = insert_instances.instance_id
-             AND insert_names.z_source_type = 'CoreDataConnector::Instance'
+            JOIN #{table_name} z_instances ON z_instances.id = insert_instances.z_instance_id
+          RETURNING id AS name_id, z_source_id, z_source_type, name
+
+        )
+
+        INSERT INTO core_data_connector_source_titles (
+          nameable_type,
+          nameable_id,
+          name_id,
+          "primary",
+          created_at,
+          updated_at
+        )
+        SELECT 'CoreDataConnector::Instance',
+                insert_instances.instance_id,
+                insert_names.name_id,
+                TRUE,
+                current_timestamp,
+                current_timestamp
+           FROM insert_instances
+           JOIN insert_names
+             ON insert_names.z_source_id = insert_instances.instance_id
+            AND insert_names.z_source_type = 'CoreDataConnector::Instance'
         SQL
       end
 

--- a/app/services/core_data_connector/import/items.rb
+++ b/app/services/core_data_connector/import/items.rb
@@ -57,31 +57,42 @@ module CoreDataConnector
 
         insert_names AS (
 
-          INSERT INTO core_data_connector_names
-            ("name", z_source_id, z_source_type, created_at, updated_at)
-            SELECT z_items.name,
-                   insert_items.item_id,
-                   'CoreDataConnector::Item',
-                   current_timestamp,
-                   current_timestamp
-              FROM insert_items
-              JOIN #{table_name} z_items ON z_items.id = insert_items.z_item_id
-          RETURNING id AS name_id, z_source_id, z_source_type, "name"
-
-        )
-
-        INSERT INTO core_data_connector_source_titles
-          (nameable_type, nameable_id, name_id, "primary", created_at, updated_at)
-          SELECT 'CoreDataConnector::Item',
+          INSERT INTO core_data_connector_names (
+            name,
+            z_source_id,
+            z_source_type,
+            created_at,
+            updated_at
+          )
+          SELECT z_items.name,
                  insert_items.item_id,
-                 insert_names.name_id,
-                 TRUE,
+                 'CoreDataConnector::Item',
                  current_timestamp,
                  current_timestamp
             FROM insert_items
-            JOIN insert_names
-              ON insert_names.z_source_id = insert_items.item_id
-             AND insert_names.z_source_type = 'CoreDataConnector::Item'
+            JOIN #{table_name} z_items ON z_items.id = insert_items.z_item_id
+          RETURNING id AS name_id, z_source_id, z_source_type, name
+
+        )
+
+        INSERT INTO core_data_connector_source_titles (
+          nameable_type,
+          nameable_id,
+          name_id,
+          "primary",
+          created_at,
+          updated_at
+        )
+        SELECT 'CoreDataConnector::Item',
+                insert_items.item_id,
+                insert_names.name_id,
+                TRUE,
+                current_timestamp,
+                current_timestamp
+           FROM insert_items
+           JOIN insert_names
+             ON insert_names.z_source_id = insert_items.item_id
+            AND insert_names.z_source_type = 'CoreDataConnector::Item'
         SQL
       end
 

--- a/app/services/core_data_connector/import/items.rb
+++ b/app/services/core_data_connector/import/items.rb
@@ -1,0 +1,110 @@
+module CoreDataConnector
+  module Import
+    class Items < Base
+      def cleanup
+        super
+
+        execute <<-SQL.squish
+          UPDATE
+          core_data_connector_items
+            SET z_item_id = NULL
+        SQL
+      end
+
+      def load
+        super
+
+        execute <<-SQL.squish
+          UPDATE core_data_connector_items items
+             SET z_item_id = z_items.id,
+                 user_defined = z_items.user_defined,
+                 updated_at = current_timestamp
+            FROM #{table_name} z_items
+           WHERE z_items.item_id = items.id
+        SQL
+
+        execute <<-SQL.squish
+        WITH
+
+        insert_items AS (
+          INSERT INTO core_data_connector_items (
+            project_model_id,
+            uuid,
+            z_item_id,
+            user_defined,
+            created_at,
+            updated_at
+          )
+          SELECT z_items.project_model_id, 
+                 z_items.uuid, 
+                 z_items.id, 
+                 z_items.description, 
+                 z_items.user_defined, 
+                 current_timestamp, 
+                 current_timestamp
+          FROM #{table_name} z_items
+          WHERE z_items.item_id IS NULL
+          RETURNING id AS item_id, z_item_id
+
+        ),
+
+        insert_names AS (
+          INSERT INTO core_data_connector_names
+            (name, created_at, updated_at)
+          SELECT insert_items.name, current_timestamp, current_timestamp
+          FROM insert_items
+          JOIN #{table_name} z_items ON z_items.id = insert_items.z_item_id
+          RETURNING id
+        )
+
+        INSERT INTO core_data_connector_source_titles
+          (nameable_type, nameable_id, name_id, primary, created_at, updated_at)
+          VALUES
+          (
+            "CoreDataConnector::Item",
+            insert_items.item_id,
+            insert_names.id,
+            TRUE,
+            current_timestamp,
+            current_timestamp
+          )
+        SQL
+      end
+
+      def transform
+        super
+
+        execute <<-SQL.squish
+          UPDATE #{table_name} z_items
+            SET item_id = items.id
+            FROM core_data_connector_items items
+            WHERE items.uuid = z_items.uuid
+        SQL
+      end
+
+      protected
+
+      def column_names
+        [{
+          name: 'project_model_id',
+          type: 'INTEGER',
+          copy: true
+        }, {
+          name: 'uuid',
+          type: 'UUID',
+          copy: true
+        }, {
+          name: 'name',
+          type: 'VARCHAR',
+          copy: true
+        }, {
+          name: 'item_id',
+          type: 'INTEGER'
+        }, {
+          name: 'user_defined',
+          type: 'JSONB'
+        }]
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import/items.rb
+++ b/app/services/core_data_connector/import/items.rb
@@ -5,14 +5,12 @@ module CoreDataConnector
         super
 
         execute <<-SQL.squish
-          UPDATE
-          core_data_connector_items
+          UPDATE core_data_connector_items
             SET z_item_id = NULL
         SQL
 
         execute <<-SQL.squish
-          UPDATE
-          core_data_connector_names
+          UPDATE core_data_connector_names
             SET z_source_id = NULL,
                 z_source_type = NULL
         SQL

--- a/app/services/core_data_connector/import/relationships.rb
+++ b/app/services/core_data_connector/import/relationships.rb
@@ -56,6 +56,14 @@ module CoreDataConnector
         execute <<-SQL.squish
           WITH all_related_types AS (
         
+          SELECT id, uuid, 'CoreDataConnector::Instance' AS type
+            FROM core_data_connector_instances instances
+           WHERE instances.z_instance_id IS NOT NULL
+           UNION
+          SELECT id, uuid, 'CoreDataConnector::Item' AS type
+            FROM core_data_connector_items items
+           WHERE items.z_item_id IS NOT NULL
+           UNION
           SELECT id, uuid, 'CoreDataConnector::Organization' AS type
             FROM core_data_connector_organizations organizations
            WHERE organizations.z_organization_id IS NOT NULL
@@ -67,6 +75,10 @@ module CoreDataConnector
           SELECT id, uuid, 'CoreDataConnector::Place' AS type
             FROM core_data_connector_places places
            WHERE places.z_place_id IS NOT NULL
+           UNION
+          SELECT id, uuid, 'CoreDataConnector::Work' AS type
+            FROM core_data_connector_works works
+           WHERE works.z_work_id IS NOT NULL
               
           )
               

--- a/app/services/core_data_connector/import/works.rb
+++ b/app/services/core_data_connector/import/works.rb
@@ -5,14 +5,12 @@ module CoreDataConnector
         super
 
         execute <<-SQL.squish
-          UPDATE
-          core_data_connector_works
+          UPDATE core_data_connector_works
             SET z_work_id = NULL
         SQL
 
         execute <<-SQL.squish
-          UPDATE
-          core_data_connector_names
+          UPDATE core_data_connector_names
             SET z_source_id = NULL,
                 z_source_type = NULL
         SQL

--- a/app/services/core_data_connector/import/works.rb
+++ b/app/services/core_data_connector/import/works.rb
@@ -57,31 +57,42 @@ module CoreDataConnector
 
         insert_names AS (
 
-          INSERT INTO core_data_connector_names
-            ("name", z_source_id, z_source_type, created_at, updated_at)
-            SELECT z_works.name,
-                   insert_works.work_id,
-                   'CoreDataConnector::Work',
-                   current_timestamp,
-                   current_timestamp
-              FROM insert_works
-              JOIN #{table_name} z_works ON z_works.id = insert_works.z_work_id
-          RETURNING id AS name_id, z_source_id, z_source_type, "name"
-
-        )
-
-        INSERT INTO core_data_connector_source_titles
-          (nameable_type, nameable_id, name_id, "primary", created_at, updated_at)
-          SELECT 'CoreDataConnector::Work',
+          INSERT INTO core_data_connector_names (
+            name,
+            z_source_id,
+            z_source_type,
+            created_at,
+            updated_at
+          )
+          SELECT z_works.name,
                  insert_works.work_id,
-                 insert_names.name_id,
-                 TRUE,
+                 'CoreDataConnector::Work',
                  current_timestamp,
                  current_timestamp
             FROM insert_works
-            JOIN insert_names
-              ON insert_names.z_source_id = insert_works.work_id
-             AND insert_names.z_source_type = 'CoreDataConnector::Work'
+            JOIN #{table_name} z_works ON z_works.id = insert_works.z_work_id
+          RETURNING id AS name_id, z_source_id, z_source_type, name
+
+        )
+
+        INSERT INTO core_data_connector_source_titles (
+          nameable_type,
+          nameable_id,
+          name_id,
+          "primary",
+          created_at,
+          updated_at
+        )
+        SELECT 'CoreDataConnector::Work',
+                insert_works.work_id,
+                insert_names.name_id,
+                TRUE,
+                current_timestamp,
+                current_timestamp
+           FROM insert_works
+           JOIN insert_names
+             ON insert_names.z_source_id = insert_works.work_id
+            AND insert_names.z_source_type = 'CoreDataConnector::Work'
         SQL
       end
 

--- a/app/services/core_data_connector/import/works.rb
+++ b/app/services/core_data_connector/import/works.rb
@@ -1,0 +1,110 @@
+module CoreDataConnector
+  module Import
+    class Works < Base
+      def cleanup
+        super
+
+        execute <<-SQL.squish
+          UPDATE
+          core_data_connector_works
+            SET z_work_id = NULL
+        SQL
+      end
+
+      def load
+        super
+
+        execute <<-SQL.squish
+          UPDATE core_data_connector_works works
+             SET z_work_id = z_works.id,
+                 user_defined = z_works.user_defined,
+                 updated_at = current_timestamp
+            FROM #{table_name} z_works
+           WHERE z_works.work_id = works.id
+        SQL
+
+        execute <<-SQL.squish
+        WITH
+
+        insert_works AS (
+          INSERT INTO core_data_connector_works (
+            project_model_id,
+            uuid,
+            z_work_id,
+            user_defined,
+            created_at,
+            updated_at
+          )
+          SELECT z_works.project_model_id, 
+                 z_works.uuid, 
+                 z_works.id, 
+                 z_works.description, 
+                 z_works.user_defined, 
+                 current_timestamp, 
+                 current_timestamp
+          FROM #{table_name} z_works
+          WHERE z_works.work_id IS NULL
+          RETURNING id AS work_id, z_work_id
+
+        ),
+
+        insert_names AS (
+          INSERT INTO core_data_connector_names
+            (name, created_at, updated_at)
+          SELECT insert_works.name, current_timestamp, current_timestamp
+          FROM insert_works
+          JOIN #{table_name} z_works ON z_works.id = insert_works.z_work_id
+          RETURNING id
+        )
+
+        INSERT INTO core_data_connector_source_titles
+          (nameable_type, nameable_id, name_id, primary, created_at, updated_at)
+          VALUES
+          (
+            "CoreDataConnector::Work",
+            insert_works.work_id,
+            insert_names.id,
+            TRUE,
+            current_timestamp,
+            current_timestamp
+          )
+        SQL
+      end
+
+      def transform
+        super
+
+        execute <<-SQL.squish
+          UPDATE #{table_name} z_works
+            SET work_id = works.id
+            FROM core_data_connector_works works
+            WHERE works.uuid = z_works.uuid
+        SQL
+      end
+
+      protected
+
+      def column_names
+        [{
+          name: 'project_model_id',
+          type: 'INTEGER',
+          copy: true
+        }, {
+          name: 'uuid',
+          type: 'UUID',
+          copy: true
+        }, {
+          name: 'name',
+          type: 'VARCHAR',
+          copy: true
+        }, {
+          name: 'work_id',
+          type: 'INTEGER'
+        }, {
+          name: 'user_defined',
+          type: 'JSONB'
+        }]
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import/works.rb
+++ b/app/services/core_data_connector/import/works.rb
@@ -5,12 +5,12 @@ module CoreDataConnector
         super
 
         execute <<-SQL.squish
-          WITH update_works AS (
-            UPDATE
-            core_data_connector_works
-              SET z_work_id = NULL
-          )
+          UPDATE
+          core_data_connector_works
+            SET z_work_id = NULL
+        SQL
 
+        execute <<-SQL.squish
           UPDATE
           core_data_connector_names
             SET z_source_id = NULL,
@@ -34,6 +34,7 @@ module CoreDataConnector
         WITH
 
         insert_works AS (
+
           INSERT INTO core_data_connector_works (
             project_model_id,
             uuid,
@@ -48,32 +49,39 @@ module CoreDataConnector
                  z_works.user_defined, 
                  current_timestamp, 
                  current_timestamp
-          FROM #{table_name} z_works
-          WHERE z_works.work_id IS NULL
+            FROM #{table_name} z_works
+            WHERE z_works.work_id IS NULL
           RETURNING id AS work_id, z_work_id
 
         ),
 
         insert_names AS (
+
           INSERT INTO core_data_connector_names
             ("name", z_source_id, z_source_type, created_at, updated_at)
-          SELECT z_works.name,
-                 insert_works.work_id,
-                 'CoreDataConnector::Work',
-                 current_timestamp,
-                 current_timestamp
-          FROM insert_works
-          JOIN #{table_name} z_works ON z_works.id = insert_works.z_work_id
+            SELECT z_works.name,
+                   insert_works.work_id,
+                   'CoreDataConnector::Work',
+                   current_timestamp,
+                   current_timestamp
+              FROM insert_works
+              JOIN #{table_name} z_works ON z_works.id = insert_works.z_work_id
           RETURNING id AS name_id, z_source_id, z_source_type, "name"
+
         )
 
         INSERT INTO core_data_connector_source_titles
           (nameable_type, nameable_id, name_id, "primary", created_at, updated_at)
-          SELECT 'CoreDataConnector::Work', insert_works.work_id, insert_names.name_id, TRUE, current_timestamp, current_timestamp
-          FROM insert_works
-          JOIN insert_names
-            ON insert_names.z_source_id = insert_works.work_id
-            AND insert_names.z_source_type = 'CoreDataConnector::Work'
+          SELECT 'CoreDataConnector::Work',
+                 insert_works.work_id,
+                 insert_names.name_id,
+                 TRUE,
+                 current_timestamp,
+                 current_timestamp
+            FROM insert_works
+            JOIN insert_names
+              ON insert_names.z_source_id = insert_works.work_id
+             AND insert_names.z_source_type = 'CoreDataConnector::Work'
         SQL
       end
 
@@ -82,9 +90,9 @@ module CoreDataConnector
 
         execute <<-SQL.squish
           UPDATE #{table_name} z_works
-            SET work_id = works.id
+             SET work_id = works.id
             FROM core_data_connector_works works
-            WHERE works.uuid = z_works.uuid
+           WHERE works.uuid = z_works.uuid
         SQL
       end
 

--- a/db/migrate/20240108143923_add_z_instance_id_to_core_data_connector_instances.rb
+++ b/db/migrate/20240108143923_add_z_instance_id_to_core_data_connector_instances.rb
@@ -1,0 +1,5 @@
+class AddZInstanceIdToCoreDataConnectorInstances < ActiveRecord::Migration[7.0]
+  def change
+    add_column :core_data_connector_instances, :z_instance_id, :integer
+  end
+end

--- a/db/migrate/20240108143938_add_z_item_id_to_core_data_connector_items.rb
+++ b/db/migrate/20240108143938_add_z_item_id_to_core_data_connector_items.rb
@@ -1,0 +1,5 @@
+class AddZItemIdToCoreDataConnectorItems < ActiveRecord::Migration[7.0]
+  def change
+    add_column :core_data_connector_items, :z_item_id, :integer
+  end
+end

--- a/db/migrate/20240108143947_add_z_work_id_to_core_data_connector_works.rb
+++ b/db/migrate/20240108143947_add_z_work_id_to_core_data_connector_works.rb
@@ -1,0 +1,5 @@
+class AddZWorkIdToCoreDataConnectorWorks < ActiveRecord::Migration[7.0]
+  def change
+    add_column :core_data_connector_works, :z_work_id, :integer
+  end
+end

--- a/db/migrate/20240108194908_add_z_source_fields_to_names.rb
+++ b/db/migrate/20240108194908_add_z_source_fields_to_names.rb
@@ -1,0 +1,6 @@
+class AddZSourceFieldsToNames < ActiveRecord::Migration[7.0]
+  def change
+    add_column :core_data_connector_names, :z_source_id, :integer
+    add_column :core_data_connector_names, :z_source_type, :string
+  end
+end


### PR DESCRIPTION
# Summary

- adds modules to the `Import` service for Instances, Items, and Works
- adds migrations for temporary `z_` columns on the source models and the names model to facilitate the import process