### PR TITLE
CDC #277 - Import Error

### DIFF
--- a/app/controllers/core_data_connector/application_controller.rb
+++ b/app/controllers/core_data_connector/application_controller.rb
@@ -10,5 +10,11 @@ module CoreDataConnector
     def serializer_class
       "CoreDataConnector::#{"#{controller_name}_serializer".classify}".constantize
     end
+
+    protected
+
+    def log_error(error)
+      Rails.logger.error (["#{self.class} - #{error.class}: #{error.message}", error.backtrace]).join("\n")
+    end
   end
 end

--- a/app/controllers/core_data_connector/projects_controller.rb
+++ b/app/controllers/core_data_connector/projects_controller.rb
@@ -14,8 +14,11 @@ module CoreDataConnector
 
       begin
         project_models.map(&:clear)
-      rescue StandardError => exception
-        errors = [exception]
+      rescue StandardError => error
+        errors = [error]
+
+        # Log the error
+        log_error error
       end
 
       if errors.nil? || errors.empty?
@@ -57,9 +60,12 @@ module CoreDataConnector
         File.open(zip, 'r') do |file|
           send_data file.read, filename: filename, type: 'application/zip', disposition: 'attachment'
         end
-      rescue StandardError => exception
+      rescue StandardError => error
+        # Log the error
+        log_error(error)
+
         # Render a 400 response if an errors occur
-        render json: { errors: [exception] }, status: :bad_request
+        render json: { errors: [error] }, status: :bad_request
       ensure
         # Remove the temporary directory
         FileSystem.remove_directory directory
@@ -85,8 +91,11 @@ module CoreDataConnector
       begin
         service = Configuration.new(project, params[:file])
         service.import_configuration
-      rescue StandardError => exception
-        errors = [exception]
+      rescue StandardError => error
+        errors = [error]
+
+        # Log the error
+        log_error(error)
       end
 
       if errors.nil? || errors.empty?
@@ -108,6 +117,9 @@ module CoreDataConnector
       if errors.nil? || errors.empty?
         render json: { }, status: :ok
       else
+        # Log the error
+        log_error(error)
+
         render json: { errors: errors }, status: :unprocessable_entity
       end
     end

--- a/app/services/core_data_connector/import_analyze/import.rb
+++ b/app/services/core_data_connector/import_analyze/import.rb
@@ -49,7 +49,7 @@ module CoreDataConnector
 
         # Iterate over the data set and remove any already merged rows, adding them to the "merged" attribute
         # for the row of the primary record.
-        relationship_data = data[FILE_RELATIONSHIPS][:data]
+        relationship_data = data.dig(FILE_RELATIONSHIPS, :data)
 
         data.keys.each do |filename|
           rows = data[filename][:data]
@@ -84,7 +84,7 @@ module CoreDataConnector
         end
 
         # De-duplicate relationships
-        relationship_data.each do |row|
+        relationship_data&.each do |row|
           next if row[:keep].present?
 
           # Find relationship rows where all fields match the current row except the "uuid"
@@ -101,7 +101,7 @@ module CoreDataConnector
         end
 
         # Remove any rows not marked with "keep"
-        relationship_data.delete_if { |r| r[:keep] != true }
+        relationship_data.delete_if { |r| r[:keep] != true } if relationship_data.present?
 
         data
       end


### PR DESCRIPTION
This pull request fixes a bug in the Import From FairCopy.cloud workflow when trying to import a document as a non-admin user. When a non-admin user initiates the import, there is an authorization check to ensure that the user is only importing records into project(s) for which they have access. We do this authorization check at two different points in the workflow:

1. After loading the CSV files from FairCopy.cloud, prior to presenting the user with the lists of records being imported
2. Before sending the CSV files to the server to be imported into Core Data

In each case, the data is formatted slightly differently, however, the authorization check was assuming the same format. The solution here was to split the checks out into `has_analyze_access?` and `has_import_access?` in the `policy.rb` class.

Additionally, this pull request also adds logging to transactional actions in the import workflow to capture any errors that may occur.