### PR TITLE
Add Digital Public Library of America as an authority

### DIFF
--- a/app/models/core_data_connector/web_authority.rb
+++ b/app/models/core_data_connector/web_authority.rb
@@ -1,6 +1,6 @@
 module CoreDataConnector
   class WebAuthority < ApplicationRecord
-    SOURCE_TYPES = %w(atom wikidata)
+    SOURCE_TYPES = %w(atom dpla wikidata)
 
     # Relationships
     belongs_to :project

--- a/app/services/core_data_connector/authority/dpla.rb
+++ b/app/services/core_data_connector/authority/dpla.rb
@@ -1,0 +1,29 @@
+module CoreDataConnector
+  module Authority
+    class Dpla
+      include Http
+
+      BASE_URL = 'https://api.dp.la/v2/items'
+
+      DEFAULT_LIMIT = 20
+
+      def find(id, options = {})
+        params = {
+          api_key: options[:api_key]
+        }
+
+        send_request("#{BASE_URL}/#{id}", method: :get, params: params)
+      end
+
+      def search(query, options = {})
+        params = {
+          api_key: options[:api_key],
+          page_size: options[:limit] || DEFAULT_LIMIT,
+          q: query
+        }
+
+        send_request(BASE_URL, method: :get, params: params)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Summary

- adds a `Dpla` class to the `Authority` module to enable DPLA for external identifiers

(this one was a lot more straightforward than BnF)