### PR TITLE
CDC #173 - AtoM Identifiers

### DIFF
--- a/lib/tasks/core_data_connector_tasks.rake
+++ b/lib/tasks/core_data_connector_tasks.rake
@@ -6,6 +6,7 @@ namespace :core_data_connector do
       CoreDataConnector::WebIdentifier.all.find_each do |web_identifier|
         service = CoreDataConnector::Authority::Base.create_service(web_identifier.web_authority)
         service.before_create(web_identifier)
+        web_identifier.save
       end
     end
   end


### PR DESCRIPTION
This pull request fixes a bug in the `reset_web_identifiers` task where the `web_identifier` record was not being saved after calling the `before_create` method on the service.