### PR TITLE
CDC #161 - IIIF Thumbnails

### DIFF
--- a/app/controllers/core_data_connector/public/manifests_controller.rb
+++ b/app/controllers/core_data_connector/public/manifests_controller.rb
@@ -95,6 +95,7 @@ module CoreDataConnector
           id: "#{ENV['HOSTNAME']}/#{manifest.identifier}",
           type: 'Manifest',
           label: manifest.label,
+          item_count: manifest.item_count,
           thumbnail: manifest.thumbnail
         }
       end

--- a/app/services/core_data_connector/iiif/manifest.rb
+++ b/app/services/core_data_connector/iiif/manifest.rb
@@ -76,18 +76,20 @@ module CoreDataConnector
                 )
               end
 
+              # Get the resources from the info object, limiting if required
+              resources = info[:resources]
+              resources = resources.take(options[:limit].to_i) if options[:limit].present?
+
               # Set the thumbnail and label on the manifest
-              manifest.thumbnail = info[:resources].first
+              manifest.thumbnail = resources.first
               manifest.label = info[:name]
+              manifest.item_count = resources.size
 
-              # If a limit is provided, limit the number of resources
-              resource_ids = info[:resources]
-              resource_ids = info[:resources].take(options[:limit].to_i) if options[:limit].present?
-
+              # Create the manifest
               manifest.content = service.create_manifest(
                 id: "#{ENV['HOSTNAME']}/#{identifier}",
                 label: I18n.t('services.iiif.manifest.label', name: label, relationship: info[:name]),
-                resource_ids: resource_ids
+                resource_ids: resources
               )
 
               manifest.save

--- a/app/services/core_data_connector/iiif/manifest.rb
+++ b/app/services/core_data_connector/iiif/manifest.rb
@@ -72,11 +72,13 @@ module CoreDataConnector
                 manifest = CoreDataConnector::Manifest.new(
                   manifestable: record,
                   project_model_relationship_id: project_model_relationship_id,
-                  thumbnail: info[:resources].first,
-                  identifier: identifier,
-                  label: info[:name]
+                  identifier: identifier
                 )
               end
+
+              # Set the thumbnail and label on the manifest
+              manifest.thumbnail = info[:resources].first
+              manifest.label = info[:name]
 
               # If a limit is provided, limit the number of resources
               resource_ids = info[:resources]

--- a/db/migrate/20240305174127_add_item_count_to_manifests.rb
+++ b/db/migrate/20240305174127_add_item_count_to_manifests.rb
@@ -1,0 +1,5 @@
+class AddItemCountToManifests < ActiveRecord::Migration[7.0]
+  def change
+    add_column :core_data_connector_manifests, :item_count, :integer, null: false, default: 0
+  end
+end


### PR DESCRIPTION
This pull request adds the `item_count` column to `core_data_connector_manifests`. It also updates the `/public/<model>/:uuid/manifests` API endpoint to send the `item_count` to IIIF Cloud when generating the collection manifest.