### PR TITLE
Fix sources missing in `build_relationships`

### DIFF
--- a/app/services/core_data_connector/search/base.rb
+++ b/app/services/core_data_connector/search/base.rb
@@ -350,17 +350,23 @@ module CoreDataConnector
         end
 
         def build_relationships(hash)
+          instance_relationships.each { |r| build_relationship(r, hash, :related_instances) }
+          item_relationships.each { |r| build_relationship(r, hash, :related_items) }
           media_content_relationships.each { |r| build_relationship(r, hash, :related_media) }
           organization_relationships.each { |r| build_relationship(r, hash, :related_organizations) }
           person_relationships.each { |r| build_relationship(r, hash, :related_people) }
           place_relationships.each { |r| build_relationship(r, hash, :related_places) }
           taxonomy_relationships.each { |r| build_relationship(r, hash, :related_taxonomies) }
+          work_relationships.each { |r| build_relationship(r, hash, :related_works) }
 
+          instance_related_relationships.each { |r| build_inverse_relationship(r, hash, :related_instances) }
+          item_related_relationships.each { |r| build_inverse_relationship(r, hash, :related_items) }
           media_content_related_relationships.each { |r| build_inverse_relationship(r, hash, :related_media) }
           organization_related_relationships.each { |r| build_inverse_relationship(r,hash, :related_organizations) }
           person_related_relationships.each { |r| build_inverse_relationship(r, hash, :related_people) }
           place_related_relationships.each { |r| build_inverse_relationship(r, hash, :related_places) }
           taxonomy_related_relationships.each { |r| build_inverse_relationship(r, hash, :related_taxonomies) }
+          work_related_relationships.each { |r| build_inverse_relationship(r, hash, :related_works) }
         end
 
         def build_user_defined(record, user_defined_fields)


### PR DESCRIPTION
# Summary

https://github.com/performant-software/core-data-cloud/issues/135 was caused by some missed boilerplate in the `Search` module, specifically in the `build_relationships` method. I've added the three source types to that method and indexed some test data to confirm the fix.

# Screenshot of index

<img width="1280" alt="Screenshot 2024-02-14 at 9 45 55 AM" src="https://github.com/performant-software/core-data-connector/assets/64725469/fc4e2b22-d761-4876-a7de-df9c03e36b01">
