### PR TITLE
Add Jisc as an authority

### DIFF
--- a/app/models/core_data_connector/web_authority.rb
+++ b/app/models/core_data_connector/web_authority.rb
@@ -1,6 +1,6 @@
 module CoreDataConnector
   class WebAuthority < ApplicationRecord
-    SOURCE_TYPES = %w(atom wikidata)
+    SOURCE_TYPES = %w(atom jisc wikidata)
 
     # Relationships
     belongs_to :project

--- a/app/services/core_data_connector/authority/jisc.rb
+++ b/app/services/core_data_connector/authority/jisc.rb
@@ -1,0 +1,29 @@
+module CoreDataConnector
+  module Authority
+    BASE_URL = 'https://discover.libraryhub.jisc.ac.uk/search'
+
+    DEFAULT_LIMIT = 20
+
+    class Jisc
+      include Http
+
+      def find(id, options = {})
+        params = {
+          format: 'json',
+          id: id
+        }
+
+        send_request(BASE_URL, method: :get, params: params)
+      end
+
+      def search(query, options = {})
+        params = {
+          format: 'json',
+          keyword: query
+        }
+
+        send_request(BASE_URL, method: :get, params: params)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Summary

- adds a `Jisc` class to the `Authority` module to enable linking Core Data records with external Jisc records