### PR TITLE
CDC #142 - Search relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,33 @@ Rails.application.config.to_prepare do
 end
 ```
 
+## Search
+
+Data can be indexed into a Typesense search index using the following commands:
+
+#### Create a new collection
+```bash
+bundle exec rake typesense:create -- -h host -p port -r protocol -a api_key -c collection_name
+```
+
+#### Delete a collection
+```bash
+bundle exec rake typesense:delete -- -h host -p port -r protocol -a api_key -c collection_name
+```
+
+#### Add documents to a collection
+```bash
+bundle exec rake typesense:index -- -h host -p port -r protocol -a api_key -c collection_name -m model_ids
+```
+
+#### Update a collection
+```bash
+bundle exec rake typesense:update -- -h host -p port -r protocol -a api_key -c collection_name
+```
+
+**Note**: This task was added as a workaround for an issue in Typesense indexing nested facetable fields using auto-detection schema. This task should be run _after_ the indexing process to update the "facet" attribute on any fields that should be facetable.
+
+
 ## Public API
 
 In addition to the authenticated API, the `core_data_connector` gem also provides a public API for the following endpoints:

--- a/app/services/core_data_connector/search/instance.rb
+++ b/app/services/core_data_connector/search/instance.rb
@@ -17,7 +17,7 @@ module CoreDataConnector
           primary_name.name.name
         end
 
-        search_attribute(:names) do
+        search_attribute(:names, facet: true) do
           source_titles.map { |st| st.name.name }
         end
       end

--- a/app/services/core_data_connector/search/item.rb
+++ b/app/services/core_data_connector/search/item.rb
@@ -17,7 +17,7 @@ module CoreDataConnector
           primary_name.name.name
         end
 
-        search_attribute(:names) do
+        search_attribute(:names, facet: true) do
           source_titles.map { |st| st.name.name }
         end
       end

--- a/app/services/core_data_connector/search/organization.rb
+++ b/app/services/core_data_connector/search/organization.rb
@@ -20,7 +20,7 @@ module CoreDataConnector
           primary_name.name
         end
 
-        search_attribute(:names) do
+        search_attribute(:names, facet: true) do
           organization_names.map(&:name)
         end
       end

--- a/app/services/core_data_connector/search/person.rb
+++ b/app/services/core_data_connector/search/person.rb
@@ -20,7 +20,7 @@ module CoreDataConnector
           create_name primary_name
         end
 
-        search_attribute(:names) do
+        search_attribute(:names, facet: true) do
           person_names.map { |n| create_name(n) }
         end
 

--- a/app/services/core_data_connector/search/place.rb
+++ b/app/services/core_data_connector/search/place.rb
@@ -22,7 +22,7 @@ module CoreDataConnector
           primary_name.name
         end
 
-        search_attribute(:names) do
+        search_attribute(:names, facet: true) do
           place_names.map(&:name)
         end
 

--- a/app/services/core_data_connector/search/taxonomy.rb
+++ b/app/services/core_data_connector/search/taxonomy.rb
@@ -8,7 +8,7 @@ module CoreDataConnector
         include Base
 
         # Search attributes
-        search_attribute :name
+        search_attribute :name, facet: true
       end
     end
   end

--- a/app/services/core_data_connector/search/work.rb
+++ b/app/services/core_data_connector/search/work.rb
@@ -17,7 +17,7 @@ module CoreDataConnector
           primary_name.name.name
         end
 
-        search_attribute(:names) do
+        search_attribute(:names, facet: true) do
           source_titles.map { |st| st.name.name }
         end
       end

--- a/lib/tasks/typesense.rake
+++ b/lib/tasks/typesense.rake
@@ -57,4 +57,21 @@ namespace :typesense do
 
     helper.index options[:project_model_ids]
   end
+
+  desc 'Updates the Typesense collection'
+  task update: :environment do
+    options = Typesense::Options.parse(ARGV) do |opts|
+      opts.banner = 'Usage: typesense:create -- --host --port --protocol --api-key --collection-name'
+    end
+
+    helper = Typesense::Helper.new(
+      host: options[:host],
+      port: options[:port],
+      protocol: options[:protocol],
+      api_key: options[:api_key],
+      collection_name: options[:collection_name]
+    )
+
+    helper.update
+  end
 end


### PR DESCRIPTION
This pull request refactors the way we're bundling related/nested objects into the Typesense search index. Previously, we were putting everything into a `related_<type>` (e.g `related_people`). This posed a problem for projects that had multiple types of related people wished to retrieve search results for a particular relationship.

Instead of using the `related_<type>` as the nested object key, we'll use the `uuid` of the `project_model_relationship` record. This can be used in concert with the [project descriptors](https://github.com/performant-software/core-data-connector/pull/68) feature to retrieve the appropriate labels.

Additionally, this pull request adds the `typesense:update` rake task. The purpose of this task is to get around an issue with Typesense's auto-detection schema and identifying facet fields. The `typesense` rake tasks should be run as follows to reindex data for a project or projects:
1. `typesense:delete` - Destroys the existing index
2. `typsense:create` - Creates a new index
3. `typsense:index` - Puts the data into the index
4. `typesense:update` - Updates the schema to ensure all facetable fields are marked as such

Here is an example of a Typesense document using the Georgia Coast Atlas data:

```
{
  "document": {
    "11ac8289-b24d-42df-8dee-577f495defce": "Library",
    "11ac8289-b24d-42df-8dee-577f495defce_facet": "Library",
    "390340d9-9f99-40be-8ae5-08f6a5ad762c": "This library was founded in 2022 by Sapelo Island Cultural and Revitalization Society Inc. (SICARS).  The library's location is Sapelo Island's former two-room schoolhouse in the Hog Hammock Community. It is one of the last intact island-based Gullah-Geechee communities in America.",
    "4959838b-c1e0-4005-a2f6-77ec9744ea15": [
      {
        "name": "hog-hammock-library.jpeg",
        "record_id": "51",
        "uuid": "72818c03-7f5f-403d-9a5c-2590e53a07bc"
      }
    ],
    "4a4b73b7-1513-452d-8eac-6609957fca95": "Environmental Research",
    "74df4f43-fa03-4f14-81ad-a712d83f9dcd": [
      {
        "11ac8289-b24d-42df-8dee-577f495defce": "Island",
        "11ac8289-b24d-42df-8dee-577f495defce_facet": "Island",
        "390340d9-9f99-40be-8ae5-08f6a5ad762c": "Sapelo Island is home to the Gullah/Geechee people, many of whom reside at Hog Hammock on the southern half of the island. The rest of Sapelo is state-owned and managed. Its ecosystem and long history of occupation make Sapelo a site of great ecological, archaeological, cultural, and historical significance.",
        "4a4b73b7-1513-452d-8eac-6609957fca95": "Environmental Research",
        "7a660244-14f9-43b5-9794-d5ef29b6860d": "11451",
        "7a660244-14f9-43b5-9794-d5ef29b6860d_facet": "11451",
        "be893c1a-c3f4-47b1-b19b-997a59c6635c": "Emory ECDS",
        "e5bcc097-9207-40b6-8966-1958ca9d6567": "https://dvl.ecdsdev.org/items/show/11451",
        "geometry": {
          "coordinates": [
            -81.2417611,
            31.4774455
          ],
          "type": "Point"
        },
        "name": "Sapelo Island",
        "names": [
          "Sapelo Island"
        ],
        "names_facet": [
          "Sapelo Island"
        ],
        "record_id": "25211",
        "uuid": "61a06121-9ca6-4d68-86d5-891b180ce490"
      }
    ],
    "7a660244-14f9-43b5-9794-d5ef29b6860d": "11612",
    "7a660244-14f9-43b5-9794-d5ef29b6860d_facet": "11612",
    "be893c1a-c3f4-47b1-b19b-997a59c6635c": "Emory ECDS",
    "coordinates": [
      31.4252249,
      -81.2653727
    ],
    "d9071ec2-6d2c-4cd0-8328-05b08d447dff": [
      {
        "biography": "Bio",
        "name": "Test Person",
        "names": [
          "Test Person"
        ],
        "names_facet": [
          "Test Person"
        ],
        "record_id": "436",
        "uuid": "c6e7ed05-940c-4b47-ba10-34eaf579f797"
      },
      {
        "biography": "Bio Two",
        "name": "Second Person Person",
        "names": [
          "Second Person Person"
        ],
        "names_facet": [
          "Second Person Person"
        ],
        "record_id": "437",
        "uuid": "7a38c75a-a7af-497f-9c45-cfc86b80b937"
      }
    ],
    "df381535-67ae-4872-a454-95f38a83e8c5": [
      {
        "name": "Test Org",
        "names": [
          "Test Org"
        ],
        "names_facet": [
          "Test Org"
        ],
        "record_id": "614",
        "uuid": "82915fd7-c030-488a-9d9f-3e16285e114a"
      }
    ],
    "e5bcc097-9207-40b6-8966-1958ca9d6567": "https://dvl.ecdsdev.org/items/show/11612",
    "geometry": {
      "coordinates": [
        -81.2653727,
        31.4252249
      ],
      "type": "Point"
    },
    "id": "883",
    "name": "Hog Hammock Public Library (Sapelo Island School)",
    "names": [
      "Hog Hammock Public Library (Sapelo Island School)"
    ],
    "names_facet": [
      "Hog Hammock Public Library (Sapelo Island School)"
    ],
    "record_id": "25372",
    "uuid": "0620b823-61c5-4bec-8fba-d1938fa12c39"
  }
}
```