### PR TITLE
CDC #179 - Works

### DIFF
--- a/app/controllers/core_data_connector/project_models_controller.rb
+++ b/app/controllers/core_data_connector/project_models_controller.rb
@@ -16,6 +16,7 @@ module CoreDataConnector
                   .model_classes
                   .map(&:model_name)
                   .map{ |mn| { label: mn.human, value: mn.name } }
+                  .sort_by{ |mn| mn[:label] }
 
       render json: { model_classes: classes }, status: :ok
     end

--- a/app/models/core_data_connector/instance.rb
+++ b/app/models/core_data_connector/instance.rb
@@ -11,5 +11,8 @@ module CoreDataConnector
 
     # Nameable table
     name_table :source_titles, polymorphic: true
+
+    # User defined fields parent
+    resolve_defineable -> (organization) { organization.project_model }
   end
 end

--- a/app/models/core_data_connector/item.rb
+++ b/app/models/core_data_connector/item.rb
@@ -12,5 +12,8 @@ module CoreDataConnector
 
     # Nameable table
     name_table :source_titles, polymorphic: true
+
+    # User defined fields parent
+    resolve_defineable -> (organization) { organization.project_model }
   end
 end

--- a/app/models/core_data_connector/work.rb
+++ b/app/models/core_data_connector/work.rb
@@ -11,5 +11,8 @@ module CoreDataConnector
 
     # Nameable table
     name_table :source_titles, polymorphic: true
+
+    # User defined fields parent
+    resolve_defineable -> (organization) { organization.project_model }
   end
 end


### PR DESCRIPTION
This pull request fixes a bug with the validation of user defined fields on `instances`, `items`, and `works` records. This issue crept in [here](https://github.com/performant-software/user-defined-fields/blob/master/app/models/concerns/user_defined_fields/fieldable.rb#L30), when attempting to validate that all required fields were entered. Since the models did not implement the `resolve_defineable` method, the concern was assuming that the user defined fields were defined at the system level, which is not the case for Core Data. The result was that if Project A marked a `works` user-defined field as required, that field was also being required in the `works` records for Project B.

Additionally, this pull request orders the model class dropdown alphabetically.

![Screenshot 2024-04-10 at 11 27 33 AM](https://github.com/performant-software/core-data-connector/assets/20641961/d9351d18-64bc-4a63-be85-3a5e3b1383da)
