### PR TITLE
CDC #54 - External identifiers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,7 @@ PATH
       rubyzip (~> 2.3.2)
       triple_eye_effable
       typesense (~> 0.14)
+      typhoeus (~> 1.4)
       user_defined_fields
 
 GEM

--- a/app/controllers/core_data_connector/web_authorities_controller.rb
+++ b/app/controllers/core_data_connector/web_authorities_controller.rb
@@ -1,0 +1,18 @@
+module CoreDataConnector
+  class WebAuthoritiesController < ApplicationController
+    # Search attributes
+    search_attributes :source_type
+
+    protected
+
+    def base_query
+      # Return the super method if an "id" is provided
+      return super if params[:id].present?
+
+      # For index routes, require the project_id to be provided
+      return WebAuthority.none unless params[:project_id].present?
+
+      WebAuthority.where(project_id: params[:project_id])
+    end
+  end
+end

--- a/app/controllers/core_data_connector/web_authorities_controller.rb
+++ b/app/controllers/core_data_connector/web_authorities_controller.rb
@@ -3,6 +3,30 @@ module CoreDataConnector
     # Search attributes
     search_attributes :source_type
 
+    def find
+      render json: { errors: [I18n.t('errors.web_authorities_controller.find.identifier')] }, status: :bad_request and return unless params[:identifier].present?
+
+      authority = WebAuthority.find(params[:id])
+      authorize authority, :search?
+
+      instance = authority_instance(authority)
+      json = instance.find(params[:identifier], authority.access&.symbolize_keys)
+
+      render json: json, status: :ok
+    end
+
+    def search
+      render json: { errors: [I18n.t('errors.web_authorities_controller.search.query')] }, status: :bad_request and return unless params[:query].present?
+
+      authority = WebAuthority.find(params[:id])
+      authorize authority, :find?
+
+      instance = authority_instance(authority)
+      json = instance.search(params[:query], authority.access&.symbolize_keys)
+
+      render json: json, status: :ok
+    end
+
     protected
 
     def base_query
@@ -13,6 +37,14 @@ module CoreDataConnector
       return WebAuthority.none unless params[:project_id].present?
 
       WebAuthority.where(project_id: params[:project_id])
+    end
+
+    private
+
+    def authority_instance(authority)
+      class_name = "CoreDataConnector::Authority::#{authority.source_type.capitalize}"
+      klass = class_name.constantize
+      klass.new
     end
   end
 end

--- a/app/controllers/core_data_connector/web_identifiers_controller.rb
+++ b/app/controllers/core_data_connector/web_identifiers_controller.rb
@@ -1,0 +1,26 @@
+module CoreDataConnector
+  class WebIdentifiersController < ApplicationController
+    # Search attributes
+    search_attributes :key
+
+    # Preloads
+    preloads :web_authority
+
+    # Joins
+    joins :web_authority
+
+    protected
+
+    def base_query
+      # Return the super method if an "id" is provided
+      return super if params[:id].present?
+
+      # For index routes, require the identifiable_id and identifiable_type to be provided
+      return WebIdentifier.none unless params[:identifiable_id].present? && params[:identifiable_type].present?
+
+      WebIdentifier
+        .where(identifiable_id: params[:identifiable_id])
+        .where(identifiable_type: params[:identifiable_type])
+    end
+  end
+end

--- a/app/models/concerns/core_data_connector/identifiable.rb
+++ b/app/models/concerns/core_data_connector/identifiable.rb
@@ -1,0 +1,9 @@
+module CoreDataConnector
+  module Identifiable
+    extend ActiveSupport::Concern
+
+    included do
+      has_many :web_identifiers, as: :identifiable, class_name: WebIdentifier.to_s, dependent: :destroy
+    end
+  end
+end

--- a/app/models/core_data_connector/instance.rb
+++ b/app/models/core_data_connector/instance.rb
@@ -1,5 +1,6 @@
 module CoreDataConnector
   class Instance < ApplicationRecord
+    include Identifiable
     include Nameable
     include Ownable
     include Relateable

--- a/app/models/core_data_connector/item.rb
+++ b/app/models/core_data_connector/item.rb
@@ -1,5 +1,6 @@
 module CoreDataConnector
   class Item < ApplicationRecord
+    include Identifiable
     include Nameable
     include Ownable
     include Relateable

--- a/app/models/core_data_connector/media_content.rb
+++ b/app/models/core_data_connector/media_content.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class MediaContent < ApplicationRecord
     # Includes
+    include Identifiable
     include Ownable
     include Relateable
     include Search::MediaContent

--- a/app/models/core_data_connector/organization.rb
+++ b/app/models/core_data_connector/organization.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class Organization < ApplicationRecord
     # Includes
+    include Identifiable
     include Nameable
     include Ownable
     include Relateable

--- a/app/models/core_data_connector/person.rb
+++ b/app/models/core_data_connector/person.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class Person < ApplicationRecord
     # Includes
+    include Identifiable
     include Nameable
     include Ownable
     include Relateable

--- a/app/models/core_data_connector/place.rb
+++ b/app/models/core_data_connector/place.rb
@@ -3,6 +3,7 @@ module CoreDataConnector
     self.primary_key = :id
 
     # Includes
+    include Identifiable
     include Nameable
     include Ownable
     include Relateable

--- a/app/models/core_data_connector/project.rb
+++ b/app/models/core_data_connector/project.rb
@@ -3,5 +3,6 @@ module CoreDataConnector
     # Relationships
     has_many :project_models, dependent: :destroy
     has_many :user_projects, dependent: :destroy
+    has_many :web_authorities, dependent: :destroy
   end
 end

--- a/app/models/core_data_connector/taxonomy.rb
+++ b/app/models/core_data_connector/taxonomy.rb
@@ -1,5 +1,6 @@
 module CoreDataConnector
   class Taxonomy < ApplicationRecord
+    include Identifiable
     include Ownable
     include Relateable
     include Search::Taxonomy

--- a/app/models/core_data_connector/web_authority.rb
+++ b/app/models/core_data_connector/web_authority.rb
@@ -1,0 +1,13 @@
+module CoreDataConnector
+  class WebAuthority < ApplicationRecord
+    SOURCE_TYPES = %w(atom wikidata)
+
+    # Relationships
+    belongs_to :project
+    has_many :web_identifiers, dependent: :destroy
+
+    # Validations
+    validates :source_type, inclusion: { in: SOURCE_TYPES }
+    validates :source_type, uniqueness: { scope: :project_id, message: I18n.t('errors.web_authority.source_type_unique') }
+  end
+end

--- a/app/models/core_data_connector/web_identifier.rb
+++ b/app/models/core_data_connector/web_identifier.rb
@@ -1,0 +1,7 @@
+module CoreDataConnector
+  class WebIdentifier < ApplicationRecord
+    # Relationships
+    belongs_to :identifiable, polymorphic: true
+    belongs_to :web_authority
+  end
+end

--- a/app/models/core_data_connector/work.rb
+++ b/app/models/core_data_connector/work.rb
@@ -1,5 +1,6 @@
 module CoreDataConnector
   class Work < ApplicationRecord
+    include Identifiable
     include Nameable
     include Ownable
     include Relateable

--- a/app/policies/core_data_connector/project_model_policy.rb
+++ b/app/policies/core_data_connector/project_model_policy.rb
@@ -37,7 +37,7 @@ module CoreDataConnector
     end
 
     def permitted_attributes
-      [:project_id, :name, :model_class, :slug, *ProjectModel.permitted_params,
+      [:project_id, :name, :model_class, :slug, :allow_identifiers, *ProjectModel.permitted_params,
        project_model_relationships_attributes: [:id, :primary_model_id, :related_model_id, :name, :multiple, :slug,
                                                 :allow_inverse, :inverse_name, :inverse_multiple, :_destroy,
                                                 *ProjectModelRelationship.permitted_params],

--- a/app/policies/core_data_connector/web_authority_policy.rb
+++ b/app/policies/core_data_connector/web_authority_policy.rb
@@ -15,11 +15,25 @@ module CoreDataConnector
       owner?
     end
 
+    # A user can find a web authority entity if they are an admin user or a member of the project.
+    def find?
+      return true if current_user.admin?
+
+      member?
+    end
+
     # A user can delete a web authority if they are an admin user or the owner of the project.
     def destroy?
       return true if current_user.admin?
 
       owner?
+    end
+
+    # A user can search a web authority if they are an admin user or a member of the project.
+    def search?
+      return true if current_user.admin?
+
+      member?
     end
 
     # A user can view a web authority if they are an admin user or the owner of the project.
@@ -41,6 +55,14 @@ module CoreDataConnector
     end
 
     private
+
+    # Returns true if the current user has a `user_projects` record for the web authority's project.
+    def member?
+      current_user
+        .user_projects
+        .where(project_id: project_id)
+        .exists?
+    end
 
     # Returns true if the current user has an owner `user_projects` record for the web authority's project.
     def owner?

--- a/app/policies/core_data_connector/web_authority_policy.rb
+++ b/app/policies/core_data_connector/web_authority_policy.rb
@@ -1,0 +1,70 @@
+module CoreDataConnector
+  class WebAuthorityPolicy < BasePolicy
+    attr_reader :current_user, :web_authority, :project_id
+
+    def initialize(current_user, web_authority)
+      @current_user = current_user
+      @web_authority = web_authority
+      @project_id = web_authority&.project_id
+    end
+
+    # A user can create a web authority if they are an admin user or the owner of the project.
+    def create?
+      return true if current_user.admin?
+
+      owner?
+    end
+
+    # A user can delete a web authority if they are an admin user or the owner of the project.
+    def destroy?
+      return true if current_user.admin?
+
+      owner?
+    end
+
+    # A user can view a web authority if they are an admin user or the owner of the project.
+    def show?
+      return true if current_user.admin?
+
+      owner?
+    end
+
+    # A user can update a web authority if they are an admin user or the owner of the project.
+    def update?
+      return true if current_user.admin?
+
+      owner?
+    end
+
+    def permitted_attributes
+      [:project_id, :source_type, access: {}]
+    end
+
+    private
+
+    # Returns true if the current user has an owner `user_projects` record for the web authority's project.
+    def owner?
+      current_user
+        .user_projects
+        .where(project_id: project_id)
+        .where(role: UserProject::ROLE_OWNER)
+        .exists?
+    end
+
+    # A user can view web authorities for any project they own.
+    class Scope < BaseScope
+      def resolve
+        return scope.all if current_user.admin?
+
+        scope.where(
+          UserProject
+            .where(UserProject.arel_table[:project_id].eq(WebAuthority.arel_table[:project_id]))
+            .where(user_id: current_user.id)
+            .where(role: UserProject::ROLE_OWNER)
+            .arel
+            .exists
+        )
+      end
+    end
+  end
+end

--- a/app/policies/core_data_connector/web_identifier_policy.rb
+++ b/app/policies/core_data_connector/web_identifier_policy.rb
@@ -1,0 +1,70 @@
+module CoreDataConnector
+  class WebIdentifierPolicy < BasePolicy
+    attr_reader :current_user, :web_identifier, :project_id
+
+    def initialize(current_user, web_identifier)
+      @current_user = current_user
+      @web_identifier = web_identifier
+      @project_id = web_identifier&.web_authority&.project_id
+    end
+
+    # A user can create a web identifier if they are an admin user or member of owning the project.
+    def create?
+      return true if current_user.admin?
+
+      member?
+    end
+
+    # A user can delete a web identifier if they are an admin user or member of owning the project.
+    def destroy?
+      return true if current_user.admin?
+
+      member?
+    end
+
+    # A user can view a web identifier if they are an admin user or member of owning the project.
+    def show?
+      return true if current_user.admin?
+
+      member?
+    end
+
+    # A user can update a web identifier if they are an admin user or member of owning the project.
+    def update?
+      return true if current_user.admin?
+
+      member?
+    end
+
+    # Allowed create/update attributes
+    def permitted_attributes
+      [:web_authority_id, :identifiable_id, :identifiable_type, :identifier]
+    end
+
+    private
+
+    # Returns true if the current user has a `user_projects` record for the web identifier's project.
+    def member?
+      current_user
+        .user_projects
+        .where(project_id: project_id)
+        .exists?
+    end
+
+    # A user can view web identifiers for all projects of which they are a member.
+    class Scope < BaseScope
+      def resolve
+        return scope.all if current_user.admin?
+
+        scope.where(
+          UserProject
+            .joins(project: :web_authorities)
+            .where(WebAuthority.arel_table[:id].eq(WebIdentifier.arel_table[:web_authority_id]))
+            .where(user_id: current_user.id)
+            .arel
+            .exists
+        )
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/project_models_serializer.rb
+++ b/app/serializers/core_data_connector/project_models_serializer.rb
@@ -9,7 +9,8 @@ module CoreDataConnector
       !project_model.project_model_shares.empty?
     end
 
-    show_attributes :id, :project_id, :name, :name_singular, :model_class, :model_class_view, :slug, project: ProjectsSerializer,
+    show_attributes :id, :project_id, :name, :name_singular, :model_class, :model_class_view, :slug, :allow_identifiers,
+                    project: ProjectsSerializer,
                     project_model_relationships: [:id, :related_model_id, :name, :multiple, :slug, :allow_inverse,
                                                   :inverse_name, :inverse_multiple, related_model: ProjectModelsSerializer,
                                                   user_defined_fields: UserDefinedFields::UserDefinedFieldsSerializer],

--- a/app/serializers/core_data_connector/web_authorities_serializer.rb
+++ b/app/serializers/core_data_connector/web_authorities_serializer.rb
@@ -1,0 +1,6 @@
+module CoreDataConnector
+  class WebAuthoritiesSerializer < BaseSerializer
+    index_attributes :id, :source_type, :access
+    show_attributes :id, :source_type, :access
+  end
+end

--- a/app/serializers/core_data_connector/web_identifiers_serializer.rb
+++ b/app/serializers/core_data_connector/web_identifiers_serializer.rb
@@ -1,0 +1,6 @@
+module CoreDataConnector
+  class WebIdentifiersSerializer < BaseSerializer
+    index_attributes :id, :identifier, web_authority: WebAuthoritiesSerializer
+    show_attributes :id, :identifier, web_authority: WebAuthoritiesSerializer
+  end
+end

--- a/app/serializers/core_data_connector/web_identifiers_serializer.rb
+++ b/app/serializers/core_data_connector/web_identifiers_serializer.rb
@@ -1,6 +1,6 @@
 module CoreDataConnector
   class WebIdentifiersSerializer < BaseSerializer
-    index_attributes :id, :identifier, web_authority: WebAuthoritiesSerializer
-    show_attributes :id, :identifier, web_authority: WebAuthoritiesSerializer
+    index_attributes :id, :identifier, :web_authority_id, web_authority: WebAuthoritiesSerializer
+    show_attributes :id, :identifier, :web_authority_id, web_authority: WebAuthoritiesSerializer
   end
 end

--- a/app/services/core_data_connector/authority/atom.rb
+++ b/app/services/core_data_connector/authority/atom.rb
@@ -1,0 +1,27 @@
+module CoreDataConnector
+  module Authority
+    class Atom
+      include Http
+
+      def find(id, options = {})
+        headers = {
+          'REST-API-Key': options[:api_key]
+        }
+
+        send_request("#{options[:url]}/api/informationobjects/#{id}", headers: headers)
+      end
+
+      def search(query, options = {})
+        params = {
+          sq0: query
+        }
+
+        headers = {
+          'REST-API-Key': options[:api_key]
+        }
+
+        send_request("#{options[:url]}/api/informationobjects", headers: headers, params: params)
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/authority/http.rb
+++ b/app/services/core_data_connector/authority/http.rb
@@ -1,0 +1,33 @@
+module CoreDataConnector
+  module Authority
+    module Http
+      extend ActiveSupport::Concern
+
+      CODE_NO_RESPONSE = 0
+
+      included do
+        def send_request(url, options)
+          request = Typhoeus::Request.new(url, options)
+
+          response = request.run
+
+          if response.success?
+            JSON.parse(response.body)
+          elsif response.timed_out?
+            render_errors I18n.t('errors.http.timeout')
+          elsif response.code == CODE_NO_RESPONSE
+            render_errors I18n.t('errors.http.no_response')
+          else
+            render_errors I18n.t('errors.http.general')
+          end
+        end
+
+        private
+
+        def render_errors(message)
+          { errors: [message] }
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/authority/wikidata.rb
+++ b/app/services/core_data_connector/authority/wikidata.rb
@@ -1,0 +1,39 @@
+require 'typhoeus'
+
+module CoreDataConnector
+  module Authority
+    BASE_URL = 'https://www.wikidata.org/w/api.php'
+
+    DEFAULT_LIMIT = 20
+
+    class Wikidata
+      include Http
+
+      def find(id, options = {})
+        params = {
+          action: 'wbgetentities',
+          format: 'json',
+          ids: id,
+          languages: 'en',
+          type: 'item',
+        }
+
+        send_request(BASE_URL, method: :get, params: params)
+      end
+
+      def search(query, options = {})
+        params = {
+          action: 'wbsearchentities',
+          format: 'json',
+          language: 'en',
+          limit: options[:limit] || DEFAULT_LIMIT,
+          search: query,
+          type: 'item',
+          uselang: 'en'
+        }
+
+        send_request(BASE_URL, method: :get, params: params)
+      end
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,11 +8,20 @@ en:
       update?: "You do not have permission to update this project."
 
   errors:
+    http:
+      general: "An error occurred when making your request"
+      no_response: "No response from the server"
+      timeout: "Your request has timed out"
     nameable:
       primary_name: "This record must have a primary name"
     projects:
       import_configuration: "Configuration file required"
       import_data: "Importable contents required"
+    web_authorities_controller:
+      find:
+        identifier: "An identifier is required"
+      search:
+        query: "A search query is required"
     web_authority:
       source_type_unique: "Only one authority per type is allowed per project"
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,6 +13,8 @@ en:
     projects:
       import_configuration: "Configuration file required"
       import_data: "Importable contents required"
+    web_authority:
+      source_type_unique: "Only one authority per type is allowed per project"
 
   serialization:
     linked_open_data:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,8 @@ CoreDataConnector::Engine.routes.draw do
   resources :taxonomies
   resources :user_projects
   resources :users
+  resources :web_authorities
+  resources :web_identifiers
   resources :works
 
   namespace :public, only: [:index, :show] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,10 @@ CoreDataConnector::Engine.routes.draw do
   resources :taxonomies
   resources :user_projects
   resources :users
-  resources :web_authorities
+  resources :web_authorities do
+    get :find, on: :member
+    get :search, on: :member
+  end
   resources :web_identifiers
   resources :works
 

--- a/core_data_connector.gemspec
+++ b/core_data_connector.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'user_defined_fields'
   spec.add_dependency 'triple_eye_effable'
   spec.add_dependency 'typesense', '~> 0.14'
+  spec.add_dependency 'typhoeus', '~> 1.4'
 end

--- a/db/migrate/20240112190944_add_allow_identifiers_to_project_models.rb
+++ b/db/migrate/20240112190944_add_allow_identifiers_to_project_models.rb
@@ -1,0 +1,5 @@
+class AddAllowIdentifiersToProjectModels < ActiveRecord::Migration[7.0]
+  def change
+    add_column :core_data_connector_project_models, :allow_identifiers, :boolean, default: false
+  end
+end

--- a/db/migrate/20240112191132_create_core_data_connector_web_authorities.rb
+++ b/db/migrate/20240112191132_create_core_data_connector_web_authorities.rb
@@ -1,0 +1,10 @@
+class CreateCoreDataConnectorWebAuthorities < ActiveRecord::Migration[7.0]
+  def change
+    create_table :core_data_connector_web_authorities do |t|
+      t.references :project
+      t.string :source_type
+      t.jsonb :access
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240112191137_create_core_data_connector_web_identifiers.rb
+++ b/db/migrate/20240112191137_create_core_data_connector_web_identifiers.rb
@@ -1,0 +1,10 @@
+class CreateCoreDataConnectorWebIdentifiers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :core_data_connector_web_identifiers do |t|
+      t.references :web_authority
+      t.references :identifiable, polymorphic: true
+      t.string :identifier
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds the back end support for creating `web_authorities` and `web_identifiers` records. It also provides the implementation for making API requests for both Wikidata and Access to Memory authorities.

![Screenshot 2024-01-18 at 3 36 31 PM](https://github.com/performant-software/core-data-connector/assets/20641961/f2dffffa-df4e-41f5-bf38-a66eaa1e2da4)
