### PR TITLE
CDC #269 - Events Filters

### DIFF
--- a/app/controllers/core_data_connector/public/v1/events_controller.rb
+++ b/app/controllers/core_data_connector/public/v1/events_controller.rb
@@ -15,6 +15,36 @@ module CoreDataConnector
 
         # Search attributes
         search_attributes :name, :description
+
+        protected
+
+        def apply_filters(query)
+          query = super
+
+          query = filter_min_year(query)
+
+          query = filter_max_year(query)
+
+          query
+        end
+
+        private
+
+        def filter_max_year(query)
+          return query unless params[:max_year].present?
+
+          date = Date.new(params[:max_year].to_i, 12, 31)
+
+          query.where('( start_date.start_date <= ? OR end_date.start_date <= ? )', date, date)
+        end
+
+        def filter_min_year(query)
+          return query unless params[:min_year].present?
+
+          date = Date.new(params[:min_year].to_i, 1, 1)
+
+          query.where('( start_date.end_date >= ? OR end_date.end_date >= ? )', date, date)
+        end
       end
     end
   end

--- a/app/controllers/core_data_connector/public/v1/manifests_controller.rb
+++ b/app/controllers/core_data_connector/public/v1/manifests_controller.rb
@@ -76,22 +76,6 @@ module CoreDataConnector
 
         private
 
-        # def identifier
-        #   route_name = current_record.class.model_name.route_key.singularize
-        #   method_name = "public_v1_#{route_name}_manifests_path"
-        #
-        #   router_helpers = Engine.routes.url_helpers
-        #   pathname = router_helpers.send(method_name.to_sym, current_record.uuid)
-        #
-        #   url = "#{ENV['HOSTNAME']}#{pathname}"
-        #
-        #   parameters = {
-        #     project_ids: params[:project_ids]
-        #   }
-        #
-        #   "#{url}?#{parameters.to_query}"
-        # end
-
         def label
           service = Iiif::Manifest.new
           service.find_label(current_record)

--- a/app/controllers/core_data_connector/public/v1/manifests_controller.rb
+++ b/app/controllers/core_data_connector/public/v1/manifests_controller.rb
@@ -43,10 +43,19 @@ module CoreDataConnector
         def build_index_response(items, metadata)
           return {} if items.empty?
 
+          parameters = {
+            project_ids: params[:project_ids]
+          }
+
+          id = Iiif::Manifest.generate_identifier(
+            model_class: current_record.class,
+            uuid: current_record.uuid
+          )
+
           service = TripleEyeEffable::Presentation.new
 
           service.create_collection(
-            id: identifier,
+            id: "#{ENV['HOSTNAME']}/#{id}/#{parameters.to_query}",
             label: label,
             items: items.map{ |i| to_collection_item(i) }
           )
@@ -67,21 +76,21 @@ module CoreDataConnector
 
         private
 
-        def identifier
-          route_name = current_record.class.model_name.route_key.singularize
-          method_name = "public_v1_#{route_name}_manifests_path"
-
-          router_helpers = Engine.routes.url_helpers
-          pathname = router_helpers.send(method_name.to_sym, current_record.uuid)
-
-          url = "#{ENV['HOSTNAME']}#{pathname}"
-
-          parameters = {
-            project_ids: params[:project_ids]
-          }
-
-          "#{url}?#{parameters.to_query}"
-        end
+        # def identifier
+        #   route_name = current_record.class.model_name.route_key.singularize
+        #   method_name = "public_v1_#{route_name}_manifests_path"
+        #
+        #   router_helpers = Engine.routes.url_helpers
+        #   pathname = router_helpers.send(method_name.to_sym, current_record.uuid)
+        #
+        #   url = "#{ENV['HOSTNAME']}#{pathname}"
+        #
+        #   parameters = {
+        #     project_ids: params[:project_ids]
+        #   }
+        #
+        #   "#{url}?#{parameters.to_query}"
+        # end
 
         def label
           service = Iiif::Manifest.new
@@ -89,8 +98,12 @@ module CoreDataConnector
         end
 
         def to_collection_item(manifest)
+          parameters = {
+            project_ids: params[:project_ids]
+          }
+
           {
-            id: "#{ENV['HOSTNAME']}/#{manifest.identifier}",
+            id: "#{ENV['HOSTNAME']}/#{manifest.identifier}?#{parameters.to_query}",
             type: 'Manifest',
             label: manifest.label,
             item_count: manifest.item_count,


### PR DESCRIPTION
This pull request adds the ability to provide a `min_year` or `max_year` parameter to the `/public/core_data/v1/events` API endpoint. It also updates the search service to include a `event_range_facet` attribute for each record.

It also fixes a bug in the IIIF Collection generation, where the `Manifest` items were not correctly being given a `v1` URL as the identifier.