### PR TITLE
CDC #31 - Model Menu

### DIFF
--- a/app/controllers/core_data_connector/project_models_controller.rb
+++ b/app/controllers/core_data_connector/project_models_controller.rb
@@ -4,6 +4,7 @@ module CoreDataConnector
     search_attributes :name
 
     # Preloads
+    preloads :project, only: :index
     preloads :project_model_shares, only: :index
     preloads project_model_relationships: :related_model, only: :show
     preloads inverse_project_model_relationships: :primary_model, only: :show

--- a/app/policies/core_data_connector/project_model_policy.rb
+++ b/app/policies/core_data_connector/project_model_policy.rb
@@ -37,12 +37,12 @@ module CoreDataConnector
     end
 
     def permitted_attributes
-      [:project_id, :name, :model_class, :slug, :allow_identifiers, *ProjectModel.permitted_params,
+      [:project_id, :name, :model_class, :slug, :allow_identifiers, :order, *ProjectModel.permitted_params,
        project_model_relationships_attributes: [:id, :primary_model_id, :related_model_id, :name, :multiple, :slug,
-                                                :allow_inverse, :inverse_name, :inverse_multiple, :_destroy,
+                                                :allow_inverse, :inverse_name, :inverse_multiple, :order, :_destroy,
                                                 *ProjectModelRelationship.permitted_params],
        inverse_project_model_relationships_attributes: [:id, :primary_model_id, :related_model_id, :name, :multiple, :slug,
-                                                :allow_inverse, :inverse_name, :inverse_multiple, :_destroy,
+                                                :allow_inverse, :inverse_name, :inverse_multiple, :order, :_destroy,
                                                 *ProjectModelRelationship.permitted_params],
        project_model_accesses_attributes: [:id, :project_id, :_destroy],
        project_model_shares_attributes: [:id, :project_model_access_id, :_destroy]

--- a/app/serializers/core_data_connector/project_models_serializer.rb
+++ b/app/serializers/core_data_connector/project_models_serializer.rb
@@ -3,19 +3,22 @@ module CoreDataConnector
     # Includes
     include UserDefinedFields::DefineableSerializer
 
-    index_attributes :id, :uuid, :project_id, :name, :name_singular, :model_class, :model_class_view, :slug, project: ProjectsSerializer
+    index_attributes :id, :uuid, :project_id, :name, :name_singular, :model_class, :model_class_view, :slug, :order,
+                     project: ProjectsSerializer
 
     index_attributes(:has_shares) do |project_model|
       !project_model.project_model_shares.empty?
     end
 
-    show_attributes :id, :uuid, :project_id, :name, :name_singular, :model_class, :model_class_view, :slug, :allow_identifiers,
-                    project: ProjectsSerializer,
-                    project_model_relationships: [:id, :uuid, :related_model_id, :name, :multiple, :slug, :allow_inverse,
-                                                  :inverse_name, :inverse_multiple, related_model: ProjectModelsSerializer,
+    show_attributes :id, :uuid, :project_id, :name, :name_singular, :model_class, :model_class_view, :slug,
+                    :allow_identifiers, :order, project: ProjectsSerializer,
+                    project_model_relationships: [:id, :uuid, :related_model_id, :name, :multiple, :slug,
+                                                  :allow_inverse, :inverse_name, :inverse_multiple, :order,
+                                                  related_model: ProjectModelsSerializer,
                                                   user_defined_fields: UserDefinedFields::UserDefinedFieldsSerializer],
-                    inverse_project_model_relationships: [:id, :uuid, :primary_model_id, :name, :multiple, :slug, :allow_inverse,
-                                                          :inverse_name, :inverse_multiple, primary_model: ProjectModelsSerializer,
+                    inverse_project_model_relationships: [:id, :uuid, :primary_model_id, :name, :multiple, :slug,
+                                                          :allow_inverse, :inverse_name, :inverse_multiple, :order,
+                                                          primary_model: ProjectModelsSerializer,
                                                           user_defined_fields: UserDefinedFields::UserDefinedFieldsSerializer],
                     project_model_accesses: [:id, :project_id, project: ProjectsSerializer],
                     project_model_shares: [:id, :project_model_access_id, project_model_access: ProjectModelAccessesSerializer]

--- a/db/migrate/20240717155011_add_order_to_project_models.rb
+++ b/db/migrate/20240717155011_add_order_to_project_models.rb
@@ -1,0 +1,5 @@
+class AddOrderToProjectModels < ActiveRecord::Migration[7.0]
+  def change
+    add_column :core_data_connector_project_models, :order, :integer, default: 0, null: false
+  end
+end

--- a/db/migrate/20240717155610_add_order_to_project_model_relationships.rb
+++ b/db/migrate/20240717155610_add_order_to_project_model_relationships.rb
@@ -1,0 +1,5 @@
+class AddOrderToProjectModelRelationships < ActiveRecord::Migration[7.0]
+  def change
+    add_column :core_data_connector_project_model_relationships, :order, :integer, default: 0, null: false
+  end
+end


### PR DESCRIPTION
This pull request adds the ability to add an `order` attribute to `project_models` and `project_models_relationships` records. See screenshots in the `core-data-cloud` [PR](https://github.com/performant-software/core-data-cloud/pull/245).