### PR TITLE
CDC #248 - Geo-reference layers

### DIFF
--- a/app/models/core_data_connector/place_layer.rb
+++ b/app/models/core_data_connector/place_layer.rb
@@ -1,6 +1,6 @@
 module CoreDataConnector
   class PlaceLayer < ApplicationRecord
-    LAYER_TYPES = %w(geojson raster)
+    LAYER_TYPES = %w(geojson raster georeference)
 
     # Relationships
     belongs_to :place
@@ -8,7 +8,7 @@ module CoreDataConnector
     # Validations
     validates :name, presence: true
     validates :layer_type, inclusion: { in: LAYER_TYPES }
-    validates :geometry, presence: true, if: -> { url.blank? }
-    validates :url, presence: true, if: -> { geometry.blank? }
+    validates :content, presence: true, if: -> { url.blank? }
+    validates :url, presence: true, if: -> { content.blank? }
   end
 end

--- a/app/policies/core_data_connector/place_policy.rb
+++ b/app/policies/core_data_connector/place_policy.rb
@@ -20,7 +20,7 @@ module CoreDataConnector
         user_defined: {},
         place_names_attributes: [:id, :name, :primary, :_destroy],
         place_geometry_attributes: [:id, :geometry_json, :_destroy],
-        place_layers_attributes: [:id, :name, :layer_type, :url, :geometry, :_destroy]
+        place_layers_attributes: [:id, :name, :layer_type, :url, :content, :_destroy]
       ]
     end
 

--- a/app/serializers/core_data_connector/place_layers_serializer.rb
+++ b/app/serializers/core_data_connector/place_layers_serializer.rb
@@ -1,6 +1,6 @@
 module CoreDataConnector
   class PlaceLayersSerializer < BaseSerializer
-    index_attributes :id, :name, :layer_type, :geometry, :url
-    show_attributes :id, :name, :layer_type, :geometry, :url
+    index_attributes :id, :name, :layer_type, :content, :url
+    show_attributes :id, :name, :layer_type, :content, :url
   end
 end

--- a/app/serializers/core_data_connector/public/v0/linked_places/place_layers_serializer.rb
+++ b/app/serializers/core_data_connector/public/v0/linked_places/place_layers_serializer.rb
@@ -4,7 +4,10 @@ module CoreDataConnector
       module LinkedPlaces
         class PlaceLayersSerializer < BaseSerializer
           index_attributes :id, :name, :layer_type, :content, :url
+          index_attributes(:geometry) { |layer| layer.content }
+
           show_attributes :id, :name, :layer_type, :content, :url
+          show_attributes(:geometry) { |layer| layer.content }
         end
       end
     end

--- a/app/serializers/core_data_connector/public/v0/linked_places/place_layers_serializer.rb
+++ b/app/serializers/core_data_connector/public/v0/linked_places/place_layers_serializer.rb
@@ -3,8 +3,8 @@ module CoreDataConnector
     module V0
       module LinkedPlaces
         class PlaceLayersSerializer < BaseSerializer
-          index_attributes :id, :name, :layer_type, :geometry, :url
-          show_attributes :id, :name, :layer_type, :geometry, :url
+          index_attributes :id, :name, :layer_type, :content, :url
+          show_attributes :id, :name, :layer_type, :content, :url
         end
       end
     end

--- a/app/serializers/core_data_connector/public/v1/place_layers_serializer.rb
+++ b/app/serializers/core_data_connector/public/v1/place_layers_serializer.rb
@@ -2,8 +2,11 @@ module CoreDataConnector
   module Public
     module V1
       class PlaceLayersSerializer < BaseSerializer
-        index_attributes :id, :name, :layer_type, :geometry, :url
-        show_attributes :id, :name, :layer_type, :geometry, :url
+        index_attributes :id, :name, :layer_type, :content, :url
+        index_attributes(:geometry) { |layer| layer.content }
+
+        show_attributes :id, :name, :layer_type, :content, :url
+        show_attributes(:geometry) { |layer| layer.content }
       end
     end
   end

--- a/db/migrate/20240722113555_rename_place_layers_geometry_to_content.rb
+++ b/db/migrate/20240722113555_rename_place_layers_geometry_to_content.rb
@@ -1,0 +1,5 @@
+class RenamePlaceLayersGeometryToContent < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :core_data_connector_place_layers, :geometry, :content
+  end
+end


### PR DESCRIPTION
This pull request renames the `geometry` column on `core_data_connector_place_layers` to `content` to support Geo-referenced images (IIIF manifest) content. We still include the `geometry` attribute in both `v0` and `v1` of the public API to maintain backwards compatibility.

See screenshots on `core-data-cloud` [PR](https://github.com/performant-software/core-data-cloud/pull/250).