### PR TITLE
CDC #198 - Items Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,17 +79,19 @@ bundle exec rake typesense:create -- -h host -p port -r protocol -a api_key -c c
 bundle exec rake typesense:delete -- -h host -p port -r protocol -a api_key -c collection_name
 ```
 
-#### Add documents to a collection
+#### Index documents into a collection
 ```bash
 bundle exec rake typesense:index -- -h host -p port -r protocol -a api_key -c collection_name -m model_ids
 ```
+
+**Note:** This task expects the entire collection to be indexed. Any records not included in the batch will be removed from the index.
 
 #### Update a collection
 ```bash
 bundle exec rake typesense:update -- -h host -p port -r protocol -a api_key -c collection_name
 ```
 
-**Note**: This task was added as a workaround for an issue in Typesense indexing nested facetable fields using auto-detection schema. This task should be run _after_ the indexing process to update the "facet" attribute on any fields that should be facetable.
+**Note:** This task was added as a workaround for an issue in Typesense indexing nested facetable fields using auto-detection schema. This task should be run _after_ the indexing process to update the "facet" attribute on any fields that should be facetable.
 
 
 ## Public API

--- a/app/services/core_data_connector/search/base.rb
+++ b/app/services/core_data_connector/search/base.rb
@@ -289,12 +289,10 @@ module CoreDataConnector
             .where(ProjectModelRelationship.arel_table.name => { allow_inverse: true })
         }, as: :related_record, class_name: Relationship.to_s
 
+        # Include the ID attributes as a string by default
+        search_attribute(:id) { uuid }
+        search_attribute(:record_id) { id.to_s }
         search_attribute :uuid
-
-        # Include the ID attribute as a string by default
-        search_attribute(:record_id) do
-          id.to_s
-        end
 
         # Uses the specified attributes to create a JSON object. We'll skip relationships by default as to
         # not create an infinite loop while serializing related records.

--- a/app/services/core_data_connector/search/item.rb
+++ b/app/services/core_data_connector/search/item.rb
@@ -13,6 +13,8 @@ module CoreDataConnector
         # Includes
         include Base
 
+        search_attribute :faircopy_cloud_id
+
         search_attribute(:name) do
           primary_name.name.name
         end


### PR DESCRIPTION
This pull request makes the following changes to the Typesense indexing process:

- Updates each document to use the `uuid` value as the Typesense document ID. This will allowing updating records from FairCopy.cloud by `uuid`.
- Updates the document index process to use the `emplace` action, rather than `upsert`. This action does not require the full document to be sent, which supports only updating a partial set of attributes. This will allow the bulk of the attributes to be set by Core Data, and the document text to be set by FairCopy.cloud, without them overwriting each other. This also allows the indexing process to be run multiple times in Core Data without overwriting updates from FairCopy.cloud.
- Updates the document index process to remove any documents from the index that are not present in the batch of records being indexed from Core Data. This will account for any records that have been deleted from Core Data and remove them from the Typesense index.