### PR TITLE
CDC #300 - Import Duplicates

### DIFF
--- a/app/controllers/concerns/core_data_connector/mergeable_controller.rb
+++ b/app/controllers/concerns/core_data_connector/mergeable_controller.rb
@@ -10,14 +10,14 @@ module CoreDataConnector
         item = item_class.new(prepare_params)
         authorize_create item
 
-        preloads = [
-          :project_model,
-          relationships: [:related_record, project_model_relationship: :user_defined_fields],
-          related_relationships: [:primary_record, project_model_relationship: :user_defined_fields],
-        ]
+        # preloads = [
+        #   :project_model,
+        #   relationships: [:related_record, project_model_relationship: :user_defined_fields],
+        #   related_relationships: [:primary_record, project_model_relationship: :user_defined_fields],
+        # ]
 
         items = item_class
-                  .preload(preloads)
+                  .preload(ImportAnalyze::Helper::PRELOADS)
                   .where(id: params[:ids])
 
         authorize_destroy items

--- a/app/controllers/concerns/core_data_connector/mergeable_controller.rb
+++ b/app/controllers/concerns/core_data_connector/mergeable_controller.rb
@@ -3,18 +3,14 @@ module CoreDataConnector
     extend ActiveSupport::Concern
 
     included do
+      # Search methods
+      search_methods :search_merged_uuid
 
       def merge
         render json: { errors: [I18n.t('errors.mergeable.ids')] }, status: :bad_request and return unless params[:ids].present?
 
         item = item_class.new(prepare_params)
         authorize_create item
-
-        # preloads = [
-        #   :project_model,
-        #   relationships: [:related_record, project_model_relationship: :user_defined_fields],
-        #   related_relationships: [:primary_record, project_model_relationship: :user_defined_fields],
-        # ]
 
         items = item_class
                   .preload(ImportAnalyze::Helper::PRELOADS)
@@ -49,6 +45,25 @@ module CoreDataConnector
         items.each do |item|
           policy = Pundit.policy!(current_user, item)
           policy.destroy?
+        end
+      end
+
+      def search_merged_uuid(query)
+        return query unless params[:search].present?
+
+        uuid_query = item_class.where(
+          RecordMerge
+            .where(RecordMerge.arel_table[:mergeable_id].eq(item_class.arel_table[:id]))
+            .where(mergeable_type: item_class.to_s)
+            .where(merged_uuid: params[:search])
+            .arel
+            .exists
+        )
+
+        if query == item_class.all
+          query.merge(uuid_query)
+        else
+          query.or(uuid_query)
         end
       end
     end

--- a/app/controllers/core_data_connector/items_controller.rb
+++ b/app/controllers/core_data_connector/items_controller.rb
@@ -75,7 +75,11 @@ module CoreDataConnector
 
         # Run the importer with the new ZIP file
         zip_importer = Import::ZipHelper.new
-        ok, errors = zip_importer.import_zip(zip_filepath)
+        ok, errors, import_id = zip_importer.import_zip(zip_filepath)
+
+        # Remove duplicates for any marked files
+        service.remove_duplicates(params[:files], import_id)
+        errors.each { |e| log_error(e) } unless errors.empty?
 
         # Remove the ZIP file directory
         directory = File.dirname(zip_filepath)

--- a/app/controllers/core_data_connector/record_merges_controller.rb
+++ b/app/controllers/core_data_connector/record_merges_controller.rb
@@ -1,0 +1,33 @@
+module CoreDataConnector
+  class RecordMergesController < ApplicationController
+    # Search attributes
+    search_attributes :merged_uuid
+
+    # Actions
+    before_action :bypass_authorization, only: :index
+    before_action :authorize_index, only: :index
+
+    protected
+
+    def base_query
+      return RecordMerge.none unless params[:mergeable_id].present? && params[:mergeable_type].present?
+
+      RecordMerge.where(
+        mergeable_id: params[:mergeable_id],
+        mergeable_type: params[:mergeable_type]
+      )
+    end
+
+    private
+
+    def authorize_index
+      return unless params[:mergeable_id].present? && params[:mergeable_type].present?
+
+      klass = params[:mergeable_type].constantize
+      item = klass.find(params[:mergeable_id])
+
+      policy_class = "#{item.class.to_s}Policy".constantize
+      authorize item, :show?, policy_class: policy_class
+    end
+  end
+end

--- a/app/models/core_data_connector/event.rb
+++ b/app/models/core_data_connector/event.rb
@@ -4,6 +4,7 @@ module CoreDataConnector
     include Export::Event
     include FuzzyDates::FuzzyDateable
     include Identifiable
+    include ImportAnalyze::Event
     include Manifestable
     include Mergeable
     include Ownable

--- a/app/models/core_data_connector/instance.rb
+++ b/app/models/core_data_connector/instance.rb
@@ -3,6 +3,7 @@ module CoreDataConnector
     # Includes
     include Export::Instance
     include Identifiable
+    include ImportAnalyze::Instance
     include Manifestable
     include Mergeable
     include Nameable

--- a/app/models/core_data_connector/item.rb
+++ b/app/models/core_data_connector/item.rb
@@ -4,6 +4,7 @@ module CoreDataConnector
     include Export::Item
     include FccImportable
     include Identifiable
+    include ImportAnalyze::Item
     include Manifestable
     include Mergeable
     include Nameable

--- a/app/models/core_data_connector/organization.rb
+++ b/app/models/core_data_connector/organization.rb
@@ -3,6 +3,7 @@ module CoreDataConnector
     # Includes
     include Export::Organization
     include Identifiable
+    include ImportAnalyze::Organization
     include Manifestable
     include Mergeable
     include Nameable

--- a/app/models/core_data_connector/person.rb
+++ b/app/models/core_data_connector/person.rb
@@ -3,6 +3,7 @@ module CoreDataConnector
     # Includes
     include Export::Person
     include Identifiable
+    include ImportAnalyze::Person
     include Manifestable
     include Mergeable
     include Nameable

--- a/app/models/core_data_connector/place.rb
+++ b/app/models/core_data_connector/place.rb
@@ -5,6 +5,7 @@ module CoreDataConnector
     # Includes
     include Export::Place
     include Identifiable
+    include ImportAnalyze::Place
     include Manifestable
     include Mergeable
     include Nameable

--- a/app/models/core_data_connector/taxonomy.rb
+++ b/app/models/core_data_connector/taxonomy.rb
@@ -3,6 +3,7 @@ module CoreDataConnector
     # Includes
     include Export::Taxonomy
     include Identifiable
+    include ImportAnalyze::Taxonomy
     include Manifestable
     include Mergeable
     include Ownable

--- a/app/models/core_data_connector/work.rb
+++ b/app/models/core_data_connector/work.rb
@@ -3,6 +3,7 @@ module CoreDataConnector
     # Includes
     include Export::Work
     include Identifiable
+    include ImportAnalyze::Work
     include Manifestable
     include Mergeable
     include Nameable

--- a/app/policies/core_data_connector/record_merge_policy.rb
+++ b/app/policies/core_data_connector/record_merge_policy.rb
@@ -1,0 +1,43 @@
+module CoreDataConnector
+  class RecordMergePolicy < BasePolicy
+    attr_reader :current_user, :record_merge, :project_id
+
+    def initialize(current_user, record_merge)
+      @current_user = current_user
+      @record_merge = record_merge
+      @project_id = record_merge&.mergeable&.project_id
+    end
+
+    # A record_merge cannot be created via the API, only through the merge function.
+    def create?
+      false
+    end
+
+    # A user can delete a record_merge if they are an admin user or member of owning the project.
+    def destroy?
+      return true if current_user.admin?
+
+      member?
+    end
+
+    # A record_merge cannot be viewed via the API.
+    def show?
+      false
+    end
+
+    # A record_merge cannot be updated via the API.
+    def update?
+      false
+    end
+
+    private
+
+    # Returns true if the current user has a `user_projects` record for the web identifier's project.
+    def member?
+      current_user
+        .user_projects
+        .where(project_id: project_id)
+        .exists?
+    end
+  end
+end

--- a/app/serializers/core_data_connector/record_merges_serializer.rb
+++ b/app/serializers/core_data_connector/record_merges_serializer.rb
@@ -1,0 +1,6 @@
+module CoreDataConnector
+  class RecordMergesSerializer < BaseSerializer
+    index_attributes :id, :merged_uuid, :created_at
+    show_attributes :id, :merged_uuid, :created_at
+  end
+end

--- a/app/services/core_data_connector/import/events.rb
+++ b/app/services/core_data_connector/import/events.rb
@@ -21,6 +21,7 @@ module CoreDataConnector
                  name = z_events.name,
                  description = z_events.description,
                  user_defined = z_events.user_defined,
+                 import_id = z_events.import_id,
                  updated_at = current_timestamp
             FROM #{table_name} z_events
            WHERE z_events.event_id = events.id
@@ -65,7 +66,8 @@ module CoreDataConnector
             z_event_id, 
             name, 
             description, 
-            user_defined, 
+            user_defined,
+            import_id,
             created_at, 
             updated_at
           )
@@ -74,7 +76,8 @@ module CoreDataConnector
                  z_events.id, 
                  z_events.name, 
                  z_events.description, 
-                 z_events.user_defined, 
+                 z_events.user_defined,
+                 z_events.import_id,
                  current_timestamp, 
                  current_timestamp
             FROM #{table_name} z_events
@@ -153,12 +156,6 @@ module CoreDataConnector
 
         execute <<-SQL.squish
           UPDATE #{table_name} z_events
-             SET uuid = gen_random_uuid()
-           WHERE z_events.uuid IS NULL
-        SQL
-
-        execute <<-SQL.squish
-          UPDATE #{table_name} z_events
              SET event_id = events.id
             FROM core_data_connector_events events
            WHERE events.uuid = z_events.uuid
@@ -230,6 +227,9 @@ module CoreDataConnector
          }, {
            name: 'end_date_end_date',
            type: 'DATE'
+         }, {
+           name: 'import_id',
+           type: 'UUID'
          }]
       end
 

--- a/app/services/core_data_connector/import/importer.rb
+++ b/app/services/core_data_connector/import/importer.rb
@@ -1,7 +1,7 @@
 module CoreDataConnector
   module Import
     class Importer
-      attr_reader :importers
+      attr_reader :importers, :import_id
 
       IMPORTERS = [{
         importer_class: Events,
@@ -45,12 +45,13 @@ module CoreDataConnector
         filepath = "#{directory}/#{filename}"
 
         if File.exist? filepath
-          @importers << klass.new(filepath)
+          @importers << klass.new(filepath, import_id)
         end
       end
 
       def initialize(directory)
         @importers = []
+        @import_id = SecureRandom.uuid
 
         IMPORTERS.each do |importer|
           populate_importer(importer, directory)
@@ -80,6 +81,8 @@ module CoreDataConnector
         importers.each do |importer|
           importer.cleanup
         end
+
+        import_id
       end
     end
   end

--- a/app/services/core_data_connector/import/organizations.rb
+++ b/app/services/core_data_connector/import/organizations.rb
@@ -22,6 +22,7 @@ module CoreDataConnector
              SET z_organization_id = z_organizations.id,
                  description = z_organizations.description,
                  user_defined = z_organizations.user_defined,
+                 import_id = z_organizations.import_id,
                  updated_at = current_timestamp
             FROM #{table_name} z_organizations
            WHERE z_organizations.organization_id = organizations.id
@@ -45,15 +46,17 @@ module CoreDataConnector
             project_model_id, uuid, 
             z_organization_id, 
             description, 
-            user_defined, 
+            user_defined,
+            import_id,
             created_at, 
             updated_at
-            )
+          )
           SELECT z_organizations.project_model_id, 
                  z_organizations.uuid, 
                  z_organizations.id, 
                  z_organizations.description, 
                  z_organizations.user_defined, 
+                 z_organizations.import_id,
                  current_timestamp, 
                  current_timestamp
             FROM #{table_name} z_organizations
@@ -81,12 +84,6 @@ module CoreDataConnector
 
       def transform
         super
-
-        execute <<-SQL.squish
-          UPDATE #{table_name} z_organizations
-             SET uuid = gen_random_uuid()
-           WHERE z_organizations.uuid IS NULL
-        SQL
 
         execute <<-SQL.squish
           UPDATE #{table_name} z_organizations
@@ -121,6 +118,9 @@ module CoreDataConnector
          }, {
            name: 'user_defined',
            type: 'JSONB'
+         }, {
+           name: 'import_id',
+           type: 'UUID'
          }]
       end
 

--- a/app/services/core_data_connector/import/people.rb
+++ b/app/services/core_data_connector/import/people.rb
@@ -22,6 +22,7 @@ module CoreDataConnector
                SET z_person_id = z_people.id,
                    biography = z_people.biography,
                    user_defined = z_people.user_defined,
+                   import_id = z_people.import_id,
                    updated_at = current_timestamp
               FROM #{table_name} z_people
              WHERE z_people.person_id = people.id
@@ -43,8 +44,24 @@ module CoreDataConnector
           
           insert_people AS (
 
-          INSERT INTO core_data_connector_people (project_model_id, uuid, z_person_id, biography, user_defined, created_at, updated_at)
-          SELECT z_people.project_model_id, z_people.uuid, z_people.id, z_people.biography, z_people.user_defined, current_timestamp, current_timestamp
+          INSERT INTO core_data_connector_people (
+            project_model_id, 
+            uuid, 
+            z_person_id, 
+            biography, 
+            user_defined,
+            import_id,
+            created_at, 
+            updated_at
+          )
+          SELECT z_people.project_model_id, 
+                 z_people.uuid, 
+                 z_people.id, 
+                 z_people.biography, 
+                 z_people.user_defined,
+                 z_people.import_id,
+                 current_timestamp, 
+                 current_timestamp
             FROM #{table_name} z_people
            WHERE z_people.person_id IS NULL
           RETURNING id AS person_id, z_person_id
@@ -70,12 +87,6 @@ module CoreDataConnector
 
       def transform
         super
-
-        execute <<-SQL.squish
-          UPDATE #{table_name} z_people
-             SET uuid = gen_random_uuid()
-           WHERE z_people.uuid IS NULL
-        SQL
 
         execute <<-SQL.squish
           UPDATE #{table_name} z_people
@@ -118,6 +129,9 @@ module CoreDataConnector
          }, {
            name: 'user_defined',
            type: 'JSONB'
+         }, {
+           name: 'import_id',
+           type: 'UUID'
          }]
       end
 

--- a/app/services/core_data_connector/import/relationships.rb
+++ b/app/services/core_data_connector/import/relationships.rb
@@ -17,6 +17,7 @@ module CoreDataConnector
           UPDATE core_data_connector_relationships relationships
              SET z_relationship_id = z_relationships.id,
                  user_defined = z_relationships.user_defined,
+                 import_id = z_relationships.import_id,
                  updated_at = current_timestamp
             FROM #{table_name} z_relationships
            WHERE z_relationships.relationship_id = relationships.id
@@ -36,6 +37,7 @@ module CoreDataConnector
             related_record_id,
             related_record_type,
             user_defined,
+            import_id,
             created_at,
             updated_at
           )
@@ -47,6 +49,7 @@ module CoreDataConnector
                  z_relationships.related_record_id,
                  z_relationships.related_record_type,
                  z_relationships.user_defined,
+                 z_relationships.import_id,
                  current_timestamp,
                  current_timestamp
             FROM #{table_name} z_relationships
@@ -68,12 +71,6 @@ module CoreDataConnector
 
       def transform
         super
-
-        execute <<-SQL.squish
-          UPDATE #{table_name} z_relationships
-             SET uuid = gen_random_uuid()
-           WHERE z_relationships.uuid IS NULL
-        SQL
 
         execute <<-SQL.squish
           WITH all_related_types AS (
@@ -185,6 +182,9 @@ module CoreDataConnector
          }, {
            name: 'user_defined',
            type: 'JSONB'
+         }, {
+           name: 'import_id',
+           type: 'UUID'
          }]
       end
 

--- a/app/services/core_data_connector/import/taxonomies.rb
+++ b/app/services/core_data_connector/import/taxonomies.rb
@@ -17,6 +17,7 @@ module CoreDataConnector
           UPDATE core_data_connector_taxonomies taxonomies
             SET  z_taxonomy_id = z_taxonomies.id,
                  name = z_taxonomies.name,
+                 import_id = z_taxonomies.import_id,
                  updated_at = current_timestamp
            FROM #{table_name} z_taxonomies
           WHERE z_taxonomies.taxonomy_id = taxonomies.id
@@ -32,17 +33,19 @@ module CoreDataConnector
             uuid,
             z_taxonomy_id,
             name,
+            import_id,
             created_at, 
             updated_at
-            )
+          )
           SELECT z_taxonomies.project_model_id,
                  z_taxonomies.uuid,
                  z_taxonomies.id,
                  z_taxonomies.name,
+                 z_taxonomies.import_id,
                  current_timestamp,
                  current_timestamp
-          FROM   #{table_name} z_taxonomies
-          WHERE  z_taxonomies.taxonomy_id IS NULL
+            FROM #{table_name} z_taxonomies
+           WHERE z_taxonomies.taxonomy_id IS NULL
           RETURNING id AS taxonomy_id, z_taxonomy_id
 
           )
@@ -56,12 +59,6 @@ module CoreDataConnector
 
       def transform
         super
-
-        execute <<-SQL.squish
-          UPDATE #{table_name} z_taxonomies
-             SET uuid = gen_random_uuid()
-           WHERE z_taxonomies.uuid IS NULL
-        SQL
 
         execute <<-SQL.squish
           UPDATE #{table_name} z_taxonomies
@@ -89,6 +86,9 @@ module CoreDataConnector
         }, {
           name: 'taxonomy_id',
           type: 'INTEGER'
+        }, {
+          name: 'import_id',
+          type: 'UUID'
         }]
       end
 

--- a/app/services/core_data_connector/import/works.rb
+++ b/app/services/core_data_connector/import/works.rb
@@ -21,6 +21,7 @@ module CoreDataConnector
           UPDATE core_data_connector_works works
              SET z_work_id = z_works.id,
                  user_defined = z_works.user_defined,
+                 import_id = z_works.import_id,
                  updated_at = current_timestamp
             FROM #{table_name} z_works
            WHERE z_works.work_id = works.id
@@ -40,23 +41,25 @@ module CoreDataConnector
 
         insert_works AS (
 
-          INSERT INTO core_data_connector_works (
-            project_model_id,
-            uuid,
-            z_work_id,
-            user_defined,
-            created_at,
-            updated_at
-          )
-          SELECT z_works.project_model_id,
-                 z_works.uuid,
-                 z_works.id,
-                 z_works.user_defined,
-                 current_timestamp,
-                 current_timestamp
-            FROM #{table_name} z_works
-            WHERE z_works.work_id IS NULL
-          RETURNING id AS work_id, z_work_id
+        INSERT INTO core_data_connector_works (
+          project_model_id,
+          uuid,
+          z_work_id,
+          user_defined,
+          import_id,
+          created_at,
+          updated_at
+        )
+        SELECT z_works.project_model_id,
+               z_works.uuid,
+               z_works.id,
+               z_works.user_defined,
+               z_works.import_id,
+               current_timestamp,
+               current_timestamp
+          FROM #{table_name} z_works
+         WHERE z_works.work_id IS NULL
+        RETURNING id AS work_id, z_work_id
 
         )
 
@@ -81,12 +84,6 @@ module CoreDataConnector
 
       def transform
         super
-
-        execute <<-SQL.squish
-          UPDATE #{table_name} z_works
-             SET uuid = gen_random_uuid()
-           WHERE z_works.uuid IS NULL
-        SQL
 
         execute <<-SQL.squish
           UPDATE #{table_name} z_works
@@ -117,6 +114,9 @@ module CoreDataConnector
         }, {
           name: 'user_defined',
           type: 'JSONB'
+        }, {
+          name: 'import_id',
+          type: 'UUID'
         }]
       end
 

--- a/app/services/core_data_connector/import/zip_helper.rb
+++ b/app/services/core_data_connector/import/zip_helper.rb
@@ -24,17 +24,19 @@ module CoreDataConnector
               zipfile.extract(entry, File.join(destination, entry.name))
             end
           end
+
+          import_id = nil
       
           # Create a new importer with the temp directory and run it
           ActiveRecord::Base.transaction do
             importer = CoreDataConnector::Import::Importer.new(destination)
-            importer.run
+            import_id = importer.run
           end
       
           # Remove the temporary directory
           FileUtils.rm_rf(destination)
       
-          return true, []
+          return true, [], import_id
         rescue ActiveRecord::RecordInvalid => exception
           return false, [exception]
         rescue StandardError => exception

--- a/app/services/core_data_connector/import_analyze/base.rb
+++ b/app/services/core_data_connector/import_analyze/base.rb
@@ -1,0 +1,35 @@
+module CoreDataConnector
+  module ImportAnalyze
+    module Base
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def base_query
+          all
+        end
+
+        def group_by_columns
+          # Implemented in sub-classes
+        end
+
+        def find_duplicates(import_id)
+          primary_key = "#{table_name}.id"
+
+          select_columns = [
+            *group_by_columns,
+            "MIN(#{primary_key}) AS primary_id",
+            "ARRAY_REMOVE(ARRAY_AGG(#{primary_key}), MIN(#{primary_key})) AS duplicate_ids"
+          ]
+
+          base_query
+            .select(select_columns)
+            .where(import_id: import_id)
+            # .where(project_model_id: 34)
+            .group(group_by_columns)
+            .having('COUNT(*) > 1')
+        end
+
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import_analyze/base.rb
+++ b/app/services/core_data_connector/import_analyze/base.rb
@@ -24,7 +24,6 @@ module CoreDataConnector
           base_query
             .select(select_columns)
             .where(import_id: import_id)
-            # .where(project_model_id: 34)
             .group(group_by_columns)
             .having('COUNT(*) > 1')
         end

--- a/app/services/core_data_connector/import_analyze/event.rb
+++ b/app/services/core_data_connector/import_analyze/event.rb
@@ -1,0 +1,20 @@
+module CoreDataConnector
+  module ImportAnalyze
+    module Event
+      extend ActiveSupport::Concern
+
+      # Includes
+      include Base
+
+      class_methods do
+        def base_query
+          joins(:primary_name)
+        end
+
+        def group_by_columns
+          [:name]
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import_analyze/event.rb
+++ b/app/services/core_data_connector/import_analyze/event.rb
@@ -7,10 +7,6 @@ module CoreDataConnector
       include Base
 
       class_methods do
-        def base_query
-          joins(:primary_name)
-        end
-
         def group_by_columns
           [:name]
         end

--- a/app/services/core_data_connector/import_analyze/helper.rb
+++ b/app/services/core_data_connector/import_analyze/helper.rb
@@ -4,6 +4,12 @@ module CoreDataConnector
 
       PREFIX_USER_DEFINED = 'udf_'
 
+      PRELOADS = [
+        :project_model,
+        relationships: [:related_record, project_model_relationship: :user_defined_fields],
+        related_relationships: [:primary_record, project_model_relationship: :user_defined_fields],
+      ]
+
       def self.column_name_to_uuid(column_name)
         column_name.gsub(PREFIX_USER_DEFINED, '').gsub('_', '-')
       end

--- a/app/services/core_data_connector/import_analyze/import.rb
+++ b/app/services/core_data_connector/import_analyze/import.rb
@@ -84,12 +84,12 @@ module CoreDataConnector
         end
 
         # De-duplicate relationships
-        relationship_data&.each do |row|
+        relationship_data&.each.with_index do |row, i|
           next if row[:keep].present?
 
-          # Find relationship rows where all fields match the current row except the "uuid"
+          # Find relationship rows where all fields match the current row except the index
           relationship = row[:import].except(:uuid)
-          duplicates = relationship_data.select { |r| r[:import][:uuid] != row[:import][:uuid] && r[:import].except(:uuid) == relationship }
+          duplicates = relationship_data.select.with_index { |r, j|  i != j && r[:import].except(:uuid) == relationship }
 
           # Keep row with an existing record in the database, or the first. Mark all other for delete.
           all = [row, *duplicates]

--- a/app/services/core_data_connector/import_analyze/instance.rb
+++ b/app/services/core_data_connector/import_analyze/instance.rb
@@ -1,0 +1,20 @@
+module CoreDataConnector
+  module ImportAnalyze
+    module Instance
+      extend ActiveSupport::Concern
+
+      # Includes
+      include Base
+
+      class_methods do
+        def base_query
+          joins(:primary_name)
+        end
+
+        def group_by_columns
+          [:name]
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import_analyze/item.rb
+++ b/app/services/core_data_connector/import_analyze/item.rb
@@ -1,0 +1,20 @@
+module CoreDataConnector
+  module ImportAnalyze
+    module Item
+      extend ActiveSupport::Concern
+
+      # Includes
+      include Base
+
+      class_methods do
+        def base_query
+          joins(:primary_name)
+        end
+
+        def group_by_columns
+          [:name]
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import_analyze/organization.rb
+++ b/app/services/core_data_connector/import_analyze/organization.rb
@@ -1,0 +1,20 @@
+module CoreDataConnector
+  module ImportAnalyze
+    module Organization
+      extend ActiveSupport::Concern
+
+      # Includes
+      include Base
+
+      class_methods do
+        def base_query
+          joins(:primary_name)
+        end
+
+        def group_by_columns
+          [:name]
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import_analyze/person.rb
+++ b/app/services/core_data_connector/import_analyze/person.rb
@@ -1,0 +1,20 @@
+module CoreDataConnector
+  module ImportAnalyze
+    module Person
+      extend ActiveSupport::Concern
+
+      # Includes
+      include Base
+
+      class_methods do
+        def base_query
+          joins(:primary_name)
+        end
+
+        def group_by_columns
+          [:last_name, :first_name]
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import_analyze/place.rb
+++ b/app/services/core_data_connector/import_analyze/place.rb
@@ -1,0 +1,20 @@
+module CoreDataConnector
+  module ImportAnalyze
+    module Place
+      extend ActiveSupport::Concern
+
+      # Includes
+      include Base
+
+      class_methods do
+        def base_query
+          joins(:primary_name)
+        end
+
+        def group_by_columns
+          [:name]
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import_analyze/taxonomy.rb
+++ b/app/services/core_data_connector/import_analyze/taxonomy.rb
@@ -1,0 +1,16 @@
+module CoreDataConnector
+  module ImportAnalyze
+    module Taxonomy
+      extend ActiveSupport::Concern
+
+      # Includes
+      include Base
+
+      class_methods do
+        def group_by_columns
+          [:name]
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import_analyze/work.rb
+++ b/app/services/core_data_connector/import_analyze/work.rb
@@ -1,0 +1,20 @@
+module CoreDataConnector
+  module ImportAnalyze
+    module Work
+      extend ActiveSupport::Concern
+
+      # Includes
+      include Base
+
+      class_methods do
+        def base_query
+          joins(:primary_name)
+        end
+
+        def group_by_columns
+          [:name]
+        end
+      end
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,11 +1,89 @@
 en:
 
   authorization:
+    core_data_connector/event_policy:
+      create?: "You do not have permission to create an event."
+      delete?: "You do not have permission to delete this event."
+      import?: "You do not have permission to import data into this event."
+      show?: "You do not have permission to view this event."
+      update?: "You do not have permission to update this event."
+
+    core_data_connector/instance_policy:
+      create?: "You do not have permission to create an instance."
+      delete?: "You do not have permission to delete this instance."
+      import?: "You do not have permission to import data into this instance."
+      show?: "You do not have permission to view this instance."
+      update?: "You do not have permission to update this instance."
+
+    core_data_connector/item_policy:
+      create?: "You do not have permission to create an item."
+      delete?: "You do not have permission to delete this item."
+      import?: "You do not have permission to import data into this item."
+      show?: "You do not have permission to view this item."
+      update?: "You do not have permission to update this item."
+
+    core_data_connector/media_content_policy:
+      create?: "You do not have permission to create a media_content."
+      delete?: "You do not have permission to delete this media_content."
+      import?: "You do not have permission to import data into this media_content."
+      show?: "You do not have permission to view this media_content."
+      update?: "You do not have permission to update this media_content."
+
+    core_data_connector/organization_policy:
+      create?: "You do not have permission to create an organization."
+      delete?: "You do not have permission to delete this organization."
+      import?: "You do not have permission to import data into this organization."
+      show?: "You do not have permission to view this organization."
+      update?: "You do not have permission to update this organization."
+
+    core_data_connector/person_policy:
+      create?: "You do not have permission to create a person."
+      delete?: "You do not have permission to delete this person."
+      import?: "You do not have permission to import data into this person."
+      show?: "You do not have permission to view this person."
+      update?: "You do not have permission to update this person."
+
+    core_data_connector/place_policy:
+      create?: "You do not have permission to create a place."
+      delete?: "You do not have permission to delete this place."
+      import?: "You do not have permission to import data into this place."
+      show?: "You do not have permission to view this place."
+      update?: "You do not have permission to update this place."
+
     core_data_connector/project_policy:
       create?: "You do not have permission to create a project."
       delete?: "You do not have permission to delete this project."
       import?: "You do not have permission to import data into this project."
+      show?: "You do not have permission to view this project."
       update?: "You do not have permission to update this project."
+
+    core_data_connector/record_merge_policy:
+      create?: "You do not have permission to create a record merge."
+      delete?: "You do not have permission to delete this record merge."
+      import?: "You do not have permission to import data into this record merge."
+      show?: "You do not have permission to view this record merge."
+      update?: "You do not have permission to update this record merge."
+
+    core_data_connector/relationship_policy:
+      create?: "You do not have permission to create a relationship."
+      delete?: "You do not have permission to delete this relationship."
+      import?: "You do not have permission to import data into this relationship."
+      show?: "You do not have permission to view this relationship."
+      update?: "You do not have permission to update this relationship."
+
+    core_data_connector/taxonomy_policy:
+      create?: "You do not have permission to create a taxonomy."
+      delete?: "You do not have permission to delete this taxonomy."
+      import?: "You do not have permission to import data into this taxonomy."
+      show?: "You do not have permission to view this taxonomy."
+      update?: "You do not have permission to update this taxonomy."
+
+    core_data_connector/work_policy:
+      create?: "You do not have permission to create a work."
+      delete?: "You do not have permission to delete this work."
+      import?: "You do not have permission to import data into this work."
+      show?: "You do not have permission to view this work."
+      update?: "You do not have permission to update this work."
 
   errors:
     http:

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -47,6 +47,8 @@ module Admin
         post :import_data, on: :member
       end
 
+      resources :record_merges, only: [:index, :destroy]
+
       resources :relationships do
         post :upload, on: :collection
       end

--- a/db/migrate/20240927191700_add_import_id_to_models.rb
+++ b/db/migrate/20240927191700_add_import_id_to_models.rb
@@ -1,0 +1,13 @@
+class AddImportIdToModels < ActiveRecord::Migration[7.0]
+  def change
+    add_column :core_data_connector_events, :import_id, :uuid, index: true
+    add_column :core_data_connector_instances, :import_id, :uuid, index: true
+    add_column :core_data_connector_items, :import_id, :uuid, index: true
+    add_column :core_data_connector_organizations, :import_id, :uuid, index: true
+    add_column :core_data_connector_people, :import_id, :uuid, index: true
+    add_column :core_data_connector_places, :import_id, :uuid, index: true
+    add_column :core_data_connector_relationships, :import_id, :uuid, index: true
+    add_column :core_data_connector_taxonomies, :import_id, :uuid, index: true
+    add_column :core_data_connector_works, :import_id, :uuid, index: true
+  end
+end


### PR DESCRIPTION
This pull request updates the schema for "mergeable" models to include and `import_id` column to allow duplicate records in a given import to be merged.

This pull request also adds the `/core_data/record_merges` API endpoint to allow listing and deleting `record_merges` records. It also updates the search for all models to include a search of merged `uuid` values.

Lastly, this pull request fixes a bug in the `/import_analyze/import` service which was creating duplicate relationship records (on subsequent imports) if the `uuid` values were blank and relationships had been removed.

See screenshots in `core-data-cloud` [PR](https://github.com/performant-software/core-data-cloud/pull/309).