### PR TITLE
Add taxonomy imports

### DIFF
--- a/app/services/core_data_connector/import/base.rb
+++ b/app/services/core_data_connector/import/base.rb
@@ -58,10 +58,12 @@ module CoreDataConnector
                        .flatten
                        .join(', ')
 
-        execute <<-SQL.squish
-          UPDATE #{table_name}
-             SET user_defined = json_strip_nulls(json_build_object(#{expression}))
-        SQL
+        if !expression.empty?
+          execute <<-SQL.squish
+            UPDATE #{table_name}
+               SET user_defined = json_strip_nulls(json_build_object(#{expression}))
+          SQL
+        end
       end
 
       protected

--- a/app/services/core_data_connector/import/importer.rb
+++ b/app/services/core_data_connector/import/importer.rb
@@ -19,6 +19,9 @@ module CoreDataConnector
         importer_class: Places,
         filename: 'places.csv'
       }, {
+        importer_class: Taxonomies,
+        filename: 'taxonomies.csv'
+      }, {
         importer_class: Works,
         filename: 'works.csv'
       }]

--- a/app/services/core_data_connector/import/relationships.rb
+++ b/app/services/core_data_connector/import/relationships.rb
@@ -78,6 +78,10 @@ module CoreDataConnector
             FROM core_data_connector_places places
            WHERE places.z_place_id IS NOT NULL
            UNION
+          SELECT id, uuid, 'CoreDataConnector::Taxonomy' AS type
+            FROM core_data_connector_taxonomies taxonomies
+           WHERE taxonomies.z_taxonomy_id IS NOT NULL
+           UNION
           SELECT id, uuid, 'CoreDataConnector::Work' AS type
             FROM core_data_connector_works works
            WHERE works.z_work_id IS NOT NULL

--- a/app/services/core_data_connector/import/taxonomies.rb
+++ b/app/services/core_data_connector/import/taxonomies.rb
@@ -1,0 +1,94 @@
+module CoreDataConnector
+  module Import
+    class Taxonomies < Base
+      def cleanup
+        super
+
+        execute <<-SQL.squish
+          UPDATE core_data_connector_taxonomies
+             SET z_taxonomy_id = NULL
+        SQL
+      end
+
+      def load
+        super
+
+        execute <<-SQL.squish
+          UPDATE core_data_connector_taxonomies taxonomies
+            SET z_taxonomy_id = z_taxonomies.id,
+              name = z_taxonomies.name,
+              updated_at = current_timestamp
+            FROM #{table_name} z_taxonomies
+          WHERE z_taxonomies.taxonomy_id = taxonomies.id
+        SQL
+
+        execute <<-SQL.squish
+        WITH
+
+        insert_taxonomies AS (
+
+          INSERT INTO core_data_connector_taxonomies (
+            project_model_id,
+            uuid,
+            z_taxonomy_id,
+            name,
+            created_at, 
+            updated_at
+            )
+          SELECT z_taxonomies.project_model_id,
+                 z_taxonomies.uuid,
+                 z_taxonomies.id,
+                 z_taxonomies.name,
+                 current_timestamp,
+                 current_timestamp
+          FROM   #{table_name} z_taxonomies
+          WHERE  z_taxonomies.taxonomy_id IS NULL
+          RETURNING id AS taxonomy_id, z_taxonomy_id
+
+        )
+
+        UPDATE #{table_name} z_taxonomies
+            SET taxonomy_id = insert_taxonomies.taxonomy_id
+            FROM insert_taxonomies
+            WHERE insert_taxonomies.z_taxonomy_id = z_taxonomies.id
+        SQL
+      end
+
+      def transform
+        super
+
+        execute <<-SQL.squish
+          UPDATE #{table_name} z_taxonomies
+             SET taxonomy_id = taxonomies.id
+            FROM core_data_connector_taxonomies taxonomies
+           WHERE taxonomies.uuid = z_taxonomies.uuid
+        SQL
+      end
+
+      protected
+
+      def column_names
+        [{
+          name: 'project_model_id',
+          type: 'INTEGER',
+          copy: true
+        }, {
+          name: 'uuid',
+          type: 'UUID',
+          copy: true
+        }, {
+          name: 'name',
+          type: 'VARCHAR',
+          copy: true
+        }, {
+          name: 'taxonomy_id',
+          type: 'INTEGER'
+        }]
+      end
+
+      def table_name_prefix
+        'z_taxonomies'
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import/taxonomies.rb
+++ b/app/services/core_data_connector/import/taxonomies.rb
@@ -15,17 +15,17 @@ module CoreDataConnector
 
         execute <<-SQL.squish
           UPDATE core_data_connector_taxonomies taxonomies
-            SET z_taxonomy_id = z_taxonomies.id,
-              name = z_taxonomies.name,
-              updated_at = current_timestamp
-            FROM #{table_name} z_taxonomies
+            SET  z_taxonomy_id = z_taxonomies.id,
+                 name = z_taxonomies.name,
+                 updated_at = current_timestamp
+           FROM #{table_name} z_taxonomies
           WHERE z_taxonomies.taxonomy_id = taxonomies.id
         SQL
 
         execute <<-SQL.squish
-        WITH
+          WITH
 
-        insert_taxonomies AS (
+          insert_taxonomies AS (
 
           INSERT INTO core_data_connector_taxonomies (
             project_model_id,
@@ -45,11 +45,11 @@ module CoreDataConnector
           WHERE  z_taxonomies.taxonomy_id IS NULL
           RETURNING id AS taxonomy_id, z_taxonomy_id
 
-        )
+          )
 
-        UPDATE #{table_name} z_taxonomies
-            SET taxonomy_id = insert_taxonomies.taxonomy_id
-            FROM insert_taxonomies
+          UPDATE #{table_name} z_taxonomies
+              SET taxonomy_id = insert_taxonomies.taxonomy_id
+             FROM insert_taxonomies
             WHERE insert_taxonomies.z_taxonomy_id = z_taxonomies.id
         SQL
       end

--- a/db/migrate/20240117215342_add_z_taxonomy_id_to_taxonomies.rb
+++ b/db/migrate/20240117215342_add_z_taxonomy_id_to_taxonomies.rb
@@ -1,0 +1,5 @@
+class AddZTaxonomyIdToTaxonomies < ActiveRecord::Migration[7.0]
+  def change
+    add_column :core_data_connector_taxonomies, :z_taxonomy_id, :integer
+  end
+end


### PR DESCRIPTION
# Summary

- adds a `Taxonomies` class to the import service
- adds a migration for the `z_taxonomy_id` column in the taxonomies table
- fixes an issue in the `Import::Base` class where the `transform` assumed that a model has a `user_defined` column and would attempt to `SET` it even if it doesn't exist