### PR TITLE
CDC #173 - AtoM identifiers

### DIFF
--- a/app/controllers/core_data_connector/public/instances_controller.rb
+++ b/app/controllers/core_data_connector/public/instances_controller.rb
@@ -9,6 +9,7 @@ module CoreDataConnector
       # Preloads
       preloads source_titles: :name
       preloads project_model: :user_defined_fields
+      preloads web_identifiers: :web_authority, only: :show
 
       # Joins
       joins primary_name: :name

--- a/app/controllers/core_data_connector/public/items_controller.rb
+++ b/app/controllers/core_data_connector/public/items_controller.rb
@@ -9,6 +9,7 @@ module CoreDataConnector
       # Preloads
       preloads source_titles: :name
       preloads project_model: :user_defined_fields
+      preloads web_identifiers: :web_authority, only: :show
 
       # Joins
       joins primary_name: :name

--- a/app/controllers/core_data_connector/public/linked_places/places_controller.rb
+++ b/app/controllers/core_data_connector/public/linked_places/places_controller.rb
@@ -15,6 +15,7 @@ module CoreDataConnector
         preloads :place_names, :place_geometry
         preloads project_model: :user_defined_fields
         preloads :place_layers, only: :show
+        preloads web_identifiers: :web_authority, only: :show
 
         # Search attributes
         search_attributes :name

--- a/app/controllers/core_data_connector/public/works_controller.rb
+++ b/app/controllers/core_data_connector/public/works_controller.rb
@@ -9,6 +9,7 @@ module CoreDataConnector
       # Preloads
       preloads source_titles: :name
       preloads project_model: :user_defined_fields
+      preloads web_identifiers: :web_authority, only: :show
 
       # Joins
       joins primary_name: :name

--- a/app/controllers/core_data_connector/web_authorities_controller.rb
+++ b/app/controllers/core_data_connector/web_authorities_controller.rb
@@ -9,7 +9,7 @@ module CoreDataConnector
       authority = WebAuthority.find(params[:id])
       authorize authority, :search?
 
-      instance = authority_instance(authority)
+      instance = Authority::Base.create_service(authority)
       json = instance.find(params[:identifier], authority.access&.symbolize_keys)
 
       render json: json, status: :ok
@@ -21,7 +21,7 @@ module CoreDataConnector
       authority = WebAuthority.find(params[:id])
       authorize authority, :find?
 
-      instance = authority_instance(authority)
+      instance = Authority::Base.create_service(authority)
       json = instance.search(params[:query], authority.access&.symbolize_keys)
 
       render json: json, status: :ok
@@ -37,14 +37,6 @@ module CoreDataConnector
       return WebAuthority.none unless params[:project_id].present?
 
       WebAuthority.where(project_id: params[:project_id])
-    end
-
-    private
-
-    def authority_instance(authority)
-      class_name = "CoreDataConnector::Authority::#{authority.source_type.capitalize}"
-      klass = class_name.constantize
-      klass.new
     end
   end
 end

--- a/app/models/core_data_connector/web_identifier.rb
+++ b/app/models/core_data_connector/web_identifier.rb
@@ -3,5 +3,15 @@ module CoreDataConnector
     # Relationships
     belongs_to :identifiable, polymorphic: true
     belongs_to :web_authority
+
+    # Callbacks
+    before_create :find_identifier
+
+    private
+
+    def find_identifier
+      service = Authority::Base.create_service(web_authority)
+      service.before_create(self)
+    end
   end
 end

--- a/app/serializers/core_data_connector/public/instances_serializer.rb
+++ b/app/serializers/core_data_connector/public/instances_serializer.rb
@@ -5,7 +5,7 @@ module CoreDataConnector
       include UserDefineableSerializer
 
       index_attributes :uuid, primary_name: SourceTitlesSerializer, source_titles: SourceTitlesSerializer
-      show_attributes :uuid, primary_name: SourceTitlesSerializer, source_titles: SourceTitlesSerializer
+      show_attributes :uuid, primary_name: SourceTitlesSerializer, source_titles: SourceTitlesSerializer, web_identifiers: WebIdentifiersSerializer
     end
   end
 end

--- a/app/serializers/core_data_connector/public/items_serializer.rb
+++ b/app/serializers/core_data_connector/public/items_serializer.rb
@@ -5,7 +5,7 @@ module CoreDataConnector
       include UserDefineableSerializer
 
       index_attributes :uuid, primary_name: SourceTitlesSerializer, source_titles: SourceTitlesSerializer
-      show_attributes :uuid, primary_name: SourceTitlesSerializer, source_titles: SourceTitlesSerializer
+      show_attributes :uuid, primary_name: SourceTitlesSerializer, source_titles: SourceTitlesSerializer, web_identifiers: WebIdentifiersSerializer
     end
   end
 end

--- a/app/serializers/core_data_connector/public/linked_places/places_serializer.rb
+++ b/app/serializers/core_data_connector/public/linked_places/places_serializer.rb
@@ -21,7 +21,7 @@ module CoreDataConnector
         show_attributes(:properties) { |place| { ccode: [], title: place.name, record_id: place.id, uuid: place.uuid } }
         show_attributes(:geometry) { |place| place.place_geometry&.to_geojson }
         show_attributes(:names) { |place| place.place_names.map{ |name| { toponym: name.name } } }
-        show_attributes user_defined: UserDefinedSerializer, place_layers: PlaceLayersSerializer
+        show_attributes user_defined: UserDefinedSerializer, place_layers: PlaceLayersSerializer, web_identifiers: WebIdentifiersSerializer
 
         target_attributes(:id) { |place| identifier place }
         target_attributes(:record_id) { |place| place.id }

--- a/app/serializers/core_data_connector/public/web_identifiers_serializer.rb
+++ b/app/serializers/core_data_connector/public/web_identifiers_serializer.rb
@@ -1,0 +1,7 @@
+module CoreDataConnector
+  module Public
+    class WebIdentifiersSerializer < BaseSerializer
+      index_attributes :id, :identifier, :extra, :web_authority_id, web_authority: [:id, :source_type]
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/works_serializer.rb
+++ b/app/serializers/core_data_connector/public/works_serializer.rb
@@ -5,7 +5,7 @@ module CoreDataConnector
       include UserDefineableSerializer
 
       index_attributes :uuid, primary_name: SourceTitlesSerializer, source_titles: SourceTitlesSerializer
-      show_attributes :uuid, primary_name: SourceTitlesSerializer, source_titles: SourceTitlesSerializer
+      show_attributes :uuid, primary_name: SourceTitlesSerializer, source_titles: SourceTitlesSerializer, web_identifiers: WebIdentifiersSerializer
     end
   end
 end

--- a/app/services/core_data_connector/authority/atom.rb
+++ b/app/services/core_data_connector/authority/atom.rb
@@ -8,6 +8,8 @@ module CoreDataConnector
         options = authority.access&.symbolize_keys
 
         data = find(web_identifier.identifier, options)
+
+        web_identifier.extra ||= {}
         web_identifier.extra['title'] = data['title']
 
         parents = []

--- a/app/services/core_data_connector/authority/base.rb
+++ b/app/services/core_data_connector/authority/base.rb
@@ -1,0 +1,25 @@
+module CoreDataConnector
+  module Authority
+    class Base
+
+      def self.create_service(authority)
+        class_name = "CoreDataConnector::Authority::#{authority.source_type.capitalize}"
+        klass = class_name.constantize
+        klass.new
+      end
+
+      def before_create(web_identifier)
+        # Implemented in sub-classes
+      end
+
+      def find(id, options = {})
+        # Implemented in sub-classes
+      end
+
+      def search(query, options = {})
+        # Implemented in sub-classes
+      end
+
+    end
+  end
+end

--- a/app/services/core_data_connector/authority/bnf.rb
+++ b/app/services/core_data_connector/authority/bnf.rb
@@ -1,6 +1,6 @@
 module CoreDataConnector
   module Authority
-    class Bnf
+    class Bnf < Base
       include Http::Requestable
 
       BASE_URL = 'https://catalogue.bnf.fr/api/SRU'

--- a/app/services/core_data_connector/authority/dpla.rb
+++ b/app/services/core_data_connector/authority/dpla.rb
@@ -1,6 +1,6 @@
 module CoreDataConnector
   module Authority
-    class Dpla
+    class Dpla < Base
       include Http::Requestable
 
       BASE_URL = 'https://api.dp.la/v2/items'

--- a/app/services/core_data_connector/authority/jisc.rb
+++ b/app/services/core_data_connector/authority/jisc.rb
@@ -1,6 +1,6 @@
 module CoreDataConnector
   module Authority
-    class Jisc
+    class Jisc < Base
       include Http::Requestable
 
       BASE_URL = 'https://discover.libraryhub.jisc.ac.uk/search'

--- a/app/services/core_data_connector/authority/viaf.rb
+++ b/app/services/core_data_connector/authority/viaf.rb
@@ -1,6 +1,6 @@
 module CoreDataConnector
   module Authority
-    class Viaf
+    class Viaf < Base
       include Http::Requestable
 
       BASE_URL = 'https://viaf.org'

--- a/app/services/core_data_connector/authority/wikidata.rb
+++ b/app/services/core_data_connector/authority/wikidata.rb
@@ -1,6 +1,6 @@
 module CoreDataConnector
   module Authority
-    class Wikidata
+    class Wikidata < Base
       include Http::Requestable
 
       BASE_URL = 'https://www.wikidata.org/w/api.php'

--- a/lib/tasks/core_data_connector_tasks.rake
+++ b/lib/tasks/core_data_connector_tasks.rake
@@ -1,24 +1,36 @@
 namespace :core_data_connector do
 
-  desc 'Creates a new database user with access to the core data tables. This tasks should be run on the Core Data Cloud.'
-  task :create_db_user => :environment do
-    postgres = CoreDataConnector::Postgres.new
-    result = postgres.create_foreign_user
-
-    puts "Created #{result[:username]} with password #{result[:password]}."
+  namespace :data do
+    desc 'Calls the before_create method for each web_identifier record'
+    task :reset_web_identifiers => :environment do
+      CoreDataConnector::WebIdentifier.all.find_each do |web_identifier|
+        service = CoreDataConnector::Authority::Base.create_service(web_identifier.web_authority)
+        service.before_create(web_identifier)
+      end
+    end
   end
 
-  desc 'Creates the foreign data wrapper. This task should be run on the local application.'
-  task :create_foreign_data_wrapper => :environment do
-    postgres = CoreDataConnector::Postgres.new
-    postgres.create_foreign_data_wrapper(
-      local_username: ENV['DATABASE_USERNAME'],
-      remote_host: ENV['CORE_DATA_CLOUD_HOST'],
-      remote_port: ENV['CORE_DATA_CLOUD_PORT'],
-      remote_database: ENV['CORE_DATA_CLOUD_DATABASE'],
-      remote_username: ENV['CORE_DATA_CLOUD_USERNAME'],
-      remote_password: ENV['CORE_DATA_CLOUD_PASSWORD']
-    )
+  namespace :db do
+    desc 'Creates a new database user with access to the core data tables. This tasks should be run on the Core Data Cloud.'
+    task :create_db_user => :environment do
+      postgres = CoreDataConnector::Postgres.new
+      result = postgres.create_foreign_user
+
+      puts "Created #{result[:username]} with password #{result[:password]}."
+    end
+
+    desc 'Creates the foreign data wrapper. This task should be run on the local application.'
+    task :create_foreign_data_wrapper => :environment do
+      postgres = CoreDataConnector::Postgres.new
+      postgres.create_foreign_data_wrapper(
+        local_username: ENV['DATABASE_USERNAME'],
+        remote_host: ENV['CORE_DATA_CLOUD_HOST'],
+        remote_port: ENV['CORE_DATA_CLOUD_PORT'],
+        remote_database: ENV['CORE_DATA_CLOUD_DATABASE'],
+        remote_username: ENV['CORE_DATA_CLOUD_USERNAME'],
+        remote_password: ENV['CORE_DATA_CLOUD_PASSWORD']
+      )
+    end
   end
 
   namespace :iiif do


### PR DESCRIPTION
This pull request adds the `web_identifiers` attribute to the public API for `instances`, `items`, `places`, and `works` API endpoints.

This pull request also adds the `find_identifier` callback to `web_identifier.rb`, which will allow for specific web authority implementations to do some pre-processing before the record is created. In the case of AtoM, we're making calls to the API to retrieve the name of the parent records in the Fond > Services > File hierarchy.

All web authority implementations will now extend the `Base` class in order to ensure the `before_create` method exists on the service.