### PR TITLE
CDC #114 - IIIF Manifests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,8 @@ gem 'faker', '~> 3.2.1'
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.2'
 gem 'resource_api', git: 'https://github.com/performant-software/resource-api.git', tag: 'v0.5.7'
 gem 'user_defined_fields', git: 'https://github.com/performant-software/user-defined-fields.git', tag: 'v0.1.8'
-gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.1.10'
+#gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.1.10'
+gem 'triple_eye_effable', path: '../triple-eye-effable'
 gem 'sqlite3'
 
 # Specify your gem's dependencies in core_data_connector.gemspec.

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,7 @@ gem 'faker', '~> 3.2.1'
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.2'
 gem 'resource_api', git: 'https://github.com/performant-software/resource-api.git', tag: 'v0.5.7'
 gem 'user_defined_fields', git: 'https://github.com/performant-software/user-defined-fields.git', tag: 'v0.1.8'
-#gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.1.10'
-gem 'triple_eye_effable', path: '../triple-eye-effable'
+gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.1.11'
 gem 'sqlite3'
 
 # Specify your gem's dependencies in core_data_connector.gemspec.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,15 +18,6 @@ GIT
       rails (>= 7.0, < 8)
 
 GIT
-  remote: https://github.com/performant-software/triple-eye-effable.git
-  revision: b4f90692c66391133383ce26f36458fde376710c
-  tag: v0.1.10
-  specs:
-    triple_eye_effable (0.1.0)
-      httparty (~> 0.20.0)
-      rails (>= 6.0.3.2, < 8)
-
-GIT
   remote: https://github.com/performant-software/user-defined-fields.git
   revision: 4872b3f1e7c5d4ecf83aedc30202aab91589e5ed
   tag: v0.1.8
@@ -34,6 +25,13 @@ GIT
     user_defined_fields (0.1.0)
       rails (>= 6.0.3.2, < 8)
       resource_api
+
+PATH
+  remote: ../triple-eye-effable
+  specs:
+    triple_eye_effable (0.1.0)
+      httparty (~> 0.20.0)
+      rails (>= 6.0.3.2, < 8)
 
 PATH
   remote: .

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,15 @@ GIT
       rails (>= 7.0, < 8)
 
 GIT
+  remote: https://github.com/performant-software/triple-eye-effable.git
+  revision: 27941317d9153df7317a0103b735356476665cfb
+  tag: v0.1.11
+  specs:
+    triple_eye_effable (0.1.0)
+      httparty (~> 0.20.0)
+      rails (>= 6.0.3.2, < 8)
+
+GIT
   remote: https://github.com/performant-software/user-defined-fields.git
   revision: 4872b3f1e7c5d4ecf83aedc30202aab91589e5ed
   tag: v0.1.8
@@ -25,13 +34,6 @@ GIT
     user_defined_fields (0.1.0)
       rails (>= 6.0.3.2, < 8)
       resource_api
-
-PATH
-  remote: ../triple-eye-effable
-  specs:
-    triple_eye_effable (0.1.0)
-      httparty (~> 0.20.0)
-      rails (>= 6.0.3.2, < 8)
 
 PATH
   remote: .

--- a/README.md
+++ b/README.md
@@ -70,13 +70,63 @@ end
 In addition to the authenticated API, the `core_data_connector` gem also provides a public API for the following endpoints:
 
 ```
+GET /core_data/public/instances
+GET /core_data/public/instances/:uuid
+GET /core_data/public/instances/:uuid/instances
+GET /core_data/public/instances/:uuid/items
+GET /core_data/public/instances/:uuid/manifests
+GET /core_data/public/instances/:uuid/manifests/:uuid
+GET /core_data/public/instances/:uuid/media_contents
+GET /core_data/public/instances/:uuid/organizations
+GET /core_data/public/instances/:uuid/people
+GET /core_data/public/instances/:uuid/places
+GET /core_data/public/instances/:uuid/taxonomies
+GET /core_data/public/instances/:uuid/works
+```
+
+```
+GET /core_data/public/items
+GET /core_data/public/items/:uuid
+GET /core_data/public/items/:uuid/instances
+GET /core_data/public/items/:uuid/items
+GET /core_data/public/items/:uuid/manifests
+GET /core_data/public/items/:uuid/manifests/:uuid
+GET /core_data/public/items/:uuid/media_contents
+GET /core_data/public/items/:uuid/organizations
+GET /core_data/public/items/:uuid/people
+GET /core_data/public/items/:uuid/places
+GET /core_data/public/items/:uuid/taxonomies
+GET /core_data/public/items/:uuid/works
+```
+
+```
 GET /core_data/public/places
 GET /core_data/public/places/:uuid
+GET /core_data/public/places/:uuid/instances
+GET /core_data/public/places/:uuid/items
+GET /core_data/public/places/:uuid/manifests
+GET /core_data/public/places/:uuid/manifests/:uuid
 GET /core_data/public/places/:uuid/media_contents
 GET /core_data/public/places/:uuid/organizations
 GET /core_data/public/places/:uuid/people
 GET /core_data/public/places/:uuid/places
 GET /core_data/public/places/:uuid/taxonomies
+GET /core_data/public/places/:uuid/works
+```
+
+```
+GET /core_data/public/works
+GET /core_data/public/works/:uuid
+GET /core_data/public/works/:uuid/instances
+GET /core_data/public/works/:uuid/items
+GET /core_data/public/works/:uuid/manifests
+GET /core_data/public/works/:uuid/manifests/:uuid
+GET /core_data/public/works/:uuid/media_contents
+GET /core_data/public/works/:uuid/organizations
+GET /core_data/public/works/:uuid/people
+GET /core_data/public/works/:uuid/places
+GET /core_data/public/works/:uuid/taxonomies
+GET /core_data/public/works/:uuid/works
 ```
 
 The following query parameters can be used to further modify the results:

--- a/app/controllers/concerns/core_data_connector/manifests_controller.rb
+++ b/app/controllers/concerns/core_data_connector/manifests_controller.rb
@@ -1,0 +1,76 @@
+module CoreDataConnector
+  module ManifestsController
+    extend ActiveSupport::Concern
+
+    # This module should be included in the relationships_controller in order to handle generating IIIF manifests
+    # after records are added/removed.
+    included do
+      # Actions
+      after_action :update_manifests_on_upload, only: :upload
+      after_action :update_manifests_on_delete, only: :destroy
+      before_action :set_record_for_manifest, only: :destroy
+
+      private
+
+      # Returns the record to update the manifest for the passed relationship.
+      def record_to_update(relationship)
+        if relationship.related_record_type == MediaContent.to_s
+          record = relationship.primary_record
+        elsif relationship.primary_record_type == MediaContent.to_s && relationship.project_model_relationship.allow_inverse?
+          record = relationship.related_record
+        end
+
+        # Only create manifests for models that include the Manifestale concern
+        return nil unless record.is_a?(Manifestable)
+
+        record
+      end
+
+      # For deleting a relationship, we'll track the record and project_model_relationship_id in the before_action,
+      # since the relationship wont exist after.
+      def set_record_for_manifest
+        relationship = Relationship.find(params[:id])
+        @record = record_to_update(relationship)
+        @project_model_relationship_id = relationship.project_model_relationship_id
+      end
+
+      # After the relationship has been deleted, re-create the manifest for the target model.
+      def update_manifests_on_delete
+        return if @record.nil? || @project_model_relationship_id.nil?
+
+        service = Iiif::Manifest.new
+        service.reset_manifests_by_type(@record.class, {
+          id: @record.id,
+          project_model_relationship_id: @project_model_relationship_id
+        })
+      end
+
+      # After uploading new relationships, generate the manifests for the target models.
+      def update_manifests_on_upload
+        cache = []
+
+        params[:relationships].keys.each do |index|
+          relationship_params = params[:relationships][index]
+
+          relationship = Relationship.find_by(
+            primary_record_id: relationship_params[:primary_record_id],
+            primary_record_type: relationship_params[:primary_record_type],
+            related_record_id: relationship_params[:related_record_id],
+            related_record_type: relationship_params[:related_record_type]
+          )
+
+          record = record_to_update(relationship)
+          next if record.nil? || cache.include?(record)
+
+          cache << record
+
+          service = Iiif::Manifest.new
+          service.reset_manifests_by_type(record.class, {
+            id: record.id,
+            project_model_relationship_id: relationship.project_model_relationship_id
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/core_data_connector/manifests_controller.rb
+++ b/app/controllers/concerns/core_data_connector/manifests_controller.rb
@@ -41,7 +41,8 @@ module CoreDataConnector
         service = Iiif::Manifest.new
         service.reset_manifests_by_type(@record.class, {
           id: @record.id,
-          project_model_relationship_id: @project_model_relationship_id
+          project_model_relationship_id: @project_model_relationship_id,
+          limit: ENV['IIIF_MANIFEST_ITEM_LIMIT']
         })
       end
 
@@ -67,7 +68,8 @@ module CoreDataConnector
           service = Iiif::Manifest.new
           service.reset_manifests_by_type(record.class, {
             id: record.id,
-            project_model_relationship_id: relationship.project_model_relationship_id
+            project_model_relationship_id: relationship.project_model_relationship_id,
+            limit: ENV['IIIF_MANIFEST_ITEM_LIMIT']
           })
         end
       end

--- a/app/controllers/concerns/core_data_connector/public/nestable_controller.rb
+++ b/app/controllers/concerns/core_data_connector/public/nestable_controller.rb
@@ -1,0 +1,29 @@
+module CoreDataConnector
+  module Public
+    module NestableController
+      extend ActiveSupport::Concern
+
+      included do
+        # Member attributes
+        attr_reader :current_record
+
+        # Actions
+        before_action :set_current_record
+
+        private
+
+        def set_current_record
+          if params[:instance_id].present?
+            @current_record = Instance.find_by_uuid(params[:instance_id])
+          elsif params[:item_id].present?
+            @current_record = Item.find_by_uuid(params[:item_id])
+          elsif params[:place_id].present?
+            @current_record = Place.find_by_uuid(params[:place_id])
+          elsif params[:work_id].present?
+            @current_record = Work.find_by_uuid(params[:work_id])
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/public/manifests_controller.rb
+++ b/app/controllers/core_data_connector/public/manifests_controller.rb
@@ -1,0 +1,103 @@
+module CoreDataConnector
+  module Public
+    class ManifestsController < ApplicationController
+      # Includes
+      include NestableController
+      include UnauthenticateableController
+
+      # Disable pagination
+      per_page 0
+
+      protected
+
+      def base_query
+        # Manifests can only be retrieved for nested routes
+        return Manifest.none unless current_record.present?
+
+        # If not retrieving a single manifest, the project_ids parameter is required
+        return Manifest.none unless params[:project_ids].present? || params[:id].present?
+
+        query = Manifest
+                  .joins(project_model_relationship: [:primary_model, :related_model])
+                  .where(
+                    manifestable_id: current_record.id,
+                    manifestable_type: current_record.class.to_s
+                  )
+
+        if params[:project_ids].present?
+          query = query.where(
+            primary_model: {
+              project_id: params[:project_ids]
+            }
+          ).or(
+            query.where(related_model: {
+              project_id: params[:project_ids]
+            })
+          )
+        end
+
+        query
+      end
+
+      def build_index_response(items, metadata)
+        return {} if items.empty?
+
+        service = TripleEyeEffable::Presentation.new
+
+        service.create_collection(
+          id: identifier,
+          label: label,
+          items: items.map{ |i| to_collection_item(i) }
+        )
+      end
+
+      def build_show_response(item)
+        item&.content
+      end
+
+      def find_record(query)
+        puts query.to_sql
+
+        query
+          .joins(:project_model_relationship)
+          .where(project_model_relationship: {
+            uuid: params[:id]
+          })
+          .take
+      end
+
+      private
+
+      def identifier
+        url = [
+          ENV['HOSTNAME'],
+          'core_data',
+          'public',
+          current_record.class.model_name.route_key,
+          current_record.uuid,
+          'manifests'
+        ].join('/')
+
+        parameters = {
+          project_ids: params[:project_ids]
+        }
+
+        "#{url}?#{parameters.to_query}"
+      end
+
+      def label
+        service = Iiif::Manifest.new
+        service.find_label(current_record)
+      end
+
+      def to_collection_item(manifest)
+        {
+          id: "#{ENV['HOSTNAME']}/#{manifest.identifier}",
+          type: 'Manifest',
+          label: manifest.label,
+          thumbnail: manifest.thumbnail
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/public/public_controller.rb
+++ b/app/controllers/core_data_connector/public/public_controller.rb
@@ -1,11 +1,8 @@
 module CoreDataConnector
   module Public
     class PublicController < ApplicationController
-      # Member attributes
-      attr_reader :current_record
-
-      # Actions
-      before_action :set_current_record
+      # Includes
+      include NestableController
 
       protected
 
@@ -122,18 +119,6 @@ module CoreDataConnector
             #{related_query.to_sql}
           )
         SQL
-      end
-
-      def set_current_record
-        if params[:instance_id].present?
-          @current_record = Instance.find_by_uuid(params[:instance_id])
-        elsif params[:item_id].present?
-          @current_record = Item.find_by_uuid(params[:item_id])
-        elsif params[:place_id].present?
-          @current_record = Place.find_by_uuid(params[:place_id])
-        elsif params[:work_id].present?
-          @current_record = Work.find_by_uuid(params[:work_id])
-        end
       end
     end
   end

--- a/app/controllers/core_data_connector/relationships_controller.rb
+++ b/app/controllers/core_data_connector/relationships_controller.rb
@@ -2,6 +2,7 @@ module CoreDataConnector
   class RelationshipsController < ApplicationController
     # Includes
     include Api::Uploadable
+    include ManifestsController
     include UserDefinedFields::Queryable
 
     # Actions

--- a/app/models/concerns/core_data_connector/manifestable.rb
+++ b/app/models/concerns/core_data_connector/manifestable.rb
@@ -1,0 +1,9 @@
+module CoreDataConnector
+  module Manifestable
+    extend ActiveSupport::Concern
+
+    included do
+      has_many :manifests, as: :manifestable, class_name: Manifest.to_s, dependent: :destroy
+    end
+  end
+end

--- a/app/models/core_data_connector/instance.rb
+++ b/app/models/core_data_connector/instance.rb
@@ -1,12 +1,15 @@
 module CoreDataConnector
   class Instance < ApplicationRecord
+    # Includes
     include Identifiable
+    include Manifestable
     include Nameable
     include Ownable
     include Relateable
     include UserDefinedFields::Fieldable
     include Search::Instance
 
+    # Nameable table
     name_table :source_titles, polymorphic: true
   end
 end

--- a/app/models/core_data_connector/item.rb
+++ b/app/models/core_data_connector/item.rb
@@ -1,12 +1,15 @@
 module CoreDataConnector
   class Item < ApplicationRecord
+    # Includes
     include Identifiable
+    include Manifestable
     include Nameable
     include Ownable
     include Relateable
     include UserDefinedFields::Fieldable
     include Search::Item
 
+    # Nameable table
     name_table :source_titles, polymorphic: true
   end
 end

--- a/app/models/core_data_connector/location.rb
+++ b/app/models/core_data_connector/location.rb
@@ -1,9 +1,0 @@
-module CoreDataConnector
-  class Location < ApplicationRecord
-    self.primary_key = :id
-
-    # Relationships
-    belongs_to :place
-    belongs_to :locateable, polymorphic: true
-  end
-end

--- a/app/models/core_data_connector/manifest.rb
+++ b/app/models/core_data_connector/manifest.rb
@@ -1,0 +1,12 @@
+module CoreDataConnector
+  class Manifest < ApplicationRecord
+    # Relationships
+    belongs_to :manifestable, polymorphic: true
+    belongs_to :project_model_relationship
+
+    # Validations
+    validates :project_model_relationship_id, uniqueness: {
+      scope: [:manifestable_id, :manifestable_type], message: I18n.t('errors.manifest.unique')
+    }
+  end
+end

--- a/app/models/core_data_connector/place.rb
+++ b/app/models/core_data_connector/place.rb
@@ -4,6 +4,7 @@ module CoreDataConnector
 
     # Includes
     include Identifiable
+    include Manifestable
     include Nameable
     include Ownable
     include Relateable

--- a/app/models/core_data_connector/project_model_relationship.rb
+++ b/app/models/core_data_connector/project_model_relationship.rb
@@ -8,6 +8,7 @@ module CoreDataConnector
     belongs_to :primary_model, class_name: ProjectModel.to_s
     belongs_to :related_model, class_name: ProjectModel.to_s
     has_many :relationships, dependent: :destroy
+    has_many :manifests, dependent: :destroy
 
     # Delegates
     delegate :project_id, to: :primary_model

--- a/app/models/core_data_connector/work.rb
+++ b/app/models/core_data_connector/work.rb
@@ -1,12 +1,15 @@
 module CoreDataConnector
   class Work < ApplicationRecord
+    # Includes
     include Identifiable
+    include Manifestable
     include Nameable
     include Ownable
     include Relateable
     include UserDefinedFields::Fieldable
     include Search::Work
 
+    # Nameable table
     name_table :source_titles, polymorphic: true
   end
 end

--- a/app/serializers/core_data_connector/project_models_serializer.rb
+++ b/app/serializers/core_data_connector/project_models_serializer.rb
@@ -3,18 +3,18 @@ module CoreDataConnector
     # Includes
     include UserDefinedFields::DefineableSerializer
 
-    index_attributes :id, :project_id, :name, :name_singular, :model_class, :model_class_view, :slug, project: ProjectsSerializer
+    index_attributes :id, :uuid, :project_id, :name, :name_singular, :model_class, :model_class_view, :slug, project: ProjectsSerializer
 
     index_attributes(:has_shares) do |project_model|
       !project_model.project_model_shares.empty?
     end
 
-    show_attributes :id, :project_id, :name, :name_singular, :model_class, :model_class_view, :slug, :allow_identifiers,
+    show_attributes :id, :uuid, :project_id, :name, :name_singular, :model_class, :model_class_view, :slug, :allow_identifiers,
                     project: ProjectsSerializer,
-                    project_model_relationships: [:id, :related_model_id, :name, :multiple, :slug, :allow_inverse,
+                    project_model_relationships: [:id, :uuid, :related_model_id, :name, :multiple, :slug, :allow_inverse,
                                                   :inverse_name, :inverse_multiple, related_model: ProjectModelsSerializer,
                                                   user_defined_fields: UserDefinedFields::UserDefinedFieldsSerializer],
-                    inverse_project_model_relationships: [:id, :primary_model_id, :name, :multiple, :slug, :allow_inverse,
+                    inverse_project_model_relationships: [:id, :uuid, :primary_model_id, :name, :multiple, :slug, :allow_inverse,
                                                           :inverse_name, :inverse_multiple, primary_model: ProjectModelsSerializer,
                                                           user_defined_fields: UserDefinedFields::UserDefinedFieldsSerializer],
                     project_model_accesses: [:id, :project_id, project: ProjectsSerializer],

--- a/app/services/core_data_connector/iiif/manifest.rb
+++ b/app/services/core_data_connector/iiif/manifest.rb
@@ -1,0 +1,168 @@
+module CoreDataConnector
+  module Iiif
+    class Manifest
+      def find_label(record)
+        if record.is_a?(Place)
+          record.name
+        elsif record.is_a?(Instance) || record.is_a?(Item) || record.is_a?(Work)
+          record.primary_name&.name&.name
+        end
+      end
+
+      def reset_manifests
+        # Find all project models that have a relationship
+        ProjectModel.model_classes.each do |model_class|
+          next unless model_class.ancestors.include?(Manifestable)
+          reset_manifests_by_type model_class
+        end
+      end
+
+      def reset_manifests_by_type(model_class, options = {})
+        service = TripleEyeEffable::Presentation.new
+
+        query = build_query(model_class, options)
+        apply_preloads(query, options)
+
+        query.find_each do |record|
+          # Build a mapping of all of the related resources indexed by project_model_relationship
+          hash = {}
+
+          # Generate the manifest label for the current record
+          label = find_label(record)
+
+          record.relationships.each do |relationship|
+            project_model_relationship = relationship.project_model_relationship
+            resource = relationship.related_record
+
+            add_resource hash, project_model_relationship, resource
+          end
+
+          record.related_relationships.each do |relationship|
+            project_model_relationship = relationship.project_model_relationship
+            resource = relationship.primary_record
+
+            add_resource hash, project_model_relationship, resource
+          end
+
+          # Iterate over all of the relationships and build a manifest for each
+          hash.keys.each do |project_model_relationship_uuid|
+            info = hash[project_model_relationship_uuid]
+
+            identifier = [
+              'core_data',
+              'public',
+              model_class.model_name.route_key,
+              record.uuid,
+              'manifests',
+              project_model_relationship_uuid
+            ].join('/')
+
+            # Create or update the manifest records
+            project_model_relationship_id = info[:id]
+            manifest = find_manifest(record, project_model_relationship_id)
+
+            if manifest.nil?
+              manifest = CoreDataConnector::Manifest.new(
+                manifestable: record,
+                project_model_relationship_id: project_model_relationship_id,
+                thumbnail: info[:resources].first,
+                identifier: identifier,
+                label: info[:name]
+              )
+            end
+
+            manifest.content = service.create_manifest(
+              id: "#{ENV['HOSTNAME']}/#{identifier}",
+              label: I18n.t('services.iiif.manifest.label', name: label, relationship: info[:name]),
+              resource_ids: info[:resources]
+            )
+
+            manifest.save
+          end
+        end
+      end
+
+      private
+
+      def add_resource(hash, project_model_relationship, resource)
+        key = project_model_relationship.uuid
+
+        hash[key] ||= {
+          id: project_model_relationship.id,
+          name: project_model_relationship.name,
+          resources: []
+        }
+
+        hash[key][:resources] << resource.resource_description.resource_id
+      end
+
+      def apply_preloads(query, options)
+        relationships_scope = Relationship
+                                .where(related_record_type: MediaContent.to_s)
+
+        if options[:project_model_relationship_id].present?
+          relationships_scope = relationships_scope.where(
+            project_model_relationship_id: options[:project_model_relationship_id]
+          )
+        end
+
+        Preloader.new(
+          records: query,
+          associations: [
+            relationships: [:project_model_relationship, :related_record]
+          ],
+          scope: relationships_scope
+        ).call
+
+        related_relationships_scope = Relationship
+                                        .joins(:project_model_relationship)
+                                        .where(primary_record_type: MediaContent.to_s)
+                                        .where(project_model_relationship: {
+                                          allow_inverse: true
+                                        })
+
+        if options[:project_model_relationship_id].present?
+          related_relationships_scope = related_relationships_scope.where(
+            project_model_relationship_id: options[:project_model_relationship_id]
+          )
+        end
+
+        Preloader.new(
+          records: query,
+          associations: [
+            related_relationships: [:project_model_relationship, :primary_record]
+          ],
+          scope: related_relationships_scope
+        ).call
+      end
+
+      def build_query(model_class, options)
+        primary_query = ProjectModel
+                          .joins(project_model_relationships: [:primary_model, :related_model])
+                          .where(ProjectModel.arel_table[:id].eq(model_class.arel_table[:project_model_id]))
+                          .where(related_model: { model_class: MediaContent.to_s })
+
+        related_query = ProjectModel
+                          .joins(project_model_relationships: [:primary_model, :related_model])
+                          .where(ProjectModel.arel_table[:id].eq(model_class.arel_table[:project_model_id]))
+                          .where(project_model_relationships: { allow_inverse: true })
+                          .where(primary_model: { model_class: MediaContent.to_s })
+
+        query = model_class
+                  .where(primary_query.or(related_query).arel.exists)
+
+
+        if options[:id].present?
+          query = query.where(id: options[:id])
+        end
+
+        query
+      end
+
+      def find_manifest(record, project_model_relationship_id)
+        record.manifests.select{ |m| m.project_model_relationship_id == project_model_relationship_id }.first
+      end
+
+    end
+  end
+end

--- a/app/services/core_data_connector/iiif/manifest.rb
+++ b/app/services/core_data_connector/iiif/manifest.rb
@@ -78,10 +78,14 @@ module CoreDataConnector
                 )
               end
 
+              # If a limit is provided, limit the number of resources
+              resource_ids = info[:resources]
+              resource_ids = info[:resources].take(options[:limit].to_i) if options[:limit].present?
+
               manifest.content = service.create_manifest(
                 id: "#{ENV['HOSTNAME']}/#{identifier}",
                 label: I18n.t('services.iiif.manifest.label', name: label, relationship: info[:name]),
-                resource_ids: info[:resources]
+                resource_ids: resource_ids
               )
 
               manifest.save
@@ -114,10 +118,6 @@ module CoreDataConnector
           )
         end
 
-        if options[:limit].present?
-          relationships_scope = relationships_scope.limit(options[:limit])
-        end
-
         Preloader.new(
           records: query,
           associations: [
@@ -137,10 +137,6 @@ module CoreDataConnector
           related_relationships_scope = related_relationships_scope.where(
             project_model_relationship_id: options[:project_model_relationship_id]
           )
-        end
-
-        if options[:limit].present?
-          related_relationships_scope = related_relationships_scope.limit(options[:limit])
         end
 
         Preloader.new(

--- a/app/services/core_data_connector/iiif/manifest.rb
+++ b/app/services/core_data_connector/iiif/manifest.rb
@@ -13,7 +13,12 @@ module CoreDataConnector
         # Find all project models that have a relationship
         ProjectModel.model_classes.each do |model_class|
           next unless model_class.ancestors.include?(Manifestable)
-          reset_manifests_by_type model_class
+
+          options = {
+            limit: ENV['IIIF_MANIFEST_ITEM_LIMIT']
+          }
+
+          reset_manifests_by_type model_class, options
         end
       end
 
@@ -21,63 +26,66 @@ module CoreDataConnector
         service = TripleEyeEffable::Presentation.new
 
         query = build_query(model_class, options)
-        apply_preloads(query, options)
 
-        query.find_each do |record|
-          # Build a mapping of all of the related resources indexed by project_model_relationship
-          hash = {}
+        query.in_batches do |batch|
+          apply_preloads batch, options
 
-          # Generate the manifest label for the current record
-          label = find_label(record)
+          batch.each do |record|
+            # Build a mapping of all of the related resources indexed by project_model_relationship
+            hash = {}
 
-          record.relationships.each do |relationship|
-            project_model_relationship = relationship.project_model_relationship
-            resource = relationship.related_record
+            # Generate the manifest label for the current record
+            label = find_label(record)
 
-            add_resource hash, project_model_relationship, resource
-          end
+            record.relationships.each do |relationship|
+              project_model_relationship = relationship.project_model_relationship
+              resource = relationship.related_record
 
-          record.related_relationships.each do |relationship|
-            project_model_relationship = relationship.project_model_relationship
-            resource = relationship.primary_record
-
-            add_resource hash, project_model_relationship, resource
-          end
-
-          # Iterate over all of the relationships and build a manifest for each
-          hash.keys.each do |project_model_relationship_uuid|
-            info = hash[project_model_relationship_uuid]
-
-            identifier = [
-              'core_data',
-              'public',
-              model_class.model_name.route_key,
-              record.uuid,
-              'manifests',
-              project_model_relationship_uuid
-            ].join('/')
-
-            # Create or update the manifest records
-            project_model_relationship_id = info[:id]
-            manifest = find_manifest(record, project_model_relationship_id)
-
-            if manifest.nil?
-              manifest = CoreDataConnector::Manifest.new(
-                manifestable: record,
-                project_model_relationship_id: project_model_relationship_id,
-                thumbnail: info[:resources].first,
-                identifier: identifier,
-                label: info[:name]
-              )
+              add_resource hash, project_model_relationship, resource
             end
 
-            manifest.content = service.create_manifest(
-              id: "#{ENV['HOSTNAME']}/#{identifier}",
-              label: I18n.t('services.iiif.manifest.label', name: label, relationship: info[:name]),
-              resource_ids: info[:resources]
-            )
+            record.related_relationships.each do |relationship|
+              project_model_relationship = relationship.project_model_relationship
+              resource = relationship.primary_record
 
-            manifest.save
+              add_resource hash, project_model_relationship, resource
+            end
+
+            # Iterate over all of the relationships and build a manifest for each
+            hash.keys.each do |project_model_relationship_uuid|
+              info = hash[project_model_relationship_uuid]
+
+              identifier = [
+                'core_data',
+                'public',
+                model_class.model_name.route_key,
+                record.uuid,
+                'manifests',
+                project_model_relationship_uuid
+              ].join('/')
+
+              # Create or update the manifest records
+              project_model_relationship_id = info[:id]
+              manifest = find_manifest(record, project_model_relationship_id)
+
+              if manifest.nil?
+                manifest = CoreDataConnector::Manifest.new(
+                  manifestable: record,
+                  project_model_relationship_id: project_model_relationship_id,
+                  thumbnail: info[:resources].first,
+                  identifier: identifier,
+                  label: info[:name]
+                )
+              end
+
+              manifest.content = service.create_manifest(
+                id: "#{ENV['HOSTNAME']}/#{identifier}",
+                label: I18n.t('services.iiif.manifest.label', name: label, relationship: info[:name]),
+                resource_ids: info[:resources]
+              )
+
+              manifest.save
+            end
           end
         end
       end
@@ -106,6 +114,10 @@ module CoreDataConnector
           )
         end
 
+        if options[:limit].present?
+          relationships_scope = relationships_scope.limit(options[:limit])
+        end
+
         Preloader.new(
           records: query,
           associations: [
@@ -125,6 +137,10 @@ module CoreDataConnector
           related_relationships_scope = related_relationships_scope.where(
             project_model_relationship_id: options[:project_model_relationship_id]
           )
+        end
+
+        if options[:limit].present?
+          related_relationships_scope = related_relationships_scope.limit(options[:limit])
         end
 
         Preloader.new(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,6 +12,8 @@ en:
       general: "An error occurred when making your request"
       no_response: "No response from the server"
       timeout: "Your request has timed out"
+    manifest:
+      unique: "Only a single manifest can exist per relationship"
     nameable:
       primary_name: "This record must have a primary name"
     projects:
@@ -28,3 +30,8 @@ en:
   serialization:
     linked_open_data:
       annotation_page_label: "Related %{klass}: %{target}"
+
+  services:
+    iiif:
+      manifest:
+        label: "%{name}: %{relationship}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,7 @@ CoreDataConnector::Engine.routes.draw do
     resources :instances do
       resources :instances, only: :index
       resources :items, only: :index
+      resources :manifests
       resources :media_contents, only: :index
       resources :organizations, only: :index
       resources :people, only: :index
@@ -46,6 +47,7 @@ CoreDataConnector::Engine.routes.draw do
     resources :items do
       resources :instances, only: :index
       resources :items, only: :index
+      resources :manifests
       resources :media_contents, only: :index
       resources :organizations, only: :index
       resources :people, only: :index
@@ -57,6 +59,7 @@ CoreDataConnector::Engine.routes.draw do
     resources :places, controller: 'linked_places/places' do
       resources :instances, only: :index, controller: 'linked_places/instances'
       resources :items, only: :index, controller: 'linked_places/items'
+      resources :manifests, controller: 'manifests'
       resources :media_contents, only: :index, controller: 'linked_places/media_contents'
       resources :organizations, only: :index, controller: 'linked_places/organizations'
       resources :people, only: :index, controller: 'linked_places/people'
@@ -68,6 +71,7 @@ CoreDataConnector::Engine.routes.draw do
     resources :works do
       resources :instances, only: :index
       resources :items, only: :index
+      resources :manifests
       resources :media_contents, only: :index
       resources :organizations, only: :index
       resources :people, only: :index

--- a/db/migrate/20240206191858_add_uuid_to_project_models.rb
+++ b/db/migrate/20240206191858_add_uuid_to_project_models.rb
@@ -1,0 +1,5 @@
+class AddUuidToProjectModels < ActiveRecord::Migration[7.0]
+  def change
+    add_column :core_data_connector_project_models, :uuid, :uuid, default: 'gen_random_uuid()', null: false
+  end
+end

--- a/db/migrate/20240206191905_add_uuid_to_project_model_relationships.rb
+++ b/db/migrate/20240206191905_add_uuid_to_project_model_relationships.rb
@@ -1,0 +1,5 @@
+class AddUuidToProjectModelRelationships < ActiveRecord::Migration[7.0]
+  def change
+    add_column :core_data_connector_project_model_relationships, :uuid, :uuid, default: 'gen_random_uuid()', null: false
+  end
+end

--- a/db/migrate/20240212175452_create_core_data_connector_manifests.rb
+++ b/db/migrate/20240212175452_create_core_data_connector_manifests.rb
@@ -1,0 +1,13 @@
+class CreateCoreDataConnectorManifests < ActiveRecord::Migration[7.0]
+  def change
+    create_table :core_data_connector_manifests do |t|
+      t.references :manifestable, polymorphic: true
+      t.references :project_model_relationship, null: false, index: { name: 'index_cdc_manifests_on_project_model_relationship_id' }
+      t.string :identifier
+      t.string :label
+      t.string :thumbnail
+      t.text :content
+      t.timestamps
+    end
+  end
+end

--- a/lib/core_data_connector/engine.rb
+++ b/lib/core_data_connector/engine.rb
@@ -20,7 +20,7 @@ module CoreDataConnector
       end
     end
 
-    initializer :core_data_connector do
+    initializer :triple_eye_effable do
       TripleEyeEffable.configure do |config|
         config.api_key = ENV['IIIF_CLOUD_API_KEY']
         config.url = ENV['IIIF_CLOUD_URL']

--- a/lib/tasks/core_data_connector_tasks.rake
+++ b/lib/tasks/core_data_connector_tasks.rake
@@ -20,4 +20,12 @@ namespace :core_data_connector do
       remote_password: ENV['CORE_DATA_CLOUD_PASSWORD']
     )
   end
+
+  namespace :iiif do
+    desc 'Resets IIIF manifests for all records.'
+    task :reset_manifests => :environment do
+      service = CoreDataConnector::Iiif::Manifest.new
+      service.reset_manifests
+    end
+  end
 end


### PR DESCRIPTION
This pull request adds the `manifests` table and models. It also creates the `/services/iiif/manifest` service used to create IIIF manifests for records that are related to "Media Content" records. It also adds the `uuid` column to `project_models` and `project_model_relationships`.

IIIF manifests will be re-generated automatically each time a related `media_contents` record is create or deleted.

See screenshots in [core-data-cloud](https://github.com/performant-software/core-data-cloud/pull/146) PR.