### PR TITLE
CDC #114 - IIIF Manifests

### DIFF
--- a/app/services/core_data_connector/iiif/manifest.rb
+++ b/app/services/core_data_connector/iiif/manifest.rb
@@ -149,14 +149,17 @@ module CoreDataConnector
       end
 
       def build_query(model_class, options)
+        primary_model_table = Arel::Table.new('primary_model')
+        related_model_table = Arel::Table.new('related_model')
+
         primary_query = ProjectModel
                           .joins(project_model_relationships: [:primary_model, :related_model])
-                          .where(ProjectModel.arel_table[:id].eq(model_class.arel_table[:project_model_id]))
+                          .where(primary_model_table[:id].eq(model_class.arel_table[:project_model_id]))
                           .where(related_model: { model_class: MediaContent.to_s })
 
         related_query = ProjectModel
                           .joins(project_model_relationships: [:primary_model, :related_model])
-                          .where(ProjectModel.arel_table[:id].eq(model_class.arel_table[:project_model_id]))
+                          .where(related_model_table[:id].eq(model_class.arel_table[:project_model_id]))
                           .where(project_model_relationships: { allow_inverse: true })
                           .where(primary_model: { model_class: MediaContent.to_s })
 


### PR DESCRIPTION
This pull request fixes a bug in the manifest generation script where the query was not always finding the correct records, depending on how the relationship was setup:

| primary_model      | related_model | status |
| ----------- | ----------- | ----------- |
| Place      | Media Content       | :white_check_mark: Works as expected |
| MediaContent   | Place        | :x: Does not work as expected |