### PR TITLE
Fix relation imports for works

### DIFF
--- a/app/services/core_data_connector/import/importer.rb
+++ b/app/services/core_data_connector/import/importer.rb
@@ -19,11 +19,11 @@ module CoreDataConnector
         importer_class: Places,
         filename: 'places.csv'
       }, {
-        importer_class: Relationships,
-        filename: 'relationships.csv'
-      }, {
         importer_class: Works,
         filename: 'works.csv'
+      }, {
+        importer_class: Relationships,
+        filename: 'relationships.csv'
       }]
 
       def initialize(directory)
@@ -57,7 +57,7 @@ module CoreDataConnector
 
         # Iterate over each importer and perform any cleanup
         importers.each do |importer|
-          importer.cleanup
+          # importer.cleanup
         end
       end
     end

--- a/app/services/core_data_connector/import/importer.rb
+++ b/app/services/core_data_connector/import/importer.rb
@@ -21,9 +21,6 @@ module CoreDataConnector
       }, {
         importer_class: Works,
         filename: 'works.csv'
-      }, {
-        importer_class: Relationships,
-        filename: 'relationships.csv'
       }]
 
       def initialize(directory)
@@ -37,6 +34,12 @@ module CoreDataConnector
           next unless File.exist? filepath
 
           @importers << klass.new(filepath)
+        end
+
+        # Import relationships last
+        relations_filepath = "#{directory}/relationships.csv"
+        if File.exist? relations_filepath
+          @importers << Relationships.new(relations_filepath)
         end
       end
 

--- a/app/services/core_data_connector/import/importer.rb
+++ b/app/services/core_data_connector/import/importer.rb
@@ -57,7 +57,7 @@ module CoreDataConnector
 
         # Iterate over each importer and perform any cleanup
         importers.each do |importer|
-          # importer.cleanup
+          importer.cleanup
         end
       end
     end


### PR DESCRIPTION
# Summary

- moves the `Relationship` item from the `IMPORTERS` array in the import service and runs it

# Background

Issue #45 took me a while to figure out - work relations weren't importing even though every step of the process seemed to be generating the correct data in the correct format.

I finally narrowed it down to the `IMPORTERS` array at https://github.com/performant-software/core-data-connector/blob/master/app/services/core_data_connector/import/importer.rb#L6. The `importers.each` loop goes through that array in order. We'd been filling the array in alphabetical order, and Relationships were last in the list alphabetically before Works were added, so there wasn't an issue with the list being alphabetical. But with Works coming after Relationships, the relationships were imported before the works were ingested, meaning that all work-related relationships were being skipped because the works didn't exist yet.

At first I moved `relationships` to the end of the array, but that leaves a potential footgun for the future because it's not obvious why relationships *must* be last in the list. So I pulled them out of the array and added them after the loop to make sure they're always run last.