### PR TITLE
CDC #178 - CSV Export

### DIFF
--- a/app/models/core_data_connector/relationship.rb
+++ b/app/models/core_data_connector/relationship.rb
@@ -34,5 +34,29 @@ module CoreDataConnector
 
     # User defined fields parent
     resolve_defineable -> (relationship) { relationship.project_model_relationship }
+
+    def self.all_records_by_project(project_id)
+      primary_query = Relationship
+                        .where(
+                          ProjectModelRelationship
+                            .joins(:primary_model)
+                            .where(ProjectModelRelationship.arel_table[:id].eq(Relationship.arel_table[:project_model_relationship_id]))
+                            .where(primary_model: { project_id: project_id })
+                            .arel
+                            .exists
+                        )
+
+      related_query = Relationship
+                        .where(
+                          ProjectModelRelationship
+                            .joins(:related_model)
+                            .where(ProjectModelRelationship.arel_table[:id].eq(Relationship.arel_table[:project_model_relationship_id]))
+                            .where(related_model: { project_id: project_id })
+                            .arel
+                            .exists
+                        )
+
+      primary_query.or(related_query)
+    end
   end
 end

--- a/app/models/core_data_connector/web_identifier.rb
+++ b/app/models/core_data_connector/web_identifier.rb
@@ -10,6 +10,12 @@ module CoreDataConnector
     # Callbacks
     before_create :find_identifier
 
+    def self.all_records_by_project(project_id)
+      WebIdentifier
+        .joins(:web_authority)
+        .where(web_authority: { project_id: project_id })
+    end
+
     private
 
     def find_identifier

--- a/app/policies/core_data_connector/project_policy.rb
+++ b/app/policies/core_data_connector/project_policy.rb
@@ -40,6 +40,12 @@ module CoreDataConnector
       project_owner?
     end
 
+    def export_data?
+      return true if current_user.admin?
+
+      project_owner?
+    end
+
     # A user can export a project's environment variables if they are an admin or an owner of the project.
     def export_variables?
       return true if current_user.admin?

--- a/app/policies/core_data_connector/project_policy.rb
+++ b/app/policies/core_data_connector/project_policy.rb
@@ -40,10 +40,11 @@ module CoreDataConnector
       project_owner?
     end
 
+    # A user can export data from a project if they are an admin.
     def export_data?
       return true if current_user.admin?
 
-      project_owner?
+      false
     end
 
     # A user can export a project's environment variables if they are an admin or an owner of the project.

--- a/app/serializers/core_data_connector/project_configurations_serializer.rb
+++ b/app/serializers/core_data_connector/project_configurations_serializer.rb
@@ -1,11 +1,11 @@
 module CoreDataConnector
   class ProjectConfigurationsSerializer < BaseSerializer
-    show_attributes project_models: [:id, :name, :model_class,
-                                     user_defined_fields: UserDefinedFields::UserDefinedFieldsSerializer,
-                                     project_model_relationships: [
-                                       :primary_model_id, :related_model_id, :name, :multiple, :allow_inverse,
-                                       :inverse_name, :inverse_multiple,
-                                       user_defined_fields: UserDefinedFields::UserDefinedFieldsSerializer
-                                     ]]
+    show_attributes :name, project_models: [:id, :name, :model_class,
+                                            user_defined_fields: UserDefinedFields::UserDefinedFieldsSerializer,
+                                            project_model_relationships: [
+                                              :primary_model_id, :related_model_id, :name, :multiple, :allow_inverse,
+                                              :inverse_name, :inverse_multiple,
+                                              user_defined_fields: UserDefinedFields::UserDefinedFieldsSerializer
+                                            ]]
   end
 end

--- a/app/services/core_data_connector/export/exporter.rb
+++ b/app/services/core_data_connector/export/exporter.rb
@@ -1,0 +1,129 @@
+require 'csv'
+
+module CoreDataConnector
+  module Export
+    class Exporter
+
+      attr_reader :project_id
+
+      EXPORT_CLASSES = [{
+        class: CoreDataConnector::Event,
+        filename: 'events.csv'
+      }, {
+        class: CoreDataConnector::Item,
+        filename: 'items.csv'
+     }, {
+        class: CoreDataConnector::Instance,
+        filename: 'instances.csv'
+     }, {
+        class: CoreDataConnector::Organization,
+        filename: 'organizations.csv'
+      }, {
+        class: CoreDataConnector::Person,
+        filename: 'people.csv'
+      }, {
+        class: CoreDataConnector::Place,
+        filename: 'places.csv'
+      }, {
+        class: CoreDataConnector::Taxonomy,
+        filename: 'taxonomies.csv'
+      }, {
+        class: CoreDataConnector::Work,
+        filename: 'works.csv'
+      }]
+
+      def initialize(project_id)
+        @project_id = project_id
+      end
+
+      def run(directory)
+        user_defined_fields = build_user_defined_fields
+
+        EXPORT_CLASSES.each do |klass|
+          model_class = klass[:class]
+          filename = klass[:filename]
+
+          filepath = File.join(directory, filename)
+
+          # Query all of the records owned or shared with the passed project
+          query = model_class.all_records_by_project(project_id)
+          query = query.merge(model_class.export_query) if model_class.respond_to?(:export_query)
+
+          # Skip this model class if the project does not contain any relevant data
+          next unless query.count(Arel.star) > 0
+
+          user_defined_field_uuids = user_defined_fields[model_class.to_s] || []
+          headers = find_headers(model_class, user_defined_field_uuids)
+
+          CSV.open(filepath, 'w', headers: headers, write_headers: true) do |csv|
+            query.find_in_batches(batch_size: 1000) do |records|
+
+              # Apply any preloads for the current model/batch
+              apply_preloads model_class, records
+
+              # Iterate over each record and convert it to a CSV row
+              records.each do |record|
+                csv_row = record.to_export_csv
+
+                # Add the user-defined field properties to the hash. The list of user-defined field UUIDs will contain
+                # the complete set of all user-defined fields across all models for the current type.
+                user_defined_field_uuids.each do |uuid|
+                  value = record.user_defined[uuid] if record.user_defined.present?
+                  csv_row[uuid] = value
+                end
+
+                csv << csv_row.values
+              end
+            end
+          end
+        end
+      end
+
+      private
+
+      def apply_preloads(klass, records)
+        # Preload any associations from the concrete class
+        if klass.respond_to?(:export_preloads) && klass.export_preloads.present?
+          Preloader.new(
+            records: records,
+            associations: klass.export_preloads
+          ).call
+        end
+      end
+
+      def build_user_defined_fields
+        subquery = ProjectModel
+                     .where(ProjectModel.arel_table[:id].eq(UserDefinedFields::UserDefinedField.arel_table[:defineable_id]))
+                     .where(project_id: project_id)
+                     .arel
+                     .exists
+
+        query = UserDefinedFields::UserDefinedField
+                  .where(defineable_type: ProjectModel.to_s)
+                  .where(subquery)
+                  .group(:table_name, :uuid)
+                  .pluck(:table_name, :uuid)
+
+        query.inject({}) do |h, v|
+          uuid, value = v
+
+          h[uuid] ||= []
+          h[uuid] << value
+
+          h
+        end
+      end
+
+      def find_headers(klass, user_defined_field_uuids)
+        headers = klass.export_attributes.map{ |a| a[:name].to_s }
+
+        user_defined_field_uuids.each do |uuid|
+          headers << ImportAnalyze::Helper.uuid_to_column_name(uuid)
+        end
+
+        headers
+      end
+
+    end
+  end
+end

--- a/app/services/core_data_connector/export/exporter.rb
+++ b/app/services/core_data_connector/export/exporter.rb
@@ -25,6 +25,9 @@ module CoreDataConnector
         class: CoreDataConnector::Place,
         filename: 'places.csv'
       }, {
+        class: CoreDataConnector::Relationship,
+        filename: 'relationships.csv'
+      }, {
         class: CoreDataConnector::Taxonomy,
         filename: 'taxonomies.csv'
       }, {
@@ -92,15 +95,8 @@ module CoreDataConnector
       end
 
       def build_user_defined_fields
-        subquery = ProjectModel
-                     .where(ProjectModel.arel_table[:id].eq(UserDefinedFields::UserDefinedField.arel_table[:defineable_id]))
-                     .where(project_id: project_id)
-                     .arel
-                     .exists
-
-        query = UserDefinedFields::UserDefinedField
-                  .where(defineable_type: ProjectModel.to_s)
-                  .where(subquery)
+        query = Queries
+                  .all_fields_by_project(project_id)
                   .group(:table_name, :uuid)
                   .pluck(:table_name, :uuid)
 

--- a/app/services/core_data_connector/export/exporter.rb
+++ b/app/services/core_data_connector/export/exporter.rb
@@ -31,6 +31,9 @@ module CoreDataConnector
         class: CoreDataConnector::Taxonomy,
         filename: 'taxonomies.csv'
       }, {
+        class: CoreDataConnector::WebIdentifier,
+        filename: 'web_identifiers.csv'
+      }, {
         class: CoreDataConnector::Work,
         filename: 'works.csv'
       }]

--- a/app/services/core_data_connector/file_system.rb
+++ b/app/services/core_data_connector/file_system.rb
@@ -14,6 +14,18 @@ module CoreDataConnector
       directory
     end
 
+    def self.create_zip(directory, zip_filename)
+      zip_filepath = File.join(directory, zip_filename)
+      file_pattern = File.join(directory, '*.csv')
+
+      Zip::File.open(zip_filepath, create: true) do |zipfile|
+        Dir.glob(file_pattern).each do |filepath|
+          filename = File.basename(filepath)
+          zipfile.add(filename, File.join(directory, filename))
+        end
+      end
+    end
+
     # Extracts the passed zip file to the passed destination
     def self.extract_zip(zip_file, destination)
       Zip::File.open(zip_file) do |zipfile|

--- a/app/services/core_data_connector/queries.rb
+++ b/app/services/core_data_connector/queries.rb
@@ -1,0 +1,43 @@
+module CoreDataConnector
+  class Queries
+
+    def self.all_fields_by_project(project_id)
+      project_models_query(project_id)
+        .or(project_model_relationships_query(project_id))
+    end
+
+    private
+
+    def self.project_models_query(project_id)
+      subquery = ProjectModel
+                   .where(ProjectModel.arel_table[:id].eq(UserDefinedFields::UserDefinedField.arel_table[:defineable_id]))
+                   .where(project_id: project_id)
+                   .arel
+                   .exists
+
+      UserDefinedFields::UserDefinedField
+        .where(defineable_type: ProjectModel.to_s)
+        .where(subquery)
+    end
+
+    def self.project_model_relationships_query(project_id)
+      subquery = ProjectModelRelationship
+                   .where(ProjectModelRelationship.arel_table[:id].eq(UserDefinedFields::UserDefinedField.arel_table[:defineable_id]))
+                   .joins(:primary_model, :related_model)
+                   .where(primary_model: { project_id: project_id })
+                   .or(
+                     ProjectModelRelationship
+                       .where(ProjectModelRelationship.arel_table[:id].eq(UserDefinedFields::UserDefinedField.arel_table[:defineable_id]))
+                       .joins(:primary_model, :related_model)
+                       .where(related_model: { project_id: project_id })
+                   )
+                   .arel
+                   .exists
+
+      UserDefinedFields::UserDefinedField
+        .where(defineable_type: ProjectModelRelationship.to_s)
+        .where(subquery)
+    end
+
+  end
+end

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -43,6 +43,7 @@ module Admin
       resources :projects do
         post :clear, on: :member
         get :export_configuration, on: :member
+        get :export_data, on: :member
         get :export_variables, on: :member
         post :import_configuration, on: :member
         post :import_data, on: :member


### PR DESCRIPTION
This pull request adds the `/projects/:id/export_data` API endpoint, which will return a `zip` files containing CSVs for the data contained in the specified project. This will include all records added by the specified project, and all records shared with the specified project. This feature was design in order to:

1. Serve as a helper for moving data from one Core Data instance to another
2. Serve as a mechanism for providing customers with their data

There are a few assumptions made as part of this implementation:

- Data will only ever be exported by admin users.
- The `uuid` values of all records will remain intact. The assumption here is that we're moving data from Instance A to Instance B of Core Data. Instance B will become the new source of truth and Instance A will be deprecated.
- In order to import data into a new instance, the `id` values and user-defined field `uuid` values will need to be replaced with the values from the new Core Data project.