### PR TITLE
CDC #169 - Export Variables

### DIFF
--- a/app/controllers/core_data_connector/projects_controller.rb
+++ b/app/controllers/core_data_connector/projects_controller.rb
@@ -40,6 +40,16 @@ module CoreDataConnector
       render json: json, status: :ok
     end
 
+    def export_variables
+      project = Project.find(params[:id])
+      authorize project, :export_variables?
+
+      serializer = ProjectVariablesSerializer.new(current_user)
+
+      json = { param_name.to_sym => serializer.render_show(project) }
+      render json: json, status: :ok
+    end
+
     def import_configuration
       render json: { errors: [I18n.t('errors.projects.import_configuration')] }, status: :bad_request and return unless params[:file].present?
 

--- a/app/policies/core_data_connector/project_policy.rb
+++ b/app/policies/core_data_connector/project_policy.rb
@@ -40,6 +40,13 @@ module CoreDataConnector
       project_owner?
     end
 
+    # A user can export a project's environment variables if thet are an admin or an owner of the project.
+    def export_variables?
+      return true if current_user.admin?
+
+      project_owner?
+    end
+
     def import_configuration?
       return true if current_user.admin?
 

--- a/app/policies/core_data_connector/project_policy.rb
+++ b/app/policies/core_data_connector/project_policy.rb
@@ -40,7 +40,7 @@ module CoreDataConnector
       project_owner?
     end
 
-    # A user can export a project's environment variables if thet are an admin or an owner of the project.
+    # A user can export a project's environment variables if they are an admin or an owner of the project.
     def export_variables?
       return true if current_user.admin?
 

--- a/app/serializers/core_data_connector/project_variables_serializer.rb
+++ b/app/serializers/core_data_connector/project_variables_serializer.rb
@@ -1,0 +1,75 @@
+module CoreDataConnector
+  class ProjectVariablesSerializer < BaseSerializer
+    TYPE_MODEL = 'MODEL'
+    TYPE_RELATIONSHIP = 'RELATIONSHIP'
+    TYPE_FIELD = 'FIELD'
+
+    def render_show(project)
+      return {} if project.nil?
+
+      serialized = []
+
+      project_models = ProjectModel
+                         .preload(:user_defined_fields)
+                         .preload(project_model_relationships: :user_defined_fields)
+                         .preload(inverse_project_model_relationships: :user_defined_fields)
+                         .where(project_id: project.id)
+                         .order(:name)
+
+      project_models.each do |project_model|
+        serialized << transform_value(project_model.id, project_model.name, TYPE_MODEL)
+        serialized += transform_fields(project_model.user_defined_fields, project_model.name)
+        serialized += transform_relationships(project_model.project_model_relationships, :name, project_model.name)
+        serialized += transform_relationships(project_model.inverse_project_model_relationships, :inverse_name, project_model.name)
+      end
+
+      serialized
+    end
+
+    private
+
+    def transform_fields(user_defined_fields, *names)
+      serialized = []
+
+      user_defined_fields.each do |user_defined_field|
+        serialized << transform_value(
+          user_defined_field.uuid,
+          *names,
+          user_defined_field.column_name,
+          TYPE_FIELD
+        )
+      end
+
+      serialized
+    end
+
+    def transform_relationships(project_model_relationships, name_attribute, names)
+      serialized = []
+
+      project_model_relationships.each do |project_model_relationship|
+        relationship_name = project_model_relationship.send(name_attribute)
+
+        serialized << transform_value(
+          project_model_relationship.id,
+          *names,
+          relationship_name,
+          TYPE_RELATIONSHIP
+        )
+
+        serialized += transform_fields(
+          project_model_relationship.user_defined_fields,
+          *names,
+          relationship_name
+        )
+      end
+
+      serialized
+    end
+
+    def transform_value(value, *names)
+      name = names.map{ |n| n.upcase.gsub(' ', '_') }.join('_')
+
+      "#{name}=#{value}"
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ CoreDataConnector::Engine.routes.draw do
   resources :projects do
     post :clear, on: :member
     get :export_configuration, on: :member
+    get :export_variables, on: :member
     post :import_configuration, on: :member
     post :import_data, on: :member
   end


### PR DESCRIPTION
This pull request adds the `/projects/:id/export_variables` API endpoint, which allows a project's model, relationship, and field `id` and `uuid` values to be exported as environment variables. See screenshots in [core-data-cloud ](https://github.com/performant-software/core-data-cloud/pull/170)PR.