### PR TITLE
CDC #160 - Project Descriptors

### DIFF
--- a/app/controllers/core_data_connector/public/projects_controller.rb
+++ b/app/controllers/core_data_connector/public/projects_controller.rb
@@ -17,7 +17,7 @@ module CoreDataConnector
         descriptors = []
 
         query = ProjectModelRelationship
-                  .preload(:user_defined_fields)
+                  .preload(:user_defined_fields, :primary_model)
                   .joins(:primary_model)
                   .where(primary_model: {
                     project_id: params[:id]
@@ -26,7 +26,8 @@ module CoreDataConnector
         query.find_each do |project_model_relationship|
           descriptors << {
             identifier: project_model_relationship.uuid,
-            label: project_model_relationship.name
+            label: project_model_relationship.name,
+            context: project_model_relationship.primary_model.name
           }
 
           project_model_relationship.user_defined_fields.each do |user_defined_field|


### PR DESCRIPTION
This pull request adds the `context` attribute to project model relationships in the `/public/projects/:id/descriptors` endpoint. This value will be the name of the primary model to which the relationship belongs.