### PR TITLE
Fix errors related to `nil``user_defined` value

### DIFF
--- a/app/serializers/core_data_connector/public/user_defined_serializer.rb
+++ b/app/serializers/core_data_connector/public/user_defined_serializer.rb
@@ -29,6 +29,8 @@ module CoreDataConnector
         return if fields.nil?
 
         fields.each do |field|
+          next unless item.user_defined
+
           value = item.user_defined[field.uuid]
           next if value.nil?
 

--- a/app/services/core_data_connector/search/base.rb
+++ b/app/services/core_data_connector/search/base.rb
@@ -373,6 +373,8 @@ module CoreDataConnector
           hash = {}
 
           user_defined_fields.each do |field|
+            next unless record.user_defined
+
             value = record.user_defined[field.uuid]
             next unless value.present?
 


### PR DESCRIPTION
# Summary

This small PR fixes two issues where Core Data tried to access a user-defined field by its UUID without first checking if the `user_defined` field was actually a JSON object. An empty user-defined field can be either `{}` (an empty object) or `nil`, so I've fixed the issue by checking that `user_defined` isn't `nil` before proceeding to try to look up a value in it.