### PR TITLE
Make 'name' string field sortable during typesense schema creation

### DIFF
--- a/lib/typesense/helper.rb
+++ b/lib/typesense/helper.rb
@@ -37,12 +37,8 @@ module Typesense
         }, {
           name: 'name',
           type: 'string',
-          sort: true
-        },{
-          name: 'name_facet',
-          type: 'string',
           sort: true,
-          facet: true
+          optional: true
         }, {
           name: '.*_facet',
           type: 'auto',

--- a/lib/typesense/helper.rb
+++ b/lib/typesense/helper.rb
@@ -35,6 +35,15 @@ module Typesense
           facet: false,
           optional: true
         }, {
+          name: 'name',
+          type: 'string',
+          sort: true
+        },{
+          name: 'name_facet',
+          type: 'string',
+          sort: true,
+          facet: true
+        }, {
           name: '.*_facet',
           type: 'auto',
           facet: true


### PR DESCRIPTION
## In this PR

Per Atlas and performant-software/core-data-cloud#323, allow sorting on the `name` and `name_facet` fields.

## Notes

- This only applies during collection creation at the schema definition stage, so existing collections will need to be recreated or manually modified.
- Consuming clients will need to specify the sort field and direction in order to take advantage of it.