### PR TITLE
CDC #214 - Relationship Descriptors

### DIFF
--- a/app/controllers/core_data_connector/public/v1/projects_controller.rb
+++ b/app/controllers/core_data_connector/public/v1/projects_controller.rb
@@ -25,13 +25,19 @@ module CoreDataConnector
                     })
 
           query.find_each do |project_model_relationship|
-            descriptors << {
+            descriptor = {
               identifier: project_model_relationship.uuid,
               label: project_model_relationship.name,
               context: project_model_relationship.primary_model.name
             }
 
-            project_model_relationship.user_defined_fields.each do |user_defined_field|
+            if project_model_relationship.allow_inverse?
+              descriptor[:inverse_label] = project_model_relationship.inverse_name
+            end
+
+            descriptors << descriptor
+
+              project_model_relationship.user_defined_fields.each do |user_defined_field|
               descriptors << {
                 identifier: user_defined_field.uuid,
                 label: user_defined_field.column_name,

--- a/app/serializers/concerns/core_data_connector/public/v1/typeable_serializer.rb
+++ b/app/serializers/concerns/core_data_connector/public/v1/typeable_serializer.rb
@@ -5,17 +5,20 @@ module CoreDataConnector
         extend ActiveSupport::Concern
 
         included do
-          index_attributes(:relationship_type) { |item, current_user, options| relationship_type(item, options) }
+          index_attributes(:project_model_relationship_uuid) { |item| relationship_uuid(item) }
+          index_attributes(:project_model_relationship_inverse) { |item| relationship_inverse(item) }
 
           protected
 
-          def self.relationship_type(item, options)
-            if options[:nested_resource].to_s.to_bool
-              if !item.relationships.empty?
-                item.relationships.map{ |r| r.project_model_relationship.inverse_name }.first
-              elsif !item.related_relationships.empty?
-                item.related_relationships.map { |r| r.project_model_relationship.name }.first
-              end
+          def self.relationship_inverse(item)
+            !item.relationships.empty?
+          end
+
+          def self.relationship_uuid(item)
+            if !item.relationships.empty?
+              item.relationships.map{ |r| r.project_model_relationship.uuid }.first
+            elsif !item.related_relationships.empty?
+              item.related_relationships.map { |r| r.project_model_relationship.uuid }.first
             end
           end
         end

--- a/app/services/core_data_connector/search/base.rb
+++ b/app/services/core_data_connector/search/base.rb
@@ -336,20 +336,38 @@ module CoreDataConnector
           project_model_relationship = relationship.project_model_relationship
           key = project_model_relationship.uuid
 
+          attributes = {
+            inverse: true
+          }
+
           user_defined = build_user_defined(relationship, project_model_relationship.user_defined_fields)
 
           hash[key] ||= []
-          hash[key] << relationship.primary_record.to_search_json.merge(user_defined)
+
+          hash[key] << relationship
+                         .primary_record
+                         .to_search_json
+                         .merge(user_defined)
+                         .merge(attributes)
         end
 
         def build_relationship(relationship, hash)
           project_model_relationship = relationship.project_model_relationship
           key = project_model_relationship.uuid
 
+          attributes = {
+            inverse: false
+          }
+
           user_defined = build_user_defined(relationship, project_model_relationship.user_defined_fields)
 
           hash[key] ||= []
-          hash[key] << relationship.related_record.to_search_json.merge(user_defined)
+
+          hash[key] << relationship
+                         .related_record
+                         .to_search_json
+                         .merge(user_defined)
+                         .merge(attributes)
         end
 
         def build_relationships(hash)


### PR DESCRIPTION
This pull request makes the following changes:

- Adds the `inverse_label` attribute to the `/public/projects/:id/descriptors` API endpoint
- Adds the `project_model_relationship_uuid` and `project_model_relationship_inverse` attributes to the `/public/*/:uuid/*` API endpoints
- Adds the `inverse` attribute to the nested related records in search