### PR TITLE
CDC #308 - Media Upload Error

### DIFF
--- a/app/services/core_data_connector/iiif/manifest.rb
+++ b/app/services/core_data_connector/iiif/manifest.rb
@@ -12,13 +12,11 @@ module CoreDataConnector
       end
 
       def find_label(record)
-        if record.is_a?(Event)
-          record.name
-        elsif record.is_a?(Place)
-          record.name
-        elsif record.is_a?(Instance) || record.is_a?(Item) || record.is_a?(Work)
-          record.primary_name&.name&.name
-        end
+        return record.full_name if record.is_a?(Person)
+
+        return record.name if record.respond_to?(:name)
+
+        nil
       end
 
       def reset_manifests


### PR DESCRIPTION
This pull request fixes a bug with update manifests when a related `media_contents` record is added or removed. The issue was that [#287](https://github.com/performant-software/core-data-cloud/issues/287) changed the way we model source names, but this instance of the old data model was missed.