### PR TITLE
CDC #205 - Merge Records

### DIFF
--- a/app/controllers/concerns/core_data_connector/mergeable_controller.rb
+++ b/app/controllers/concerns/core_data_connector/mergeable_controller.rb
@@ -1,0 +1,56 @@
+module CoreDataConnector
+  module MergeableController
+    extend ActiveSupport::Concern
+
+    included do
+
+      def merge
+        render json: { errors: [I18n.t('errors.mergeable.ids')] }, status: :bad_request and return unless params[:ids].present?
+
+        item = item_class.new(prepare_params)
+        authorize_create item
+
+        preloads = [
+          :project_model,
+          relationships: [:related_record, project_model_relationship: :user_defined_fields],
+          related_relationships: [:primary_record, project_model_relationship: :user_defined_fields],
+        ]
+
+        items = item_class
+                  .preload(preloads)
+                  .where(id: params[:ids])
+
+        authorize_destroy items
+
+        begin
+          service = Merge::Merger.new
+          service.merge(item, items)
+
+          errors = item.errors
+        rescue StandardError => exception
+          errors = [exception]
+        end
+
+        if errors.nil? || errors.empty?
+          render json: build_show_response(item), status: :ok
+        else
+          render json: { errors: errors }, status: :bad_request
+        end
+      end
+
+      private
+
+      def authorize_create(item)
+        policy = Pundit.policy!(current_user, item)
+        policy.create?
+      end
+
+      def authorize_destroy(items)
+        items.each do |item|
+          policy = Pundit.policy!(current_user, item)
+          policy.destroy?
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/events_controller.rb
+++ b/app/controllers/core_data_connector/events_controller.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class EventsController < ApplicationController
     # Includes
+    include MergeableController
     include OwnableController
     include UserDefinedFields::Queryable
 

--- a/app/controllers/core_data_connector/instances_controller.rb
+++ b/app/controllers/core_data_connector/instances_controller.rb
@@ -1,11 +1,15 @@
 module CoreDataConnector
   class InstancesController < ApplicationController
+    # Includes
+    include MergeableController
     include NameableController
     include OwnableController
     include UserDefinedFields::Queryable
 
+    # Preloads
     preloads source_titles: :name
 
+    # Joins
     joins primary_name: :name
   end
 end

--- a/app/controllers/core_data_connector/items_controller.rb
+++ b/app/controllers/core_data_connector/items_controller.rb
@@ -1,11 +1,15 @@
 module CoreDataConnector
   class ItemsController < ApplicationController
+    # Includes
+    include MergeableController
     include NameableController
     include OwnableController
     include UserDefinedFields::Queryable
 
+    # Preloads
     preloads source_titles: :name
 
+    # Joins
     joins primary_name: :name
   end
 end

--- a/app/controllers/core_data_connector/media_contents_controller.rb
+++ b/app/controllers/core_data_connector/media_contents_controller.rb
@@ -1,11 +1,35 @@
 module CoreDataConnector
   class MediaContentsController < ApplicationController
     # Includes
+    include Http::Requestable
+    include MergeableController
     include OwnableController
     include TripleEyeEffable::ResourceableController
     include UserDefinedFields::Queryable
 
     # Search attributes
     search_attributes :name
+
+    # Actions
+    before_action :set_content, only: :merge
+
+    protected
+
+    def set_content
+      send_request(params[:media_content][:content_url], followlocation: true) do |content|
+        tempfile = Tempfile.new
+        tempfile.binmode
+        tempfile.write(content)
+        tempfile.rewind
+
+        file = ActionDispatch::Http::UploadedFile.new(
+          tempfile: tempfile,
+          type: params[:media_content][:content_type],
+          filename: params[:media_content][:name]
+        )
+
+        params[:media_content][:content] = file
+      end
+    end
   end
 end

--- a/app/controllers/core_data_connector/organizations_controller.rb
+++ b/app/controllers/core_data_connector/organizations_controller.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class OrganizationsController < ApplicationController
     # Includes
+    include MergeableController
     include NameableController
     include OwnableController
     include UserDefinedFields::Queryable

--- a/app/controllers/core_data_connector/people_controller.rb
+++ b/app/controllers/core_data_connector/people_controller.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class PeopleController < ApplicationController
     # Includes
+    include MergeableController
     include NameableController
     include OwnableController
     include UserDefinedFields::Queryable

--- a/app/controllers/core_data_connector/places_controller.rb
+++ b/app/controllers/core_data_connector/places_controller.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class PlacesController < ApplicationController
     # Includes
+    include MergeableController
     include NameableController
     include OwnableController
     include UserDefinedFields::Queryable

--- a/app/controllers/core_data_connector/taxonomies_controller.rb
+++ b/app/controllers/core_data_connector/taxonomies_controller.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class TaxonomiesController < ApplicationController
     # Includes
+    include MergeableController
     include OwnableController
     include UserDefinedFields::Queryable
 

--- a/app/controllers/core_data_connector/works_controller.rb
+++ b/app/controllers/core_data_connector/works_controller.rb
@@ -1,11 +1,15 @@
 module CoreDataConnector
   class WorksController < ApplicationController
+    # Includes
+    include MergeableController
     include NameableController
     include OwnableController
     include UserDefinedFields::Queryable
 
+    # Preloads
     preloads source_titles: :name
 
+    # Joins
     joins primary_name: :name
   end
 end

--- a/app/models/core_data_connector/event.rb
+++ b/app/models/core_data_connector/event.rb
@@ -3,6 +3,7 @@ module CoreDataConnector
     # Includes
     include FuzzyDates::FuzzyDateable
     include Identifiable
+    include Manifestable
     include Ownable
     include Relateable
     include Search::Event

--- a/app/models/core_data_connector/media_content.rb
+++ b/app/models/core_data_connector/media_content.rb
@@ -2,6 +2,7 @@ module CoreDataConnector
   class MediaContent < ApplicationRecord
     # Includes
     include Identifiable
+    include Manifestable
     include Ownable
     include Relateable
     include Search::MediaContent

--- a/app/models/core_data_connector/organization.rb
+++ b/app/models/core_data_connector/organization.rb
@@ -2,6 +2,7 @@ module CoreDataConnector
   class Organization < ApplicationRecord
     # Includes
     include Identifiable
+    include Manifestable
     include Nameable
     include Ownable
     include Relateable

--- a/app/models/core_data_connector/person.rb
+++ b/app/models/core_data_connector/person.rb
@@ -2,6 +2,7 @@ module CoreDataConnector
   class Person < ApplicationRecord
     # Includes
     include Identifiable
+    include Manifestable
     include Nameable
     include Ownable
     include Relateable

--- a/app/models/core_data_connector/taxonomy.rb
+++ b/app/models/core_data_connector/taxonomy.rb
@@ -1,6 +1,8 @@
 module CoreDataConnector
   class Taxonomy < ApplicationRecord
+    # Includes
     include Identifiable
+    include Manifestable
     include Ownable
     include Relateable
     include Search::Taxonomy

--- a/app/policies/concerns/core_data_connector/mergeable_policy.rb
+++ b/app/policies/concerns/core_data_connector/mergeable_policy.rb
@@ -1,0 +1,11 @@
+module CoreDataConnector
+  module MergeablePolicy
+    extend ActiveSupport::Concern
+
+    included do
+      def permitted_attributes_for_merge
+        [*permitted_attributes, :uuid]
+      end
+    end
+  end
+end

--- a/app/policies/core_data_connector/event_policy.rb
+++ b/app/policies/core_data_connector/event_policy.rb
@@ -1,5 +1,7 @@
 module CoreDataConnector
   class EventPolicy < BasePolicy
+    # Includes
+    include MergeablePolicy
     include OwnablePolicy
 
     attr_reader :current_user, :event, :project_model_id, :project_id

--- a/app/policies/core_data_connector/instance_policy.rb
+++ b/app/policies/core_data_connector/instance_policy.rb
@@ -1,5 +1,7 @@
 module CoreDataConnector
   class InstancePolicy < BasePolicy
+    # Includes
+    include MergeablePolicy
     include OwnablePolicy
 
     attr_reader :current_user, :instance, :project_model_id, :project_id

--- a/app/policies/core_data_connector/item_policy.rb
+++ b/app/policies/core_data_connector/item_policy.rb
@@ -1,5 +1,7 @@
 module CoreDataConnector
   class ItemPolicy < BasePolicy
+    # Includes
+    include MergeablePolicy
     include OwnablePolicy
 
     attr_reader :current_user, :item, :project_model_id, :project_id

--- a/app/policies/core_data_connector/media_content_policy.rb
+++ b/app/policies/core_data_connector/media_content_policy.rb
@@ -1,5 +1,7 @@
 module CoreDataConnector
   class MediaContentPolicy < BasePolicy
+    # Includes
+    include MergeablePolicy
     include OwnablePolicy
 
     attr_reader :current_user, :media_content, :project_model_id, :project_id

--- a/app/policies/core_data_connector/organization_policy.rb
+++ b/app/policies/core_data_connector/organization_policy.rb
@@ -1,5 +1,7 @@
 module CoreDataConnector
   class OrganizationPolicy < BasePolicy
+    # Includes
+    include MergeablePolicy
     include OwnablePolicy
 
     attr_reader :current_user, :organization, :project_model_id, :project_id

--- a/app/policies/core_data_connector/person_policy.rb
+++ b/app/policies/core_data_connector/person_policy.rb
@@ -1,5 +1,6 @@
 module CoreDataConnector
   class PersonPolicy < BasePolicy
+    include MergeablePolicy
     include OwnablePolicy
 
     attr_reader :current_user, :person, :project_model_id, :project_id

--- a/app/policies/core_data_connector/place_policy.rb
+++ b/app/policies/core_data_connector/place_policy.rb
@@ -1,5 +1,7 @@
 module CoreDataConnector
   class PlacePolicy < BasePolicy
+    # Includes
+    include MergeablePolicy
     include OwnablePolicy
 
     attr_reader :current_user, :place, :project_model_id, :project_id

--- a/app/policies/core_data_connector/taxonomy_policy.rb
+++ b/app/policies/core_data_connector/taxonomy_policy.rb
@@ -1,5 +1,7 @@
 module CoreDataConnector
   class TaxonomyPolicy < BasePolicy
+    # Includes
+    include MergeablePolicy
     include OwnablePolicy
 
     attr_reader :current_user, :taxonomy, :project_model_id, :project_id

--- a/app/policies/core_data_connector/work_policy.rb
+++ b/app/policies/core_data_connector/work_policy.rb
@@ -1,5 +1,7 @@
 module CoreDataConnector
   class WorkPolicy < BasePolicy
+    # Includes
+    include MergeablePolicy
     include OwnablePolicy
 
     attr_reader :current_user, :work, :project_model_id, :project_id

--- a/app/services/core_data_connector/merge/merger.rb
+++ b/app/services/core_data_connector/merge/merger.rb
@@ -1,0 +1,89 @@
+module CoreDataConnector
+  module Merge
+    class Merger
+      MANIFEST_ATTRIBUTES = [
+        :project_model_relationship_id
+      ]
+
+      RELATIONSHIP_ATTRIBUTES = [
+        :project_model_relationship_id,
+        :primary_record_type,
+        :related_record_id,
+        :related_record_type,
+        :user_defined
+      ]
+
+      RELATED_RELATIONSHIP_ATTRIBUTES = [
+        :project_model_relationship_id,
+        :primary_record_id,
+        :primary_record_type,
+        :related_record_type,
+        :user_defined
+      ]
+
+      WEB_IDENTIFIER_ATTRIBUTES = [
+        :web_authority_id,
+        :identifier,
+        :extra
+      ]
+
+      def merge(new_record, merged_records)
+        manifests = []
+        relationships = []
+        related_relationships = []
+        web_identifiers = []
+
+        merged_records.each do |record|
+          # Append the manifests from the merged record(s) to the new record
+          record.manifests.each { |manifest| add_item(manifests, manifest, MANIFEST_ATTRIBUTES) }
+
+          # Append the relationships from the merged record(s) to the new record
+          record.relationships.each { |relationship| add_item(relationships, relationship, RELATIONSHIP_ATTRIBUTES) }
+          record.related_relationships.each { |relationship| add_item(related_relationships, relationship, RELATED_RELATIONSHIP_ATTRIBUTES) }
+
+          # Append the web identifiers from the merged record(s) to the new record
+          record.web_identifiers.each { |web_identifier| add_item(web_identifiers, web_identifier, WEB_IDENTIFIER_ATTRIBUTES) }
+        end
+
+        # Add the manifests to the new record
+        manifests.each { |manifest| manifest.manifestable = new_record }
+        new_record.manifests = manifests
+
+        # Add the relationships to the new record
+        relationships.each { |relationship| relationship.primary_record = new_record }
+        new_record.relationships = relationships
+
+        related_relationships.each { |relationship| relationship.related_record = new_record }
+        new_record.related_relationships = related_relationships
+
+        # Add web identifiers to the new record
+        web_identifiers.each { |web_identifier| web_identifier.identifiable = new_record }
+        new_record.web_identifiers = web_identifiers
+
+        # Save the new record
+        success = new_record.save
+
+        if success
+          # Re-generate manifests
+          service = Iiif::Manifest.new
+          service.reset_manifests_by_type(new_record.class, { id: new_record.id })
+
+          # Destroy the merged records
+          merged_records.destroy_all
+        end
+      end
+
+      private
+
+      def add_item(array, item, attrs)
+        included = false
+
+        array.each do |i|
+          included = true and break if attrs.all? { |attr| i[attr] == item[attr] }
+        end
+
+        array << item.dup unless included
+      end
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,6 +14,8 @@ en:
       timeout: "Your request has timed out"
     manifest:
       unique: "Only a single manifest can exist per relationship"
+    mergeable:
+      ids: "IDs are required"
     nameable:
       primary_name: "This record must have a primary name"
     projects:

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -2,21 +2,35 @@
 module Admin
   def self.extended(router)
     router.instance_exec do
-      resources :events
+      resources :events do
+        post :merge, on: :collection
+      end
 
-      resources :instances
+      resources :instances do
+        post :merge, on: :collection
+      end
 
-      resources :items
+      resources :items do
+        post :merge, on: :collection
+      end
 
-      resources :media_contents
+      resources :media_contents do
+        post :merge, on: :collection
+      end
 
       resources :names, only: :index
 
-      resources :organizations
+      resources :organizations do
+        post :merge, on: :collection
+      end
 
-      resources :people
+      resources :people do
+        post :merge, on: :collection
+      end
 
-      resources :places
+      resources :places do
+        post :merge, on: :collection
+      end
 
       resources :project_models do
         get :model_classes, on: :collection
@@ -36,7 +50,9 @@ module Admin
         post :upload, on: :collection
       end
 
-      resources :taxonomies
+      resources :taxonomies do
+        post :merge, on: :collection
+      end
 
       resources :user_projects
 
@@ -49,7 +65,9 @@ module Admin
 
       resources :web_identifiers
 
-      resources :works
+      resources :works do
+        post :merge, on: :collection
+      end
     end
   end
 end


### PR DESCRIPTION
This pull request adds the `/core_data/*/merge` API endpoints for merging together multiple records. The endpoints will accept a payload and an array of ID values. The payload will be used to create a new record. Relationships, manifests, and web identifiers connected to the merged records will be copied over to the newly created created. The merged records will then be removed.

There is a special edge case in the `media_contents_controller` for merging records. The front-end doesn't actually have access to the binary content of the media, so we can't simply `POST` the entire new record like we would if the user was uploading a file. Instead, we'll pass the `content_url` to the server. The controller will then fetch file content, write it to a file, and instantiate a new `ActionDispatch::Http::UploadedFile` to serve as the `content` attribute.

See screenshots in the [PR](https://github.com/performant-software/core-data-cloud/pull/219) in the `core-data-cloud` repo.