### PR TITLE
CDC #27 - Events

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem 'faker', '~> 3.2.1'
+# gem 'fuzzy_dates', git: 'https://github.com/performant-software/fuzzy-dates.git', tag: 'v0.1.0'
+gem 'fuzzy_dates', path: '../fuzzy-dates'
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.2'
 gem 'resource_api', git: 'https://github.com/performant-software/resource-api.git', tag: 'v0.5.7'
 gem 'user_defined_fields', git: 'https://github.com/performant-software/user-defined-fields.git', tag: 'v0.1.8'

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,7 @@ source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem 'faker', '~> 3.2.1'
-# gem 'fuzzy_dates', git: 'https://github.com/performant-software/fuzzy-dates.git', tag: 'v0.1.0'
-gem 'fuzzy_dates', path: '../fuzzy-dates'
+gem 'fuzzy_dates', git: 'https://github.com/performant-software/fuzzy-dates.git', tag: 'v0.1.0'
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.2'
 gem 'resource_api', git: 'https://github.com/performant-software/resource-api.git', tag: 'v0.5.7'
 gem 'user_defined_fields', git: 'https://github.com/performant-software/user-defined-fields.git', tag: 'v0.1.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,11 +36,19 @@ GIT
       resource_api
 
 PATH
+  remote: ../fuzzy-dates
+  specs:
+    fuzzy_dates (0.1.0)
+      rails (>= 6.0.3.2, < 8)
+      resource_api
+
+PATH
   remote: .
   specs:
     core_data_connector (0.1.0)
       activerecord-postgis-adapter (~> 8.0)
       faker
+      fuzzy_dates
       jwt (~> 2.7.1)
       jwt_auth
       rack-cors (~> 2.0.1)
@@ -244,6 +252,7 @@ PLATFORMS
 DEPENDENCIES
   core_data_connector!
   faker (~> 3.2.1)
+  fuzzy_dates!
   jwt_auth!
   resource_api!
   sqlite3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: https://github.com/performant-software/fuzzy-dates.git
+  revision: fa3f237882f9c89888f82af41f6fe2b8ff2281a3
+  tag: v0.1.0
+  specs:
+    fuzzy_dates (0.1.0)
+      rails (>= 6.0.3.2, < 8)
+      resource_api
+
+GIT
   remote: https://github.com/performant-software/jwt-auth.git
   revision: fa54af0cdcad6122fad10d9ad745b814c2918853
   tag: v0.1.2
@@ -32,13 +41,6 @@ GIT
   tag: v0.1.8
   specs:
     user_defined_fields (0.1.0)
-      rails (>= 6.0.3.2, < 8)
-      resource_api
-
-PATH
-  remote: ../fuzzy-dates
-  specs:
-    fuzzy_dates (0.1.0)
       rails (>= 6.0.3.2, < 8)
       resource_api
 

--- a/app/controllers/concerns/core_data_connector/public/nestable_controller.rb
+++ b/app/controllers/concerns/core_data_connector/public/nestable_controller.rb
@@ -13,7 +13,9 @@ module CoreDataConnector
         private
 
         def set_current_record
-          if params[:instance_id].present?
+          if params[:event_id].present?
+            @current_record = Event.find_by_uuid(params[:event_id])
+          elsif params[:instance_id].present?
             @current_record = Instance.find_by_uuid(params[:instance_id])
           elsif params[:item_id].present?
             @current_record = Item.find_by_uuid(params[:item_id])

--- a/app/controllers/core_data_connector/events_controller.rb
+++ b/app/controllers/core_data_connector/events_controller.rb
@@ -2,6 +2,7 @@ module CoreDataConnector
   class EventsController < ApplicationController
     # Includes
     include OwnableController
+    include UserDefinedFields::Queryable
 
     # Search attributes
     search_attributes :name, :description

--- a/app/controllers/core_data_connector/events_controller.rb
+++ b/app/controllers/core_data_connector/events_controller.rb
@@ -4,6 +4,12 @@ module CoreDataConnector
     include OwnableController
     include UserDefinedFields::Queryable
 
+    # Preloads
+    preloads :start_date, :end_date
+
+    # Joins
+    joins Event.start_date_join, Event.end_date_join
+
     # Search attributes
     search_attributes :name, :description
   end

--- a/app/controllers/core_data_connector/events_controller.rb
+++ b/app/controllers/core_data_connector/events_controller.rb
@@ -1,0 +1,9 @@
+module CoreDataConnector
+  class EventsController < ApplicationController
+    # Includes
+    include OwnableController
+
+    # Search attributes
+    search_attributes :name, :description
+  end
+end

--- a/app/controllers/core_data_connector/public/events_controller.rb
+++ b/app/controllers/core_data_connector/public/events_controller.rb
@@ -1,0 +1,19 @@
+module CoreDataConnector
+  module Public
+    class EventsController < PublicController
+      # Includes
+      include UnauthenticateableController
+      include UserDefinedFields::Queryable
+
+      # Preloads
+      preloads project_model: :user_defined_fields
+      preloads :start_date, :end_date
+
+      # Joins
+      joins Event.start_date_join, Event.end_date_join
+
+      # Search attributes
+      search_attributes :name, :description
+    end
+  end
+end

--- a/app/controllers/core_data_connector/public/linked_places/events_controller.rb
+++ b/app/controllers/core_data_connector/public/linked_places/events_controller.rb
@@ -1,0 +1,21 @@
+module CoreDataConnector
+  module Public
+    module LinkedPlaces
+      class EventsController < LinkedPlacesController
+        # Includes
+        include UnauthenticateableController
+        include UserDefinedFields::Queryable
+
+        # Preloads
+        preloads project_model: :user_defined_fields
+        preloads :start_date, :end_date
+
+        # Joins
+        joins Event.start_date_join, Event.end_date_join
+
+        # Search attributes
+        search_attributes :name, :description
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/relationships_controller.rb
+++ b/app/controllers/core_data_connector/relationships_controller.rb
@@ -38,10 +38,32 @@ module CoreDataConnector
         )
       end
 
+      # Include preloads for the different model types
+      case model_class
+      when Event.to_s
+        query = query.preload(params[:inverse] ? { primary_record: [:start_date, :end_date] } : { related_record: [:start_date, :end_date] })
+      when Instance.to_s
+        query = query.preload(params[:inverse] ? { primary_record: [primary_name: :name] } : { related_record: [primary_name: :name] })
+      when Item.to_s
+        query = query.preload(params[:inverse] ? { primary_record: [primary_name: :name] } : { related_record: [primary_name: :name] })
+      when MediaContent.to_s
+        query = query.preload(params[:inverse] ? :primary_record : :related_record)
+      when Organization.to_s
+        query = query.preload(params[:inverse] ? { primary_record: :primary_name } : { related_record: :primary_name })
+      when Person.to_s
+        query = query.preload(params[:inverse] ? { primary_record: :primary_name } : { related_record: :primary_name })
+      when Place.to_s
+        query = query.preload(params[:inverse] ? { primary_record: :primary_name } : { related_record: :primary_name })
+      when Taxonomy.to_s
+        query = query.preload(params[:inverse] ? :primary_record : :related_record)
+      when Work.to_s
+        query = query.preload(params[:inverse] ? { primary_record: [primary_name: :name] } : { related_record: [primary_name: :name] })
+      end
+
       # For sorting, left join the polymorphic model we're currently looking at.
       case model_class
       when Event.to_s
-        query = query.joins(params[:inverse] ? :inverse_related_event : :related_event)
+        query = query.joins(params[:inverse] ? :inverse_related_event : :related_event).joins(Event.start_date_join, Event.end_date_join)
       when Instance.to_s
         query = query.joins(params[:inverse] ? { inverse_related_instance: [primary_name: :name] } : { related_instance: [primary_name: :name] })
       when Item.to_s

--- a/app/controllers/core_data_connector/relationships_controller.rb
+++ b/app/controllers/core_data_connector/relationships_controller.rb
@@ -40,6 +40,8 @@ module CoreDataConnector
 
       # For sorting, left join the polymorphic model we're currently looking at.
       case model_class
+      when Event.to_s
+        query = query.joins(params[:inverse] ? :inverse_related_event : :related_event)
       when Instance.to_s
         query = query.joins(params[:inverse] ? { inverse_related_instance: [primary_name: :name] } : { related_instance: [primary_name: :name] })
       when Item.to_s
@@ -101,6 +103,9 @@ module CoreDataConnector
       or_query = nil
 
       case model_class
+      when Event.to_s
+        attribute = "#{Event.arel_table.name}.#{Event.arel_table[:name].name}"
+        or_query = resolve_search_query(attribute)
       when Instance.to_s
         or_query = Instance.where(
           Name

--- a/app/models/core_data_connector/event.rb
+++ b/app/models/core_data_connector/event.rb
@@ -1,9 +1,13 @@
 module CoreDataConnector
   class Event < ApplicationRecord
     # Includes
+    include FuzzyDates::FuzzyDateable
     include Identifiable
     include Ownable
     include Relateable
-    include UserDefinedFields::FieldableSerializer
+    include UserDefinedFields::Fieldable
+
+    # Fuzzy dates
+    has_fuzzy_dates :start_date, :end_date
   end
 end

--- a/app/models/core_data_connector/event.rb
+++ b/app/models/core_data_connector/event.rb
@@ -1,0 +1,8 @@
+module CoreDataConnector
+  class Event < ApplicationRecord
+    # Includes
+    include Identifiable
+    include Ownable
+    include Relateable
+  end
+end

--- a/app/models/core_data_connector/event.rb
+++ b/app/models/core_data_connector/event.rb
@@ -5,6 +5,7 @@ module CoreDataConnector
     include Identifiable
     include Ownable
     include Relateable
+    include Search::Event
     include UserDefinedFields::Fieldable
 
     # Fuzzy dates

--- a/app/models/core_data_connector/event.rb
+++ b/app/models/core_data_connector/event.rb
@@ -4,5 +4,6 @@ module CoreDataConnector
     include Identifiable
     include Ownable
     include Relateable
+    include UserDefinedFields::FieldableSerializer
   end
 end

--- a/app/models/core_data_connector/relationship.rb
+++ b/app/models/core_data_connector/relationship.rb
@@ -8,6 +8,7 @@ module CoreDataConnector
     belongs_to :primary_record, polymorphic: true
     belongs_to :related_record, polymorphic: true
 
+    belongs_to :related_event, -> { where(Relationship.arel_table.name => { related_record_type: Event.to_s }) }, class_name: Event.to_s, foreign_key: :related_record_id, optional: true
     belongs_to :related_instance, -> { where(Relationship.arel_table.name => { related_record_type: Instance.to_s }) }, class_name: Instance.to_s, foreign_key: :related_record_id, optional: true
     belongs_to :related_item, -> { where(Relationship.arel_table.name => { related_record_type: Item.to_s }) }, class_name: Item.to_s, foreign_key: :related_record_id, optional: true
     belongs_to :related_media_content, -> { where(Relationship.arel_table.name => { related_record_type: MediaContent.to_s }) }, class_name: MediaContent.to_s, foreign_key: :related_record_id, optional: true
@@ -17,6 +18,7 @@ module CoreDataConnector
     belongs_to :related_taxonomy, -> { where(Relationship.arel_table.name => { related_record_type: Taxonomy.to_s }) }, class_name: Taxonomy.to_s, foreign_key: :related_record_id, optional: true
     belongs_to :related_work, -> { where(Relationship.arel_table.name => { related_record_type: Work.to_s }) }, class_name: Work.to_s, foreign_key: :related_record_id, optional: true
 
+    belongs_to :inverse_related_event, -> { where(Relationship.arel_table.name => { primary_record_type: Event.to_s }) }, class_name: Event.to_s, foreign_key: :primary_record_id, optional: true
     belongs_to :inverse_related_instance, -> { where(Relationship.arel_table.name => { primary_record_type: Instance.to_s }) }, class_name: Instance.to_s, foreign_key: :primary_record_id, optional: true
     belongs_to :inverse_related_item, -> { where(Relationship.arel_table.name => { primary_record_type: Item.to_s }) }, class_name: Item.to_s, foreign_key: :primary_record_id, optional: true
     belongs_to :inverse_related_media_content, -> { where(Relationship.arel_table.name => { primary_record_type: MediaContent.to_s }) }, class_name: MediaContent.to_s, foreign_key: :primary_record_id, optional: true

--- a/app/policies/core_data_connector/event_policy.rb
+++ b/app/policies/core_data_connector/event_policy.rb
@@ -1,0 +1,28 @@
+module CoreDataConnector
+  class EventPolicy < BasePolicy
+    include OwnablePolicy
+
+    attr_reader :current_user, :event, :project_model_id, :project_id
+
+    def initialize(current_user, event)
+      @current_user = current_user
+      @event = event
+
+      @project_model_id = event&.project_model_id
+      @project_id = event&.project_id
+    end
+
+    # Allowed create/update attributes.
+    def permitted_attributes
+      [ *ownable_attributes,
+        :name,
+        :description
+      ]
+    end
+
+    # Include default ownable scope.
+    class Scope < BaseScope
+      include OwnableScope
+    end
+  end
+end

--- a/app/policies/core_data_connector/event_policy.rb
+++ b/app/policies/core_data_connector/event_policy.rb
@@ -15,6 +15,7 @@ module CoreDataConnector
     # Allowed create/update attributes.
     def permitted_attributes
       [ *ownable_attributes,
+        *Event.permitted_params,
         :name,
         :description,
         user_defined: {}

--- a/app/policies/core_data_connector/event_policy.rb
+++ b/app/policies/core_data_connector/event_policy.rb
@@ -16,7 +16,8 @@ module CoreDataConnector
     def permitted_attributes
       [ *ownable_attributes,
         :name,
-        :description
+        :description,
+        user_defined: {}
       ]
     end
 

--- a/app/serializers/core_data_connector/events_serializer.rb
+++ b/app/serializers/core_data_connector/events_serializer.rb
@@ -3,7 +3,7 @@ module CoreDataConnector
     include OwnableSerializer
     include UserDefinedFields::FieldableSerializer
 
-    index_attributes :id, :name, :description
-    show_attributes :id, :name, :description
+    index_attributes :id, :name, :description, start_date: FuzzyDates::FuzzyDateSerializer, end_date: FuzzyDates::FuzzyDateSerializer
+    show_attributes :id, :name, :description, start_date: FuzzyDates::FuzzyDateSerializer, end_date: FuzzyDates::FuzzyDateSerializer
   end
 end

--- a/app/serializers/core_data_connector/events_serializer.rb
+++ b/app/serializers/core_data_connector/events_serializer.rb
@@ -1,0 +1,8 @@
+module CoreDataConnector
+  class EventsSerializer < BaseSerializer
+    include OwnableSerializer
+
+    index_attributes :id, :name, :description
+    show_attributes :id, :name, :description
+  end
+end

--- a/app/serializers/core_data_connector/events_serializer.rb
+++ b/app/serializers/core_data_connector/events_serializer.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class EventsSerializer < BaseSerializer
     include OwnableSerializer
+    include UserDefinedFields::FieldableSerializer
 
     index_attributes :id, :name, :description
     show_attributes :id, :name, :description

--- a/app/serializers/core_data_connector/public/events_serializer.rb
+++ b/app/serializers/core_data_connector/public/events_serializer.rb
@@ -1,0 +1,11 @@
+module CoreDataConnector
+  module Public
+    class EventsSerializer < BaseSerializer
+      include TypeableSerializer
+      include UserDefineableSerializer
+
+      index_attributes :uuid, :name, :description, start_date: FuzzyDates::FuzzyDateSerializer, end_date: FuzzyDates::FuzzyDateSerializer
+      show_attributes :uuid, :name, :description, start_date: FuzzyDates::FuzzyDateSerializer, end_date: FuzzyDates::FuzzyDateSerializer
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/linked_places/events_serializer.rb
+++ b/app/serializers/core_data_connector/public/linked_places/events_serializer.rb
@@ -1,0 +1,17 @@
+module CoreDataConnector
+  module Public
+    module LinkedPlaces
+      class EventsSerializer < Base
+        # Includes
+        include TypeableSerializer
+
+        annotation_attributes(:id) { |event| "#{base_url}/events/#{event.uuid}" }
+        annotation_attributes(:record_id) { |event| event.id }
+        annotation_attributes(:title) { |event| event.name }
+        annotation_attributes(:type) { 'Event' }
+        annotation_attributes :uuid, :description, start_date: FuzzyDates::FuzzyDateSerializer,
+                              end_date: FuzzyDates::FuzzyDateSerializer, user_defined: UserDefinedSerializer
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import/events.rb
+++ b/app/services/core_data_connector/import/events.rb
@@ -1,0 +1,235 @@
+module CoreDataConnector
+  module Import
+    class Events < Base
+      DATE_FORMAT = 'YYYY-MM-DD'
+
+      def cleanup
+        super
+
+        execute <<-SQL.squish
+          UPDATE core_data_connector_events
+             SET z_event_id = NULL
+        SQL
+      end
+
+      def load
+        super
+
+        execute <<-SQL.squish
+          UPDATE core_data_connector_events events
+             SET z_event_id = z_events.id,
+                 name = z_events.name,
+                 description = z_events.description,
+                 user_defined = z_events.user_defined,
+                 updated_at = current_timestamp
+            FROM #{table_name} z_events
+           WHERE z_events.event_id = events.id
+        SQL
+
+        execute <<-SQL.squish
+          UPDATE fuzzy_dates_fuzzy_dates fuzzy_dates
+             SET accuracy = #{FuzzyDates::FuzzyDate.accuraries['date']},
+                 range = FALSE,
+                 start_date = z_events.start_date_start_date,
+                 end_date = z_events.start_date_end_date,
+                 description = z_events.start_date_description,
+                 updated_at = CURRENT_TIMESTAMP
+            FROM #{table_name} z_events
+           WHERE fuzzy_dates.dateable_id = z_events.event_id
+             AND fuzzy_dates.dateable_type = 'CoreDataConnector::Event'
+             AND fuzzy_dates.attribute_name = 'start_date'
+        SQL
+
+        execute <<-SQL.squish
+          UPDATE fuzzy_dates_fuzzy_dates fuzzy_dates
+             SET accuracy = #{FuzzyDates::FuzzyDate.accuraries['date']},
+                 range = FALSE,
+                 start_date = z_events.end_date_start_date,
+                 end_date = z_events.end_date_end_date,
+                 description = z_events.end_date_description,
+                 updated_at = CURRENT_TIMESTAMP
+            FROM #{table_name} z_events
+           WHERE fuzzy_dates.dateable_id = z_events.event_id
+             AND fuzzy_dates.dateable_type = 'CoreDataConnector::Event'
+             AND fuzzy_dates.attribute_name = 'end_date'
+        SQL
+
+        execute <<-SQL.squish
+          WITH 
+          
+          insert_events AS (
+
+          INSERT INTO core_data_connector_events (
+            project_model_id, 
+            uuid, 
+            z_event_id, 
+            name, 
+            description, 
+            user_defined, 
+            created_at, 
+            updated_at
+          )
+          SELECT z_events.project_model_id, 
+                 z_events.uuid, 
+                 z_events.id, 
+                 z_events.name, 
+                 z_events.description, 
+                 z_events.user_defined, 
+                 current_timestamp, 
+                 current_timestamp
+            FROM #{table_name} z_events
+           WHERE z_events.event_id IS NULL
+          RETURNING id AS event_id, z_event_id
+
+          ),
+
+          insert_start_date AS (
+
+          INSERT INTO fuzzy_dates_fuzzy_dates (
+            dateable_id, 
+            dateable_type, 
+            attribute_name, 
+            accuracy, 
+            range, 
+            start_date, 
+            end_date, 
+            description, 
+            created_at, 
+            updated_at
+          )
+          SELECT insert_events.event_id,
+                 'CoreDataConnector::Event',
+                 'start_date',
+                  #{FuzzyDates::FuzzyDate::accuraries['date']},
+                  false,
+                  z_events.start_date_start_date,
+                  z_events.start_date_end_date,
+                  z_events.start_date_description,
+                  CURRENT_TIMESTAMP,
+                  CURRENT_TIMESTAMP
+            FROM insert_events
+            JOIN #{table_name} z_events ON z_events.id = insert_events.z_event_id
+
+          ),
+
+          insert_end_date AS (
+
+          INSERT INTO fuzzy_dates_fuzzy_dates (
+            dateable_id, 
+            dateable_type, 
+            attribute_name, 
+            accuracy, 
+            range, 
+            start_date, 
+            end_date, 
+            description, 
+            created_at, 
+            updated_at
+          )
+          SELECT insert_events.event_id,
+                 'CoreDataConnector::Event',
+                 'end_date',
+                  #{FuzzyDates::FuzzyDate::accuraries['date']},
+                  false,
+                  z_events.end_date_start_date,
+                  z_events.end_date_end_date,
+                  z_events.end_date_description,
+                  CURRENT_TIMESTAMP,
+                  CURRENT_TIMESTAMP
+            FROM insert_events
+            JOIN #{table_name} z_events ON z_events.id = insert_events.z_event_id
+
+          )
+
+          UPDATE #{table_name} z_events
+             SET event_id = insert_events.event_id
+            FROM insert_events
+           WHERE insert_events.z_event_id = z_events.id
+        SQL
+      end
+
+      def transform
+        super
+
+        execute <<-SQL.squish
+          UPDATE #{table_name} z_events
+             SET event_id = events.id
+            FROM core_data_connector_events events
+           WHERE events.uuid = z_events.uuid
+        SQL
+
+        execute <<-SQL.squish
+          UPDATE #{table_name} z_events
+             SET start_date_start_date = TO_DATE(z_events.start_date, '#{DATE_FORMAT}'),
+                 end_date_start_date = TO_DATE(z_events.end_date, '#{DATE_FORMAT}')
+        SQL
+
+        execute <<-SQL.squish
+          UPDATE #{table_name} z_events
+             SET start_date_end_date = z_events.start_date_start_date + INTERVAL '1 day',
+                 end_date_end_date = z_events.end_date_start_date + INTERVAL '1 day'
+        SQL
+      end
+
+      protected
+
+      def column_names
+        [{
+           name: 'project_model_id',
+           type: 'INTEGER',
+           copy: true
+         }, {
+           name: 'uuid',
+           type: 'UUID',
+           copy: true
+         }, {
+           name: 'name',
+           type: 'VARCHAR',
+           copy: true
+         }, {
+           name: 'description',
+           type: 'TEXT',
+           copy: true
+         }, {
+           name: 'start_date',
+           type: 'VARCHAR',
+           copy: true
+         }, {
+           name: 'start_date_description',
+           type: 'VARCHAR',
+           copy: true
+         }, {
+           name: 'end_date',
+           type: 'VARCHAR',
+           copy: true
+         }, {
+           name: 'end_date_description',
+           type: 'VARCHAR',
+           copy: true
+         }, {
+           name: 'event_id',
+           type: 'INTEGER'
+         }, {
+           name: 'user_defined',
+           type: 'JSONB'
+         }, {
+           name: 'start_date_start_date',
+           type: 'DATE'
+         }, {
+           name: 'start_date_end_date',
+           type: 'DATE'
+         }, {
+           name: 'end_date_start_date',
+           type: 'DATE'
+         }, {
+           name: 'end_date_end_date',
+           type: 'DATE'
+         }]
+      end
+
+      def table_name_prefix
+        'z_events'
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import/importer.rb
+++ b/app/services/core_data_connector/import/importer.rb
@@ -4,6 +4,9 @@ module CoreDataConnector
       attr_reader :importers
 
       IMPORTERS = [{
+        importer_class: Events,
+        filename: 'events.csv'
+      }, {
         importer_class: Instances,
         filename: 'instances.csv'
       }, {

--- a/app/services/core_data_connector/import/relationships.rb
+++ b/app/services/core_data_connector/import/relationships.rb
@@ -57,7 +57,11 @@ module CoreDataConnector
 
         execute <<-SQL.squish
           WITH all_related_types AS (
-
+         
+          SELECT id, uuid, 'CoreDataConnector::Event' AS type
+            FROM core_data_connector_events events
+           WHERE events.z_event_id IS NOT NULL
+           UNION
           SELECT id, uuid, 'CoreDataConnector::Instance' AS type
             FROM core_data_connector_instances instances
            WHERE instances.z_instance_id IS NOT NULL

--- a/app/services/core_data_connector/search/base.rb
+++ b/app/services/core_data_connector/search/base.rb
@@ -198,6 +198,10 @@ module CoreDataConnector
 
       included do
         # Primary relationships
+        has_many :event_relationships, -> {
+          where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::Event.to_s })
+        }, as: :primary_record, class_name: Relationship.to_s
+
         has_many :instance_relationships, -> {
           where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::Instance.to_s })
         }, as: :primary_record, class_name: Relationship.to_s
@@ -231,6 +235,12 @@ module CoreDataConnector
         }, as: :primary_record, class_name: Relationship.to_s
 
         # Related relationships
+        has_many :event_related_relationships, -> {
+          joins(:project_model_relationship)
+            .where(Relationship.arel_table.name => { primary_record_type: CoreDataConnector::Event.to_s })
+            .where(ProjectModelRelationship.arel_table.name => { allow_inverse: true })
+        }, as: :related_record, class_name: Relationship.to_s
+
         has_many :instance_related_relationships, -> {
           joins(:project_model_relationship)
             .where(Relationship.arel_table.name => { primary_record_type: CoreDataConnector::Instance.to_s })
@@ -345,6 +355,7 @@ module CoreDataConnector
         end
 
         def build_relationships(hash)
+          event_relationships.each { |r| build_relationship(r, hash) }
           instance_relationships.each { |r| build_relationship(r, hash) }
           item_relationships.each { |r| build_relationship(r, hash) }
           media_content_relationships.each { |r| build_relationship(r, hash) }
@@ -354,6 +365,7 @@ module CoreDataConnector
           taxonomy_relationships.each { |r| build_relationship(r, hash) }
           work_relationships.each { |r| build_relationship(r, hash) }
 
+          event_related_relationships.each { |r| build_inverse_relationship(r, hash) }
           instance_related_relationships.each { |r| build_inverse_relationship(r, hash) }
           item_related_relationships.each { |r| build_inverse_relationship(r, hash) }
           media_content_related_relationships.each { |r| build_inverse_relationship(r, hash) }

--- a/app/services/core_data_connector/search/event.rb
+++ b/app/services/core_data_connector/search/event.rb
@@ -1,0 +1,39 @@
+module CoreDataConnector
+  module Search
+    module Event
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def preloads
+          [:start_date, :end_date]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Search attributes
+        search_attribute :name, facet: true
+        search_attribute :description
+
+        search_attribute(:start_date, facet: true) do
+          resolve_date start_date
+        end
+
+        search_attribute(:end_date, facet: true) do
+          resolve_date end_date
+        end
+
+        private
+
+        def resolve_date(date)
+          return [] unless date.present?
+
+          [date.start_date&.to_time&.to_i, date.end_date&.to_time&.to_i]
+        end
+
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,21 @@ CoreDataConnector::Engine.routes.draw do
   resources :works
 
   namespace :public, only: [:index, :show] do
+    resources :events do
+      resources :events, only: :index
+      resources :instances, only: :index
+      resources :items, only: :index
+      resources :manifests
+      resources :media_contents, only: :index
+      resources :organizations, only: :index
+      resources :people, only: :index
+      resources :places, only: :index
+      resources :taxonomies, only: :index
+      resources :works, only: :index
+    end
+
     resources :instances do
+      resources :events, only: :index
       resources :instances, only: :index
       resources :items, only: :index
       resources :manifests
@@ -47,6 +61,7 @@ CoreDataConnector::Engine.routes.draw do
     end
 
     resources :items do
+      resources :events, only: :index
       resources :instances, only: :index
       resources :items, only: :index
       resources :manifests
@@ -59,6 +74,7 @@ CoreDataConnector::Engine.routes.draw do
     end
 
     resources :places, controller: 'linked_places/places' do
+      resources :events, only: :index, controller: 'linked_places/events'
       resources :instances, only: :index, controller: 'linked_places/instances'
       resources :items, only: :index, controller: 'linked_places/items'
       resources :manifests, controller: 'manifests'
@@ -75,6 +91,7 @@ CoreDataConnector::Engine.routes.draw do
     end
 
     resources :works do
+      resources :events, only: :index
       resources :instances, only: :index
       resources :items, only: :index
       resources :manifests

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 CoreDataConnector::Engine.routes.draw do
   mount JwtAuth::Engine => '/auth'
 
+  resources :events
   resources :instances
   resources :items
   resources :media_contents

--- a/core_data_connector.gemspec
+++ b/core_data_connector.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faker'
   spec.add_dependency 'rails', '>= 6.0.3.2', '< 8'
   spec.add_dependency 'activerecord-postgis-adapter', '~> 8.0'
+  spec.add_dependency 'fuzzy_dates'
   spec.add_dependency 'jwt', '~> 2.7.1'
   spec.add_dependency 'jwt_auth'
   spec.add_dependency 'rack-cors', '~> 2.0.1'

--- a/db/migrate/20240416153109_create_core_data_connector_events.rb
+++ b/db/migrate/20240416153109_create_core_data_connector_events.rb
@@ -1,0 +1,12 @@
+class CreateCoreDataConnectorEvents < ActiveRecord::Migration[7.0]
+  def change
+    create_table :core_data_connector_events do |t|
+      t.references :project_model
+      t.uuid :uuid, default: 'gen_random_uuid()', null: false
+      t.string :name
+      t.text :description
+      t.integer :z_event_id
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240416175657_add_user_defined_fields_to_core_data_connector_events.rb
+++ b/db/migrate/20240416175657_add_user_defined_fields_to_core_data_connector_events.rb
@@ -1,0 +1,11 @@
+class AddUserDefinedFieldsToCoreDataConnectorEvents < ActiveRecord::Migration[7.0]
+  def up
+    add_column :core_data_connector_events, :user_defined, :jsonb, default: {}
+    add_index :core_data_connector_events, :user_defined, using: :gin
+  end
+
+  def down
+    remove_index :core_data_connector_events, :user_defined
+    remove_column :core_data_connector_events, :user_defined
+  end
+end

--- a/lib/generators/core_data_connector/install/install_generator.rb
+++ b/lib/generators/core_data_connector/install/install_generator.rb
@@ -5,6 +5,7 @@ module CoreDataConnector
     desc "CoreDataConnector migrations"
     def copy_initializer
       rake 'core_data_connector:install:migrations'
+      rake 'fuzzy_dates:install:migrations'
       rake "triple_eye_effable:install:migrations"
       rake "user_defined_fields:install:migrations"
     end


### PR DESCRIPTION
This pull request implements the `events` model in Core Data:

- Creates the `/core_data/events` API endpoints used by admin CMS
- Creates the `/core_data/public/events` API endpoints used by consumers
- Updates the search service to support events
- Updates the import service to support events

See screenshots on `core-data-cloud` [PR](https://github.com/performant-software/core-data-cloud/pull/191).