### PR TITLE
Add `FieldableSerializer` to source models

### DIFF
--- a/app/serializers/core_data_connector/instances_serializer.rb
+++ b/app/serializers/core_data_connector/instances_serializer.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class InstancesSerializer < BaseSerializer
     include OwnableSerializer
+    include UserDefinedFields::FieldableSerializer
 
     index_attributes :id, primary_name: SourceTitlesSerializer, source_titles: SourceTitlesSerializer
     show_attributes :id, primary_name: SourceTitlesSerializer, source_titles: SourceTitlesSerializer

--- a/app/serializers/core_data_connector/items_serializer.rb
+++ b/app/serializers/core_data_connector/items_serializer.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class ItemsSerializer < BaseSerializer
     include OwnableSerializer
+    include UserDefinedFields::FieldableSerializer
 
     index_attributes :id, primary_name: SourceTitlesSerializer, source_titles: SourceTitlesSerializer
     show_attributes :id, primary_name: SourceTitlesSerializer, source_titles: SourceTitlesSerializer

--- a/app/serializers/core_data_connector/works_serializer.rb
+++ b/app/serializers/core_data_connector/works_serializer.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class WorksSerializer < BaseSerializer
     include OwnableSerializer
+    include UserDefinedFields::FieldableSerializer
 
     index_attributes :id, primary_name: SourceTitlesSerializer, source_titles: SourceTitlesSerializer
     show_attributes :id, primary_name: SourceTitlesSerializer, source_titles: SourceTitlesSerializer


### PR DESCRIPTION
This is a small PR to fix an issue that was preventing sources from displaying user-defined fields. The solution is to add `include UserDefinedFields::FieldableSerializer` to all three serializers.