### PR TITLE
Add Viaf as an authority

### DIFF
--- a/app/models/core_data_connector/web_authority.rb
+++ b/app/models/core_data_connector/web_authority.rb
@@ -1,6 +1,6 @@
 module CoreDataConnector
   class WebAuthority < ApplicationRecord
-    SOURCE_TYPES = %w(atom wikidata)
+    SOURCE_TYPES = %w(atom viaf wikidata)
 
     # Relationships
     belongs_to :project

--- a/app/services/core_data_connector/authority/viaf.rb
+++ b/app/services/core_data_connector/authority/viaf.rb
@@ -1,0 +1,23 @@
+module CoreDataConnector
+  module Authority
+    BASE_URL = 'https://viaf.org'
+
+    DEFAULT_LIMIT = 20
+
+    class Viaf
+      include Http
+
+      def find(id, options = {})
+        send_request("#{BASE_URL}/viaf/#{id}/viaf.json", method: :get)
+      end
+
+      def search(query, options = {})
+        params = {
+          query: query
+        }
+
+        send_request("#{BASE_URL}/viaf/AutoSuggest", method: :get, params: params)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Summary

- adds a Viaf class to the Authority module to enable linking Core Data records with external Viaf records