### PR TITLE
CDC #54 - External Identifiers

### DIFF
--- a/app/services/core_data_connector/authority/http.rb
+++ b/app/services/core_data_connector/authority/http.rb
@@ -1,3 +1,5 @@
+require 'typhoeus'
+
 module CoreDataConnector
   module Authority
     module Http

--- a/app/services/core_data_connector/authority/wikidata.rb
+++ b/app/services/core_data_connector/authority/wikidata.rb
@@ -1,5 +1,3 @@
-require 'typhoeus'
-
 module CoreDataConnector
   module Authority
     BASE_URL = 'https://www.wikidata.org/w/api.php'


### PR DESCRIPTION
Fixing a bug with `typhoeus` require in the wrong class. Moving `typhoeus` require into http.rb concern.