### PR TITLE
CDC #298 - Index error

### DIFF
--- a/app/services/core_data_connector/search/person.rb
+++ b/app/services/core_data_connector/search/person.rb
@@ -14,8 +14,11 @@ module CoreDataConnector
         include Base
 
         # Search attributes
-        search_attribute :name, facet: true
         search_attribute :biography
+
+        search_attribute(:name, facet: true) do
+          create_name primary_name
+        end
 
         search_attribute(:names, facet: true) do
           person_names.map { |n| create_name(n) }


### PR DESCRIPTION
This pull request fixes a bug indexing `people` records into Typesense. The `/search/person.rb` class was using an attribute called `name`, which does not exist on the `person` model. We'll instead use a block to generate the full name for the `person`.