### PR TITLE
CDC #206 - Import From FairCopy.cloud

### DIFF
--- a/app/controllers/core_data_connector/items_controller.rb
+++ b/app/controllers/core_data_connector/items_controller.rb
@@ -1,5 +1,3 @@
-require 'zip'
-
 module CoreDataConnector
   class ItemsController < ApplicationController
     # Includes
@@ -31,8 +29,11 @@ module CoreDataConnector
           file.write(contents)
           file.rewind
 
+          # Create a temporary directory
+          directory = FileSystem.create_directory
+
           # Extract the CSV files
-          directory = FileSystem.extract_zip(file)
+          FileSystem.extract_zip(file, directory)
 
           # Analyze the import files
           service = ImportAnalyze::Import.new

--- a/app/controllers/core_data_connector/items_controller.rb
+++ b/app/controllers/core_data_connector/items_controller.rb
@@ -1,3 +1,5 @@
+require 'zip'
+
 module CoreDataConnector
   class ItemsController < ApplicationController
     # Includes
@@ -11,5 +13,37 @@ module CoreDataConnector
 
     # Joins
     joins primary_name: :name
+
+    def analyze_import
+      item = find_record(item_class)
+      authorize item if authorization_valid?
+
+      errors = nil
+
+      begin
+        # Download the zip file from FairCopy.cloud
+        file = File.open('/Users/dleadbetter/Performant/core-data/import-fcc/Archive.zip')
+
+        # Extract the CSV files
+        directory = FileSystem.extract_zip(file)
+
+        # Analyze the import files
+        service = ImportAnalyze::Import.new
+        data = service.analyze(directory)
+
+        # Remove the temporary directory
+        FileSystem.remove_directory(directory)
+      rescue StandardError => exception
+        errors = [exception]
+        puts errors
+        throw exception
+      end
+
+      if errors.nil? || errors.empty?
+        render json: data, status: :ok
+      else
+        render json: { errors: errors }, status: :bad_request
+      end
+    end
   end
 end

--- a/app/controllers/core_data_connector/items_controller.rb
+++ b/app/controllers/core_data_connector/items_controller.rb
@@ -35,8 +35,6 @@ module CoreDataConnector
         FileSystem.remove_directory(directory)
       rescue StandardError => exception
         errors = [exception]
-        puts errors
-        throw exception
       end
 
       if errors.nil? || errors.empty?
@@ -49,6 +47,8 @@ module CoreDataConnector
     def import
       item = find_record(item_class)
       authorize item if authorization_valid?
+
+      # TODO: Authorize user to import each item in the CSV
 
       begin
         # Generate the CSV files and compress them in a ZIP

--- a/app/models/concerns/core_data_connector/fcc_importable.rb
+++ b/app/models/concerns/core_data_connector/fcc_importable.rb
@@ -32,20 +32,31 @@ module CoreDataConnector
           return nil
         end
 
-        send_request(url, followlocation: true) do |file_string|
-          tempfile = Tempfile.new
-          tempfile.binmode
-          tempfile.write(file_string)
-          tempfile.rewind
-  
-          zip_importer = Import::ZipHelper.new
-          ok, errors = zip_importer.import_zip(tempfile)
-  
-          if errors && !errors.empty?
-            puts "Errors importing records for #{url}:"
-            puts errors.inspect
-          end
+        # TODO: Temporary change to bypass valid FairCopy.cloud records
+        file = File.open('/Users/dleadbetter/Performant/core-data/import-fcc/Archive.zip')
+
+        zip_importer = Import::ZipHelper.new
+        ok, errors = zip_importer.import_zip(file)
+
+        if errors && !errors.empty?
+          puts "Errors importing records for #{url}:"
+          puts errors.inspect
         end
+
+        # send_request(url, followlocation: true) do |file_string|
+        #   tempfile = Tempfile.new
+        #   tempfile.binmode
+        #   tempfile.write(file_string)
+        #   tempfile.rewind
+        #
+        #   zip_importer = Import::ZipHelper.new
+        #   ok, errors = zip_importer.import_zip(tempfile)
+        #
+        #   if errors && !errors.empty?
+        #     puts "Errors importing records for #{url}:"
+        #     puts errors.inspect
+        #   end
+        # end
       end
     end
   end

--- a/app/models/concerns/core_data_connector/fcc_importable.rb
+++ b/app/models/concerns/core_data_connector/fcc_importable.rb
@@ -1,62 +1,14 @@
 module CoreDataConnector
   module FccImportable
     extend ActiveSupport::Concern
-    include Http::Requestable
 
     included do
-      after_create :fcc_import
-      
-      CODE_NO_RESPONSE = 0
-
       # Generate the full URL for the record's CSV files in FairCopy.cloud
-      def faircopy_cloud_url(project)
-        if !self[:faircopy_cloud_id] || !project[:faircopy_cloud_url]
-          return nil
-        end
+      def faircopy_cloud_url
+        project = project_model.project
+        return nil unless project_model.id == project.faircopy_cloud_project_model_id
 
-        "#{project[:faircopy_cloud_url]}/documents/#{self[:faircopy_cloud_id]}/csv"
-      end
-
-      def fcc_import
-        project = Project.find(self.project_id)
-
-        url = self.faircopy_cloud_url(project)
-
-        if !url
-          return nil
-        end
-
-        project_model = self.project_model
-
-        if project.faircopy_cloud_project_model_id != project_model.id
-          return nil
-        end
-
-        # TODO: Temporary change to bypass valid FairCopy.cloud records
-        file = File.open('/Users/dleadbetter/Performant/core-data/import-fcc/Archive.zip')
-
-        zip_importer = Import::ZipHelper.new
-        ok, errors = zip_importer.import_zip(file)
-
-        if errors && !errors.empty?
-          puts "Errors importing records for #{url}:"
-          puts errors.inspect
-        end
-
-        # send_request(url, followlocation: true) do |file_string|
-        #   tempfile = Tempfile.new
-        #   tempfile.binmode
-        #   tempfile.write(file_string)
-        #   tempfile.rewind
-        #
-        #   zip_importer = Import::ZipHelper.new
-        #   ok, errors = zip_importer.import_zip(tempfile)
-        #
-        #   if errors && !errors.empty?
-        #     puts "Errors importing records for #{url}:"
-        #     puts errors.inspect
-        #   end
-        # end
+        "#{project.faircopy_cloud_url}/documents/#{faircopy_cloud_id}/csv"
       end
     end
   end

--- a/app/models/concerns/core_data_connector/mergeable.rb
+++ b/app/models/concerns/core_data_connector/mergeable.rb
@@ -1,0 +1,9 @@
+module CoreDataConnector
+  module Mergeable
+    extend ActiveSupport::Concern
+
+    included do
+      has_many :record_merges, as: :mergeable, dependent: :destroy
+    end
+  end
+end

--- a/app/models/core_data_connector/event.rb
+++ b/app/models/core_data_connector/event.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class Event < ApplicationRecord
     # Includes
+    include Export::Event
     include FuzzyDates::FuzzyDateable
     include Identifiable
     include Manifestable

--- a/app/models/core_data_connector/event.rb
+++ b/app/models/core_data_connector/event.rb
@@ -5,6 +5,7 @@ module CoreDataConnector
     include FuzzyDates::FuzzyDateable
     include Identifiable
     include Manifestable
+    include Mergeable
     include Ownable
     include Relateable
     include Search::Event

--- a/app/models/core_data_connector/instance.rb
+++ b/app/models/core_data_connector/instance.rb
@@ -4,6 +4,7 @@ module CoreDataConnector
     include Export::Instance
     include Identifiable
     include Manifestable
+    include Mergeable
     include Nameable
     include Ownable
     include Relateable

--- a/app/models/core_data_connector/instance.rb
+++ b/app/models/core_data_connector/instance.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class Instance < ApplicationRecord
     # Includes
+    include Export::Instance
     include Identifiable
     include Manifestable
     include Nameable

--- a/app/models/core_data_connector/item.rb
+++ b/app/models/core_data_connector/item.rb
@@ -5,6 +5,7 @@ module CoreDataConnector
     include FccImportable
     include Identifiable
     include Manifestable
+    include Mergeable
     include Nameable
     include Ownable
     include Relateable

--- a/app/models/core_data_connector/item.rb
+++ b/app/models/core_data_connector/item.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class Item < ApplicationRecord
     # Includes
+    include Export::Item
     include FccImportable
     include Identifiable
     include Manifestable

--- a/app/models/core_data_connector/media_content.rb
+++ b/app/models/core_data_connector/media_content.rb
@@ -3,6 +3,7 @@ module CoreDataConnector
     # Includes
     include Identifiable
     include Manifestable
+    include Mergeable
     include Ownable
     include Relateable
     include Search::MediaContent

--- a/app/models/core_data_connector/organization.rb
+++ b/app/models/core_data_connector/organization.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class Organization < ApplicationRecord
     # Includes
+    include Export::Organization
     include Identifiable
     include Manifestable
     include Nameable

--- a/app/models/core_data_connector/organization.rb
+++ b/app/models/core_data_connector/organization.rb
@@ -4,6 +4,7 @@ module CoreDataConnector
     include Export::Organization
     include Identifiable
     include Manifestable
+    include Mergeable
     include Nameable
     include Ownable
     include Relateable

--- a/app/models/core_data_connector/person.rb
+++ b/app/models/core_data_connector/person.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class Person < ApplicationRecord
     # Includes
+    include Export::Person
     include Identifiable
     include Manifestable
     include Nameable

--- a/app/models/core_data_connector/person.rb
+++ b/app/models/core_data_connector/person.rb
@@ -4,6 +4,7 @@ module CoreDataConnector
     include Export::Person
     include Identifiable
     include Manifestable
+    include Mergeable
     include Nameable
     include Ownable
     include Relateable

--- a/app/models/core_data_connector/place.rb
+++ b/app/models/core_data_connector/place.rb
@@ -3,6 +3,7 @@ module CoreDataConnector
     self.primary_key = :id
 
     # Includes
+    include Export::Place
     include Identifiable
     include Manifestable
     include Nameable

--- a/app/models/core_data_connector/place.rb
+++ b/app/models/core_data_connector/place.rb
@@ -6,6 +6,7 @@ module CoreDataConnector
     include Export::Place
     include Identifiable
     include Manifestable
+    include Mergeable
     include Nameable
     include Ownable
     include Relateable

--- a/app/models/core_data_connector/record_merge.rb
+++ b/app/models/core_data_connector/record_merge.rb
@@ -1,0 +1,5 @@
+module CoreDataConnector
+  class RecordMerge < ApplicationRecord
+    belongs_to :mergeable, polymorphic: true
+  end
+end

--- a/app/models/core_data_connector/relationship.rb
+++ b/app/models/core_data_connector/relationship.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class Relationship < ApplicationRecord
     # Includes
+    include Export::Relationship
     include UserDefinedFields::Fieldable
 
     # Relationships

--- a/app/models/core_data_connector/taxonomy.rb
+++ b/app/models/core_data_connector/taxonomy.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class Taxonomy < ApplicationRecord
     # Includes
+    include Export::Taxonomy
     include Identifiable
     include Manifestable
     include Ownable

--- a/app/models/core_data_connector/taxonomy.rb
+++ b/app/models/core_data_connector/taxonomy.rb
@@ -4,6 +4,7 @@ module CoreDataConnector
     include Export::Taxonomy
     include Identifiable
     include Manifestable
+    include Mergeable
     include Ownable
     include Relateable
     include Search::Taxonomy

--- a/app/models/core_data_connector/web_identifier.rb
+++ b/app/models/core_data_connector/web_identifier.rb
@@ -1,5 +1,8 @@
 module CoreDataConnector
   class WebIdentifier < ApplicationRecord
+    # Includes
+    include Export::WebIdentifier
+
     # Relationships
     belongs_to :identifiable, polymorphic: true
     belongs_to :web_authority

--- a/app/models/core_data_connector/work.rb
+++ b/app/models/core_data_connector/work.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class Work < ApplicationRecord
     # Includes
+    include Export::Work
     include Identifiable
     include Manifestable
     include Nameable

--- a/app/models/core_data_connector/work.rb
+++ b/app/models/core_data_connector/work.rb
@@ -4,6 +4,7 @@ module CoreDataConnector
     include Export::Work
     include Identifiable
     include Manifestable
+    include Mergeable
     include Nameable
     include Ownable
     include Relateable

--- a/app/policies/core_data_connector/item_policy.rb
+++ b/app/policies/core_data_connector/item_policy.rb
@@ -14,6 +14,13 @@ module CoreDataConnector
       @project_id = item&.project_id
     end
 
+    # A user can analyze the import for an item if the user is an admin or has update permissions.
+    def analyze_import?
+      return true if current_user.admin?
+
+      update?
+    end
+
     # Allowed create/update attributes.
     def permitted_attributes
       [ *ownable_attributes,

--- a/app/policies/core_data_connector/item_policy.rb
+++ b/app/policies/core_data_connector/item_policy.rb
@@ -21,6 +21,13 @@ module CoreDataConnector
       update?
     end
 
+    # A user can import for an item if the user is an admin or has update permissions.
+    def import?
+      return true if current_user.admin?
+
+      update?
+    end
+
     # Allowed create/update attributes.
     def permitted_attributes
       [ *ownable_attributes,

--- a/app/services/core_data_connector/export/base.rb
+++ b/app/services/core_data_connector/export/base.rb
@@ -1,0 +1,43 @@
+module CoreDataConnector
+  module Export
+    module Base
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def export_attribute(*attrs, &block)
+          name, options = attrs
+
+          @export_attrs ||= []
+          @export_attrs << { name: name, block: block}.merge(options || {})
+        end
+
+        def export_attributes
+          @export_attrs
+        end
+      end
+
+      included do
+        def to_export_csv
+          hash = {}
+
+          # Add attributes defined by the concrete-class
+          self.class.export_attributes.each do |attr|
+            name = attr[:name]
+
+            # Extract the value for the attribute
+            if attr[:block].present?
+              value = instance_eval(&attr[:block])
+            else
+              value = self.send(attr[:name])
+            end
+
+            # Add the name/value pair to the CSV
+            hash[name] = value
+          end
+
+          hash
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/export/event.rb
+++ b/app/services/core_data_connector/export/event.rb
@@ -1,0 +1,42 @@
+module CoreDataConnector
+  module Export
+    module Event
+      extend ActiveSupport::Concern
+
+      DATE_FORMAT = '%Y-%m-%d'
+
+      class_methods do
+        def export_preloads
+          [:start_date, :end_date]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Export attributes
+        export_attribute :project_model_id
+        export_attribute :uuid
+        export_attribute :name
+        export_attribute :description
+
+        export_attribute(:start_date) do
+          start_date&.start_date&.strftime(DATE_FORMAT)
+        end
+
+        export_attribute(:start_date_description) do
+          start_date&.description
+        end
+
+        export_attribute(:end_date) do
+          end_date&.start_date&.strftime(DATE_FORMAT)
+        end
+
+        export_attribute(:end_date_description) do
+          end_date&.description
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/export/instance.rb
+++ b/app/services/core_data_connector/export/instance.rb
@@ -1,0 +1,26 @@
+module CoreDataConnector
+  module Export
+    module Instance
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def export_preloads
+          [:primary_name]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Export attributes
+        export_attribute :project_model_id
+        export_attribute :uuid
+
+        export_attribute(:name) do
+          primary_name&.name&.name
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/export/item.rb
+++ b/app/services/core_data_connector/export/item.rb
@@ -1,0 +1,26 @@
+module CoreDataConnector
+  module Export
+    module Item
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def export_preloads
+          [:primary_name]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Export attributes
+        export_attribute :project_model_id
+        export_attribute :uuid
+
+        export_attribute(:name) do
+          primary_name&.name&.name
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/export/organization.rb
+++ b/app/services/core_data_connector/export/organization.rb
@@ -1,0 +1,24 @@
+module CoreDataConnector
+  module Export
+    module Organization
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def export_preloads
+          [:primary_name]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Export attributes
+        export_attribute :project_model_id
+        export_attribute :uuid
+        export_attribute :name
+        export_attribute :description
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/export/person.rb
+++ b/app/services/core_data_connector/export/person.rb
@@ -1,0 +1,26 @@
+module CoreDataConnector
+  module Export
+    module Person
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def export_preloads
+          [:primary_name]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Export attributes
+        export_attribute :project_model_id
+        export_attribute :uuid
+        export_attribute :last_name
+        export_attribute :first_name
+        export_attribute :middle_name
+        export_attribute :biography
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/export/place.rb
+++ b/app/services/core_data_connector/export/place.rb
@@ -1,0 +1,35 @@
+module CoreDataConnector
+  module Export
+    module Place
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def export_query
+          self.all.with_centroid
+        end
+
+        def export_preloads
+          [:primary_name]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Export attributes
+        export_attribute :project_model_id
+        export_attribute :uuid
+        export_attribute :name
+
+        export_attribute(:latitude) do
+          geometry_center&.y
+        end
+
+        export_attribute(:longitude) do
+          geometry_center&.x
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/export/relationship.rb
+++ b/app/services/core_data_connector/export/relationship.rb
@@ -1,0 +1,32 @@
+module CoreDataConnector
+  module Export
+    module Relationship
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def export_preloads
+          [:primary_record, :related_record]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Export attributes
+        export_attribute :project_model_relationship_id
+        export_attribute :uuid
+        export_attribute :primary_record_type
+        export_attribute :related_record_type
+
+        export_attribute(:primary_record_uuid) do
+          primary_record&.uuid
+        end
+
+        export_attribute(:related_record_uuid) do
+          related_record&.uuid
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/export/taxonomy.rb
+++ b/app/services/core_data_connector/export/taxonomy.rb
@@ -1,0 +1,17 @@
+module CoreDataConnector
+  module Export
+    module Taxonomy
+      extend ActiveSupport::Concern
+
+      included do
+        # Includes
+        include Base
+
+        # Export attributes
+        export_attribute :project_model_id
+        export_attribute :uuid
+        export_attribute :name
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/export/web_identifier.rb
+++ b/app/services/core_data_connector/export/web_identifier.rb
@@ -1,0 +1,28 @@
+module CoreDataConnector
+  module Export
+    module WebIdentifier
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def export_preloads
+          [:identifiable]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Export attributes
+        export_attribute :web_authority_id
+
+        export_attribute(:identifiable_uuid) do
+          identifiable&.uuid
+        end
+
+        export_attribute :identifiable_type
+        export_attribute :identifier
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/export/work.rb
+++ b/app/services/core_data_connector/export/work.rb
@@ -1,0 +1,26 @@
+module CoreDataConnector
+  module Export
+    module Work
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def export_preloads
+          [:primary_name]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Export attributes
+        export_attribute :project_model_id
+        export_attribute :uuid
+
+        export_attribute(:name) do
+          primary_name&.name&.name
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/file_system.rb
+++ b/app/services/core_data_connector/file_system.rb
@@ -14,12 +14,8 @@ module CoreDataConnector
       directory
     end
 
-    # Extracts the passed zip file to a temporary directory and returns the path
-    def self.extract_zip(zip_file)
-      # Create the target directory
-      destination = create_directory
-
-      # Extract the zip file to the directory
+    # Extracts the passed zip file to the passed destination
+    def self.extract_zip(zip_file, destination)
       Zip::File.open(zip_file) do |zipfile|
         zipfile.each do |entry|
           # Ignore directories
@@ -32,9 +28,6 @@ module CoreDataConnector
           zipfile.extract(entry, File.join(destination, entry.name))
         end
       end
-
-      # Return the path of the extracted files
-      destination
     end
 
     # Removes the passed directory

--- a/app/services/core_data_connector/file_system.rb
+++ b/app/services/core_data_connector/file_system.rb
@@ -1,0 +1,43 @@
+require 'zip'
+
+IGNORE_PATTERN = /\.DS_Store|__MACOSX|(^|\/)\._/
+
+module CoreDataConnector
+  class FileSystem
+
+    # Creates a temporary directory in the Rails root/tmp folder
+    def self.create_directory
+      "#{Rails.root}/tmp/#{SecureRandom.urlsafe_base64}"
+    end
+
+    # Extracts the passed zip file to a temporary directory and returns the path
+    def self.extract_zip(zip_file)
+      # Create the target directory
+      destination = create_directory
+      FileUtils.mkdir_p(destination) unless File.exist? destination
+
+      # Extract the zip file to the directory
+      Zip::File.open(zip_file) do |zipfile|
+        zipfile.each do |entry|
+          # Ignore directories
+          next unless entry.file?
+
+          # Ignore MacOS archive
+          next if entry.name =~ IGNORE_PATTERN
+
+          # Extract the file
+          zipfile.extract(entry, File.join(destination, entry.name))
+        end
+      end
+
+      # Return the path of the extracted files
+      destination
+    end
+
+    # Removes the passed directory
+    def self.remove_directory(directory)
+      FileUtils.rm_rf directory
+    end
+
+  end
+end

--- a/app/services/core_data_connector/file_system.rb
+++ b/app/services/core_data_connector/file_system.rb
@@ -7,14 +7,17 @@ module CoreDataConnector
 
     # Creates a temporary directory in the Rails root/tmp folder
     def self.create_directory
-      "#{Rails.root}/tmp/#{SecureRandom.urlsafe_base64}"
+      directory = "#{Rails.root}/tmp/#{SecureRandom.urlsafe_base64}"
+
+      FileUtils.mkdir_p(directory) unless File.exist? directory
+
+      directory
     end
 
     # Extracts the passed zip file to a temporary directory and returns the path
     def self.extract_zip(zip_file)
       # Create the target directory
       destination = create_directory
-      FileUtils.mkdir_p(destination) unless File.exist? destination
 
       # Extract the zip file to the directory
       Zip::File.open(zip_file) do |zipfile|

--- a/app/services/core_data_connector/http/requestable.rb
+++ b/app/services/core_data_connector/http/requestable.rb
@@ -3,28 +3,32 @@ require 'typhoeus'
 module CoreDataConnector
   module Http
     module Requestable
+      extend ActiveSupport::Concern
+
       CODE_NO_RESPONSE = 0
-  
-      def send_request(url, options)
-        request = Typhoeus::Request.new(url, options)
-  
-        response = request.run
-  
-        if response.success?
-          yield response.body
-        elsif response.timed_out?
-          render_errors I18n.t('errors.http.timeout')
-        elsif response.code == CODE_NO_RESPONSE
-          render_errors I18n.t('errors.http.no_response')
-        else
-          render_errors I18n.t('errors.http.general')
+
+      included do
+        def send_request(url, options)
+          request = Typhoeus::Request.new(url, options)
+
+          response = request.run
+
+          if response.success?
+            yield response.body
+          elsif response.timed_out?
+            render_errors I18n.t('errors.http.timeout')
+          elsif response.code == CODE_NO_RESPONSE
+            render_errors I18n.t('errors.http.no_response')
+          else
+            render_errors I18n.t('errors.http.general')
+          end
         end
-      end
-  
-      private
-  
-      def render_errors(message)
-        { errors: [message] }
+
+        private
+
+        def render_errors(message)
+          { errors: [message] }
+        end
       end
     end
   end

--- a/app/services/core_data_connector/import/base.rb
+++ b/app/services/core_data_connector/import/base.rb
@@ -54,7 +54,7 @@ module CoreDataConnector
       def transform
         # Sets the user_defined column based on any included user-defined fields
         expression = user_defined_columns
-                       .map{ |c| ["'#{column_name_to_uuid(c[:name])}'", c[:name]] }
+                       .map{ |c| ["'#{ImportAnalyze::Helper.column_name_to_uuid(c[:name])}'", c[:name]] }
                        .flatten
                        .join(', ')
 
@@ -82,11 +82,6 @@ module CoreDataConnector
         [ *column_names, *user_defined_columns ]
       end
 
-      # Converts the passed colum name to a UUID value.
-      def column_name_to_uuid(column_name)
-        column_name.gsub('_', '-')[1..-1]
-      end
-
       def create_table_name
         "#{table_name_prefix}_#{Random.rand(1000..9999)}"
       end
@@ -97,11 +92,10 @@ module CoreDataConnector
         headers = CSV.foreach(filepath).first
 
         headers.each do |header|
-          next unless header.starts_with?('udf_')
-          uuid = header.gsub('udf_', '')
+          next unless ImportAnalyze::Helper.is_user_defined_column?(header)
 
           columns << {
-            name: uuid_to_column_name(uuid),
+            name: header,
             type: 'VARCHAR',
             copy: true
           }

--- a/app/services/core_data_connector/import/events.rb
+++ b/app/services/core_data_connector/import/events.rb
@@ -153,6 +153,12 @@ module CoreDataConnector
 
         execute <<-SQL.squish
           UPDATE #{table_name} z_events
+             SET uuid = gen_random_uuid()
+           WHERE z_events.uuid IS NULL
+        SQL
+
+        execute <<-SQL.squish
+          UPDATE #{table_name} z_events
              SET event_id = events.id
             FROM core_data_connector_events events
            WHERE events.uuid = z_events.uuid

--- a/app/services/core_data_connector/import/instances.rb
+++ b/app/services/core_data_connector/import/instances.rb
@@ -99,6 +99,12 @@ module CoreDataConnector
 
         execute <<-SQL.squish
           UPDATE #{table_name} z_instances
+             SET uuid = gen_random_uuid()
+           WHERE z_instances.uuid IS NULL
+        SQL
+
+        execute <<-SQL.squish
+          UPDATE #{table_name} z_instances
              SET instance_id = instances.id
             FROM core_data_connector_instances instances
            WHERE instances.uuid = z_instances.uuid

--- a/app/services/core_data_connector/import/items.rb
+++ b/app/services/core_data_connector/import/items.rb
@@ -99,6 +99,12 @@ module CoreDataConnector
 
         execute <<-SQL.squish
           UPDATE #{table_name} z_items
+             SET uuid = gen_random_uuid()
+           WHERE z_items.uuid IS NULL
+        SQL
+
+        execute <<-SQL.squish
+          UPDATE #{table_name} z_items
              SET item_id = items.id
             FROM core_data_connector_items items
            WHERE items.uuid = z_items.uuid

--- a/app/services/core_data_connector/import/organizations.rb
+++ b/app/services/core_data_connector/import/organizations.rb
@@ -83,6 +83,12 @@ module CoreDataConnector
 
         execute <<-SQL.squish
           UPDATE #{table_name} z_organizations
+             SET uuid = gen_random_uuid()
+           WHERE z_organizations.uuid IS NULL
+        SQL
+
+        execute <<-SQL.squish
+          UPDATE #{table_name} z_organizations
              SET organization_id = organizations.id
             FROM core_data_connector_organizations organizations
            WHERE organizations.uuid = z_organizations.uuid

--- a/app/services/core_data_connector/import/people.rb
+++ b/app/services/core_data_connector/import/people.rb
@@ -72,6 +72,12 @@ module CoreDataConnector
 
         execute <<-SQL.squish
           UPDATE #{table_name} z_people
+             SET uuid = gen_random_uuid()
+           WHERE z_people.uuid IS NULL
+        SQL
+
+        execute <<-SQL.squish
+          UPDATE #{table_name} z_people
              SET person_id = people.id
             FROM core_data_connector_people people
            WHERE people.uuid = z_people.uuid

--- a/app/services/core_data_connector/import/places.rb
+++ b/app/services/core_data_connector/import/places.rb
@@ -89,6 +89,12 @@ module CoreDataConnector
 
         execute <<-SQL.squish
           UPDATE #{table_name} z_places
+             SET uuid = gen_random_uuid()
+           WHERE z_places.uuid IS NULL
+        SQL
+
+        execute <<-SQL.squish
+          UPDATE #{table_name} z_places
              SET place_id = places.id
             FROM core_data_connector_places places
            WHERE places.uuid = z_places.uuid

--- a/app/services/core_data_connector/import/taxonomies.rb
+++ b/app/services/core_data_connector/import/taxonomies.rb
@@ -59,6 +59,12 @@ module CoreDataConnector
 
         execute <<-SQL.squish
           UPDATE #{table_name} z_taxonomies
+             SET uuid = gen_random_uuid()
+           WHERE z_taxonomies.uuid IS NULL
+        SQL
+
+        execute <<-SQL.squish
+          UPDATE #{table_name} z_taxonomies
              SET taxonomy_id = taxonomies.id
             FROM core_data_connector_taxonomies taxonomies
            WHERE taxonomies.uuid = z_taxonomies.uuid

--- a/app/services/core_data_connector/import/web_identifiers.rb
+++ b/app/services/core_data_connector/import/web_identifiers.rb
@@ -62,7 +62,10 @@ module CoreDataConnector
           WITH
           
           related_types AS (
-
+          SELECT id, uuid, 'CoreDataConnector::Event' AS type
+            FROM core_data_connector_events events
+           WHERE events.z_event_id IS NOT NULL
+           UNION
           SELECT id, uuid, 'CoreDataConnector::Instance' AS type
             FROM core_data_connector_instances instances
            WHERE instances.z_instance_id IS NOT NULL
@@ -91,7 +94,7 @@ module CoreDataConnector
             FROM core_data_connector_works works
            WHERE works.z_work_id IS NOT NULL
 
-          )
+        )
 
         UPDATE #{table_name} z_web_identifiers
            SET identifiable_id = related_types.id

--- a/app/services/core_data_connector/import/works.rb
+++ b/app/services/core_data_connector/import/works.rb
@@ -99,6 +99,12 @@ module CoreDataConnector
 
         execute <<-SQL.squish
           UPDATE #{table_name} z_works
+             SET uuid = gen_random_uuid()
+           WHERE z_works.uuid IS NULL
+        SQL
+
+        execute <<-SQL.squish
+          UPDATE #{table_name} z_works
              SET work_id = works.id
             FROM core_data_connector_works works
            WHERE works.uuid = z_works.uuid

--- a/app/services/core_data_connector/import_analyze/helper.rb
+++ b/app/services/core_data_connector/import_analyze/helper.rb
@@ -1,0 +1,24 @@
+module CoreDataConnector
+  module ImportAnalyze
+    class Helper
+
+      PREFIX_USER_DEFINED = 'udf_'
+
+      def self.column_name_to_uuid(column_name)
+        column_name.gsub(PREFIX_USER_DEFINED, '').gsub('_', '-')
+      end
+
+      def self.is_user_defined_column?(column_name)
+        column_name.starts_with?(PREFIX_USER_DEFINED)
+      end
+
+      def self.user_defined_columns(filepath)
+        CSV.foreach(filepath).first.select{ |h| is_user_defined_column?(h) }
+      end
+
+      def self.uuid_to_column_name(uuid)
+        "#{PREFIX_USER_DEFINED}#{uuid.gsub('-', '_')}"
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import_analyze/import.rb
+++ b/app/services/core_data_connector/import_analyze/import.rb
@@ -1,0 +1,78 @@
+require 'csv'
+
+module CoreDataConnector
+  module ImportAnalyze
+    class Import
+
+      def analyze(directory)
+        # TODO: Check authorization somewhere?
+
+        data = {}
+
+        pattern = File.join(directory, "*.csv")
+
+        Dir.glob(pattern).each do |filepath|
+          filename = File.basename(filepath)
+          klass = find_class(filename)
+
+          attributes = klass.export_attributes.map{ |a| a[:name] } unless klass.nil?
+          records_by_uuid = find_records_by_uuid(filepath, klass)
+
+          CSV.foreach(filepath, headers: true, converters: [:numeric]) do |row|
+            data[filename] ||= { attributes: attributes, data: [] }
+
+            row_hash = row.to_h.symbolize_keys
+            record = records_by_uuid[row_hash[:uuid]]
+
+            data[filename][:data] << {
+              import: row_hash,
+              db: record&.to_export_csv
+            }
+          end
+        end
+
+        data
+      end
+
+      private
+
+      def apply_preloads(klass, records)
+        # Preload any associations from the concrete class
+        if klass.respond_to?(:export_preloads) && klass.export_preloads.present?
+          Preloader.new(
+            records: records,
+            associations: klass.export_preloads
+          ).call
+        end
+      end
+
+      def find_class(filename)
+        "CoreDataConnector::#{File.basename(filename, '.csv').singularize.capitalize}".classify.constantize
+      end
+
+      def find_records_by_uuid(filepath, klass)
+        records_by_uuid = {}
+
+        uuids = []
+
+        CSV.foreach(filepath, headers: true, converters: [:numeric]) do |row|
+          uuids << row.to_h.symbolize_keys[:uuid]
+        end
+
+        query = klass.all
+        query = query.merge(klass.export_query) if klass.respond_to?(:export_query)
+        query = query.where(uuid: uuids)
+
+        query.find_in_batches(batch_size: 1000) do |records|
+          apply_preloads klass, records
+
+          records.each do |record|
+            records_by_uuid[record.uuid] = record
+          end
+        end
+
+        records_by_uuid
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import_analyze/import.rb
+++ b/app/services/core_data_connector/import_analyze/import.rb
@@ -5,6 +5,7 @@ module CoreDataConnector
     class Import
 
       FILE_RELATIONSHIPS = 'relationships.csv'
+      FILE_WEB_IDENTIFIERS = 'web_identifiers.csv'
 
       def analyze(directory)
         data = {}
@@ -13,6 +14,10 @@ module CoreDataConnector
 
         Dir.glob(pattern).each do |filepath|
           filename = File.basename(filepath)
+
+          # Analyzing web identifiers is currently not supported
+          next if filename == FILE_WEB_IDENTIFIERS
+
           klass = find_class(filename)
 
           user_defined_columns = Helper.user_defined_columns(filepath)

--- a/app/services/core_data_connector/import_analyze/import.rb
+++ b/app/services/core_data_connector/import_analyze/import.rb
@@ -9,7 +9,7 @@ module CoreDataConnector
 
         data = {}
 
-        pattern = File.join(directory, "*.csv")
+        pattern = File.join(directory, '*.csv')
 
         Dir.glob(pattern).each do |filepath|
           filename = File.basename(filepath)
@@ -38,6 +38,38 @@ module CoreDataConnector
         end
 
         data
+      end
+
+      def create_zip(files)
+        return nil unless files.present?
+
+        # Create the temporary directory
+        directory = FileSystem.create_directory
+
+        # Generate the CSV files from the passed files hash
+        files.keys.each do |filename|
+          CSV.open("#{directory}/#{filename}", 'w') do |csv|
+            records = files[filename]
+            csv << records.first.keys
+
+            records.each do |record|
+              csv << record.values
+            end
+          end
+        end
+
+        # Zip the generated CSV files
+        zipfile_name = "#{directory}/archive.zip"
+        pattern = File.join(directory, '*.csv')
+
+        Zip::File.open(zipfile_name, create: true) do |zipfile|
+          Dir.glob(pattern).each do |filepath|
+            zipfile.add(File.basename(filepath), filepath)
+          end
+        end
+
+        # Return the file path to the created zip file
+        zipfile_name
       end
 
       private

--- a/app/services/core_data_connector/import_analyze/policy.rb
+++ b/app/services/core_data_connector/import_analyze/policy.rb
@@ -1,0 +1,76 @@
+module CoreDataConnector
+  module ImportAnalyze
+    class Policy
+
+      attr_reader :current_user
+
+      def initialize(current_user)
+        @current_user = current_user
+      end
+
+      # A user can import the set of files if they are an admin or have access to the project(s) containing all of the
+      # models and relationships they are attempting to import.
+      def has_access?(files)
+        return true if current_user.admin?
+
+        access = true
+
+        # Verify the user has access to all of the project_models for which they are attempting to import
+        project_model_ids = project_models_query.pluck(:id)
+        model_files = files.except(Import::FILE_RELATIONSHIPS)
+
+        return false if project_model_ids.empty? && !model_files.empty?
+
+        model_files.keys.each do |filename|
+          model_files[filename][:data].each do |row|
+            project_model_id = row[:import][:project_model_id]
+            (access = false) and break unless project_model_ids.include?(project_model_id)
+          end
+
+          break unless access
+        end
+
+        # Verify the user has access to all of the project_model_relationships for which they are attempting to import
+        project_model_relationship_ids = project_model_relationships_query.pluck(:id)
+        relationships_file = files[Import::FILE_RELATIONSHIPS]
+
+        return false if project_model_relationship_ids.empty? && !relationships_file.empty?
+
+        relationships_file[:data].each do |row|
+          project_model_relationship_id = row[:import][:project_model_relationship_id]
+          (access = false) and break unless project_model_relationship_ids.include?(project_model_relationship_id)
+        end
+
+        access
+      end
+
+      private
+
+      def project_models_query
+        ProjectModel
+          .where(
+            Project
+              .joins(:user_projects)
+              .where(Project.arel_table[:id].eq(ProjectModel.arel_table[:project_id]))
+              .where(user_projects: { user_id: current_user.id })
+              .arel
+              .exists
+          )
+      end
+
+      def project_model_relationships_query
+        ProjectModelRelationship
+          .where(
+            ProjectModel
+              .joins(project: :user_projects)
+              .where(
+                ProjectModel.arel_table[:id].eq(ProjectModelRelationship.arel_table[:primary_model_id])
+                            .or(ProjectModel.arel_table[:id].eq(ProjectModelRelationship.arel_table[:related_model_id])))
+              .where(user_projects: { user_id: current_user.id })
+              .arel
+              .exists
+          )
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/merge/merger.rb
+++ b/app/services/core_data_connector/merge/merger.rb
@@ -5,6 +5,10 @@ module CoreDataConnector
         :project_model_relationship_id
       ]
 
+      MERGE_ATTRIBUTES = [
+        :merged_uuid
+      ]
+
       RELATIONSHIP_ATTRIBUTES = [
         :project_model_relationship_id,
         :primary_record_type,
@@ -29,6 +33,7 @@ module CoreDataConnector
 
       def merge(new_record, merged_records)
         manifests = []
+        record_merges = []
         relationships = []
         related_relationships = []
         web_identifiers = []
@@ -36,6 +41,12 @@ module CoreDataConnector
         merged_records.each do |record|
           # Append the manifests from the merged record(s) to the new record
           record.manifests.each { |manifest| add_item(manifests, manifest, MANIFEST_ATTRIBUTES) }
+
+          # Append the merges from the merged record(s) to the new record
+          record.record_merges.each { |record_merge| add_item(record_merges, record_merge, MERGE_ATTRIBUTES) }
+
+          # Create a record_merge for the merged record(s)
+          record_merges << RecordMerge.new(merged_uuid: record.uuid) unless record.uuid == new_record.uuid
 
           # Append the relationships from the merged record(s) to the new record
           record.relationships.each { |relationship| add_item(relationships, relationship, RELATIONSHIP_ATTRIBUTES) }
@@ -48,6 +59,10 @@ module CoreDataConnector
         # Add the manifests to the new record
         manifests.each { |manifest| manifest.manifestable = new_record }
         new_record.manifests = manifests
+
+        # Add the merges to the new record
+        record_merges.each { |record_merge| record_merge.mergeable = new_record }
+        new_record.record_merges = record_merges
 
         # Add the relationships to the new record
         relationships.each { |relationship| relationship.primary_record = new_record }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,3 +37,23 @@ en:
     iiif:
       manifest:
         label: "%{name}: %{relationship}"
+    import_analyze:
+      common:
+        name: "Name"
+        uuid: "Identifier"
+      events:
+        description: "Description"
+        end_date: "End date"
+        end_date_description: "End date description"
+        start_date: "Start date"
+        start_date_description: "Start date description"
+      organizations:
+        description: "Description"
+      people:
+        biography: "Biography"
+        first_name: "First name"
+        last_name: "Last name"
+        middle_name: "Middle name"
+      places:
+        latitude: "Latitude"
+        longitude: "Longitude"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,6 +12,8 @@ en:
       general: "An error occurred when making your request"
       no_response: "No response from the server"
       timeout: "Your request has timed out"
+    items_controller:
+      authorize: "You do not have permission to import these records. Please contact your system administrator."
     manifest:
       unique: "Only a single manifest can exist per relationship"
     mergeable:

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -11,6 +11,7 @@ module Admin
       end
 
       resources :items do
+        get :analyze_import, on: :member
         post :merge, on: :collection
       end
 

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -12,6 +12,7 @@ module Admin
 
       resources :items do
         get :analyze_import, on: :member
+        post :import, on: :member
         post :merge, on: :collection
       end
 

--- a/db/migrate/20240529143512_add_uuid_to_relationships.rb
+++ b/db/migrate/20240529143512_add_uuid_to_relationships.rb
@@ -1,0 +1,5 @@
+class AddUuidToRelationships < ActiveRecord::Migration[7.0]
+  def change
+    add_column :core_data_connector_relationships, :uuid, :uuid, default: 'gen_random_uuid()', null: false
+  end
+end

--- a/db/migrate/20240531174613_create_core_data_connector_record_merges.rb
+++ b/db/migrate/20240531174613_create_core_data_connector_record_merges.rb
@@ -1,0 +1,9 @@
+class CreateCoreDataConnectorRecordMerges < ActiveRecord::Migration[7.0]
+  def change
+    create_table :core_data_connector_record_merges do |t|
+      t.references :mergeable, polymorphic: true
+      t.string :merged_uuid
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
This pull request makes the following changes to support downloading, comparing, and importing CSV files from FairCopy.cloud.

- Adds the `/core_data/items/:id/analyze_import` and `/core_data/items/:id/import` API endpoints
- Adds the `export` service to convert database records to CSV rows
- Refactors the `fcc_importable` concern. **Note:** Upon `item` creation, the CSV files will not longer be automatically imported
- Adds the `record_merges` table to facilitate tracking of merged `uuid` values
- Adds the `uuid` column to `relationships` to support updating relationships on import
  - The `uuid` column will be required to exist in the import CSV file(s), but the values can be blank
- Updates the `merge` service to move `record_merges` records when records are merged

See screenshots in `core-data-cloud` [PR](https://github.com/performant-software/core-data-cloud/pull/221).