### PR TITLE
Add Bibliothèque nationale de France as a web authority

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,3 @@ gem 'sqlite3'
 
 # Specify your gem's dependencies in core_data_connector.gemspec.
 gemspec
-
-gem "rexml", "~> 3.2"

--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,5 @@ gem 'sqlite3'
 
 # Specify your gem's dependencies in core_data_connector.gemspec.
 gemspec
+
+gem "rexml", "~> 3.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,7 @@ PATH
       rack-cors (~> 2.0.1)
       rails (>= 6.0.3.2, < 8)
       resource_api
+      rexml (~> 3.2)
       rgeo-geojson (~> 2.1)
       rubyzip (~> 2.3.2)
       triple_eye_effable
@@ -245,7 +246,6 @@ DEPENDENCIES
   faker (~> 3.2.1)
   jwt_auth!
   resource_api!
-  rexml (~> 3.2)
   sqlite3
   triple_eye_effable!
   user_defined_fields!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,6 +212,7 @@ GEM
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rake (13.0.6)
+    rexml (3.2.6)
     rgeo (3.0.0)
     rgeo-activerecord (7.0.1)
       activerecord (>= 5.0)
@@ -244,6 +245,7 @@ DEPENDENCIES
   faker (~> 3.2.1)
   jwt_auth!
   resource_api!
+  rexml (~> 3.2)
   sqlite3
   triple_eye_effable!
   user_defined_fields!

--- a/app/models/core_data_connector/web_authority.rb
+++ b/app/models/core_data_connector/web_authority.rb
@@ -1,6 +1,6 @@
 module CoreDataConnector
   class WebAuthority < ApplicationRecord
-    SOURCE_TYPES = %w(atom dpla jisc viaf wikidata)
+    SOURCE_TYPES = %w(atom bnf dpla jisc viaf wikidata)
 
     # Relationships
     belongs_to :project

--- a/app/services/core_data_connector/authority/atom.rb
+++ b/app/services/core_data_connector/authority/atom.rb
@@ -8,7 +8,9 @@ module CoreDataConnector
           'REST-API-Key': options[:api_key]
         }
 
-        send_request("#{options[:url]}/api/informationobjects/#{id}", headers: headers)
+        send_request("#{options[:url]}/api/informationobjects/#{id}", headers: headers) do |body|
+          JSON.parse(body)
+        end
       end
 
       def search(query, options = {})
@@ -20,7 +22,9 @@ module CoreDataConnector
           'REST-API-Key': options[:api_key]
         }
 
-        send_request("#{options[:url]}/api/informationobjects", headers: headers, params: params)
+        send_request("#{options[:url]}/api/informationobjects", headers: headers, params: params) do |body|
+          JSON.parse(body)
+        end
       end
     end
   end

--- a/app/services/core_data_connector/authority/bnf.rb
+++ b/app/services/core_data_connector/authority/bnf.rb
@@ -1,0 +1,44 @@
+require 'json'
+require 'active_support/core_ext'
+require 'typhoeus'
+
+module CoreDataConnector
+  module Authority
+    class Bnf
+      include Http
+
+      BASE_URL = 'https://catalogue.bnf.fr/api/SRU'
+
+      DEFAULT_LIMIT = 20
+
+      BASE_PARAMS = {
+        operation: 'searchRetrieve',
+        startRecord: 1,
+        recordSchema: 'dublincore',
+        version: 1.2
+      }
+
+      def find(id, options = {})
+        params = {
+          query: "bib.ark+all+\"#{id}\"",
+          maximumRecords: options[:limit] || DEFAULT_LIMIT
+        }.merge(BASE_PARAMS)
+
+        send_request(BASE_URL, params: params) do |body|
+          Hash.from_xml(body).to_json
+        end
+      end
+
+      def search(query, options = {})
+        params = {
+          query: "bib.anywhere+all+\"#{query}\"",
+          maximumRecords: options[:limit] || DEFAULT_LIMIT
+        }.merge(BASE_PARAMS)
+
+        send_request(BASE_URL, params: params) do |body|
+          Hash.from_xml(body).to_json
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/authority/bnf.rb
+++ b/app/services/core_data_connector/authority/bnf.rb
@@ -1,7 +1,3 @@
-require 'json'
-require 'active_support/core_ext'
-require 'typhoeus'
-
 module CoreDataConnector
   module Authority
     class Bnf

--- a/app/services/core_data_connector/authority/dpla.rb
+++ b/app/services/core_data_connector/authority/dpla.rb
@@ -12,7 +12,9 @@ module CoreDataConnector
           api_key: options[:api_key]
         }
 
-        send_request("#{BASE_URL}/#{id}", method: :get, params: params)
+        send_request("#{BASE_URL}/#{id}", method: :get, params: params) do |body|
+          JSON.parse(body)
+        end
       end
 
       def search(query, options = {})
@@ -22,7 +24,9 @@ module CoreDataConnector
           q: query
         }
 
-        send_request(BASE_URL, method: :get, params: params)
+        send_request(BASE_URL, method: :get, params: params) do |body|
+          JSON.parse(body)
+        end
       end
     end
   end

--- a/app/services/core_data_connector/authority/http.rb
+++ b/app/services/core_data_connector/authority/http.rb
@@ -14,7 +14,7 @@ module CoreDataConnector
           response = request.run
 
           if response.success?
-            JSON.parse(response.body)
+            yield response.body
           elsif response.timed_out?
             render_errors I18n.t('errors.http.timeout')
           elsif response.code == CODE_NO_RESPONSE

--- a/app/services/core_data_connector/authority/jisc.rb
+++ b/app/services/core_data_connector/authority/jisc.rb
@@ -1,11 +1,11 @@
 module CoreDataConnector
   module Authority
-    BASE_URL = 'https://discover.libraryhub.jisc.ac.uk/search'
-
-    DEFAULT_LIMIT = 20
-
     class Jisc
       include Http
+
+      BASE_URL = 'https://discover.libraryhub.jisc.ac.uk/search'
+  
+      DEFAULT_LIMIT = 20
 
       def find(id, options = {})
         params = {
@@ -13,7 +13,9 @@ module CoreDataConnector
           id: id
         }
 
-        send_request(BASE_URL, method: :get, params: params)
+        send_request(BASE_URL, method: :get, params: params) do |body|
+          JSON.parse(body)
+        end
       end
 
       def search(query, options = {})
@@ -22,7 +24,9 @@ module CoreDataConnector
           keyword: query
         }
 
-        send_request(BASE_URL, method: :get, params: params)
+        send_request(BASE_URL, method: :get, params: params) do |body|
+          JSON.parse(body)
+        end
       end
     end
   end

--- a/app/services/core_data_connector/authority/viaf.rb
+++ b/app/services/core_data_connector/authority/viaf.rb
@@ -1,14 +1,16 @@
 module CoreDataConnector
   module Authority
-    BASE_URL = 'https://viaf.org'
-
-    DEFAULT_LIMIT = 20
-
     class Viaf
       include Http
 
+      BASE_URL = 'https://viaf.org'
+
+      DEFAULT_LIMIT = 20
+
       def find(id, options = {})
-        send_request("#{BASE_URL}/viaf/#{id}/viaf.json", method: :get)
+        send_request("#{BASE_URL}/viaf/#{id}/viaf.json", method: :get) do |body|
+          JSON.parse(body)
+        end
       end
 
       def search(query, options = {})
@@ -16,7 +18,9 @@ module CoreDataConnector
           query: query
         }
 
-        send_request("#{BASE_URL}/viaf/AutoSuggest", method: :get, params: params)
+        send_request("#{BASE_URL}/viaf/AutoSuggest", method: :get, params: params) do |body|
+          JSON.parse(body)
+        end
       end
     end
   end

--- a/app/services/core_data_connector/authority/wikidata.rb
+++ b/app/services/core_data_connector/authority/wikidata.rb
@@ -1,11 +1,11 @@
 module CoreDataConnector
   module Authority
-    BASE_URL = 'https://www.wikidata.org/w/api.php'
-
-    DEFAULT_LIMIT = 20
-
     class Wikidata
       include Http
+
+      BASE_URL = 'https://www.wikidata.org/w/api.php'
+
+      DEFAULT_LIMIT = 20
 
       def find(id, options = {})
         params = {
@@ -16,7 +16,9 @@ module CoreDataConnector
           type: 'item',
         }
 
-        send_request(BASE_URL, method: :get, params: params)
+        send_request(BASE_URL, method: :get, params: params) do |body|
+          JSON.parse(body)
+        end
       end
 
       def search(query, options = {})
@@ -30,7 +32,9 @@ module CoreDataConnector
           uselang: 'en'
         }
 
-        send_request(BASE_URL, method: :get, params: params)
+        send_request(BASE_URL, method: :get, params: params) do |body|
+          JSON.parse(body)
+        end
       end
     end
   end

--- a/core_data_connector.gemspec
+++ b/core_data_connector.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rack-cors', '~> 2.0.1'
   spec.add_dependency 'rgeo-geojson', '~> 2.1'
   spec.add_dependency 'resource_api'
+  spec.add_dependency 'rexml', '~> 3.2'
   spec.add_dependency 'rubyzip', '~> 2.3.2'
   spec.add_dependency 'user_defined_fields'
   spec.add_dependency 'triple_eye_effable'


### PR DESCRIPTION
# Summary

- adds an `Authority` module for BnF
- adds the `rexml` gem, which was required for converting the XML from their response to JSON
- fixes an issue with the scope of the `BASE_URL` constant in the Wikidata authority class where it overwrote the value of BnF's `BASE_URL` in an unpredictable manner
  - also fixes where I made the same mistake in the Jisc and VIAF classes
- refactors the `Authority::Http` class to `yield` the response so we can handle it in different ways depending on the API