### PR TITLE
CDC #189 - Authorization

### DIFF
--- a/app/policies/core_data_connector/project_model_policy.rb
+++ b/app/policies/core_data_connector/project_model_policy.rb
@@ -22,7 +22,7 @@ module CoreDataConnector
       owner? && !shared?
     end
 
-    # A user can view project models if they are the owner of the project.
+    # A user can view project models if they are a member of the project.
     def show?
       return true if current_user.admin?
 
@@ -73,7 +73,7 @@ module CoreDataConnector
       project_model.project_model_accesses.any?
     end
 
-    # A user can view project models for any project they own.
+    # A user can view project models for any project of which they are a member.
     class Scope < BaseScope
       def resolve
         return scope.all if current_user.admin?
@@ -82,7 +82,6 @@ module CoreDataConnector
           UserProject
             .where(UserProject.arel_table[:project_id].eq(ProjectModel.arel_table[:project_id]))
             .where(user_id: current_user.id)
-            .where(role: UserProject::ROLE_OWNER)
             .arel
             .exists
         )


### PR DESCRIPTION
This pull request fixes a bug that was occurring when a user had the role of "Editor" in a project. Attempting to access the `/project_models` API endpoint would return a 403 because it was set up to only list the records for a project "Owner". The solution was to update the API endpoint to return the expected records for all members of the project (regardless of role).