### PR TITLE
CDC #314 - Remove duplicates scoping to import set

### DIFF
--- a/app/controllers/core_data_connector/items_controller.rb
+++ b/app/controllers/core_data_connector/items_controller.rb
@@ -75,10 +75,10 @@ module CoreDataConnector
 
         # Run the importer with the new ZIP file
         zip_importer = Import::ZipHelper.new
-        ok, errors, import_id = zip_importer.import_zip(zip_filepath)
+        ok, errors = zip_importer.import_zip(zip_filepath)
 
         # Remove duplicates for any marked files
-        service.remove_duplicates(params[:files], import_id)
+        service.remove_duplicates(params[:files], item.project_model.project_id)
         errors.each { |e| log_error(e) } unless errors.empty?
 
         # Remove the ZIP file directory

--- a/app/services/core_data_connector/import_analyze/base.rb
+++ b/app/services/core_data_connector/import_analyze/base.rb
@@ -12,19 +12,25 @@ module CoreDataConnector
           # Implemented in sub-classes
         end
 
-        def find_duplicates(import_id)
+        def find_duplicates(project_id)
           primary_key = "#{table_name}.id"
 
+          group_columns = [
+            :project_model_id,
+            *group_by_columns
+          ]
+
           select_columns = [
-            *group_by_columns,
+            *group_columns,
             "MIN(#{primary_key}) AS primary_id",
             "ARRAY_REMOVE(ARRAY_AGG(#{primary_key}), MIN(#{primary_key})) AS duplicate_ids"
           ]
 
           base_query
             .select(select_columns)
-            .where(import_id: import_id)
-            .group(group_by_columns)
+            .joins(:project_model)
+            .where(project_model: { project_id: project_id })
+            .group(group_columns)
             .having('COUNT(*) > 1')
         end
 

--- a/app/services/core_data_connector/import_analyze/import.rb
+++ b/app/services/core_data_connector/import_analyze/import.rb
@@ -139,14 +139,14 @@ module CoreDataConnector
         zipfile_name
       end
 
-      def remove_duplicates(files, import_id)
+      def remove_duplicates(files, project_id)
         service = Merge::Merger.new
 
         files.keys.each do |filename|
           next unless files[filename][:remove_duplicates].to_s.to_bool
 
           klass = find_class(filename)
-          grouped_duplicates = klass.find_duplicates(import_id)
+          grouped_duplicates = klass.find_duplicates(project_id)
 
           next if grouped_duplicates.empty?
 


### PR DESCRIPTION
This pull request updates the "Remove duplicates" option that exists when importing from FairCopy.cloud to _not_ scope removal of duplicates to the set currently being imported. Duplicates will be merged across the project.

This pull request also adds the `project_model_id` to the grouping of duplicates, as to not merge duplicates across models.