### PR TITLE
CDC #232 - Adding search_uuid method to ownable_controller

### DIFF
--- a/app/controllers/concerns/core_data_connector/ownable_controller.rb
+++ b/app/controllers/concerns/core_data_connector/ownable_controller.rb
@@ -7,6 +7,7 @@ module CoreDataConnector
     VIEW_SHARED = 'shared'
 
     included do
+      search_methods :search_uuid
 
       protected
 
@@ -29,6 +30,20 @@ module CoreDataConnector
           query.merge(item_class.shared_records_by_project_model(params[:project_model_id]))
         else
           query.merge(item_class.owned_records_by_project_model(params[:project_model_id]))
+        end
+      end
+
+      private
+
+      def search_uuid(query)
+        return query unless params[:search].present?
+
+        uuid_query = item_class.where(uuid: params[:search])
+
+        if query == item_class.all
+          query.merge(uuid_query)
+        else
+          query.or(uuid_query)
         end
       end
     end


### PR DESCRIPTION
This pull request adds the `search_uuid` method to the `ownable_controller` to allow searching for records by the `uuid` value. Unlike most searches, this will require an exact match, rather than a partial match.

![Screenshot 2024-06-25 at 4 03 36 PM](https://github.com/performant-software/core-data-connector/assets/20641961/c35f31ea-8dcd-457a-92fb-fd73bd1797fd)
