### PR TITLE
CDC #325 - Import error

### DIFF
--- a/app/services/core_data_connector/import_analyze/event.rb
+++ b/app/services/core_data_connector/import_analyze/event.rb
@@ -8,7 +8,7 @@ module CoreDataConnector
 
       class_methods do
         def group_by_columns
-          [:name]
+          [Event.arel_table[:name]]
         end
       end
     end

--- a/app/services/core_data_connector/import_analyze/import.rb
+++ b/app/services/core_data_connector/import_analyze/import.rb
@@ -85,7 +85,7 @@ module CoreDataConnector
         end
 
         # De-duplicate relationships
-        relationship_data&.each.with_index do |row, i|
+        relationship_data&.each&.with_index do |row, i|
           next if row[:keep].present?
 
           # Find relationship rows where all fields match the current row except the index

--- a/app/services/core_data_connector/import_analyze/instance.rb
+++ b/app/services/core_data_connector/import_analyze/instance.rb
@@ -12,7 +12,7 @@ module CoreDataConnector
         end
 
         def group_by_columns
-          [:name]
+          [SourceName.arel_table[:name]]
         end
       end
     end

--- a/app/services/core_data_connector/import_analyze/item.rb
+++ b/app/services/core_data_connector/import_analyze/item.rb
@@ -12,7 +12,7 @@ module CoreDataConnector
         end
 
         def group_by_columns
-          [:name]
+          [SourceName.arel_table[:name]]
         end
       end
     end

--- a/app/services/core_data_connector/import_analyze/organization.rb
+++ b/app/services/core_data_connector/import_analyze/organization.rb
@@ -12,7 +12,7 @@ module CoreDataConnector
         end
 
         def group_by_columns
-          [:name]
+          [OrganizationName.arel_table[:name]]
         end
       end
     end

--- a/app/services/core_data_connector/import_analyze/person.rb
+++ b/app/services/core_data_connector/import_analyze/person.rb
@@ -12,7 +12,7 @@ module CoreDataConnector
         end
 
         def group_by_columns
-          [:last_name, :first_name]
+          [PersonName.arel_table[:last_name], PersonName.arel_table[:first_name]]
         end
       end
     end

--- a/app/services/core_data_connector/import_analyze/place.rb
+++ b/app/services/core_data_connector/import_analyze/place.rb
@@ -12,7 +12,7 @@ module CoreDataConnector
         end
 
         def group_by_columns
-          [:name]
+          [PlaceName.arel_table[:name]]
         end
       end
     end

--- a/app/services/core_data_connector/import_analyze/taxonomy.rb
+++ b/app/services/core_data_connector/import_analyze/taxonomy.rb
@@ -8,7 +8,7 @@ module CoreDataConnector
 
       class_methods do
         def group_by_columns
-          [:name]
+          [Taxonomy.arel_table[:name]]
         end
       end
     end

--- a/app/services/core_data_connector/import_analyze/work.rb
+++ b/app/services/core_data_connector/import_analyze/work.rb
@@ -12,7 +12,7 @@ module CoreDataConnector
         end
 
         def group_by_columns
-          [:name]
+          [SourceName.arel_table[:name]]
         end
       end
     end


### PR DESCRIPTION
This pull request fixes a bug that occurs when importing records from FairCopy.cloud and using the "Remove duplicates" option. We were using simple column names (`name`, `last_name`, etc) in the `GROUP BY` clause of the SQL query that finds the duplicates, which let to the potential for ambiguous column names.

The solution is to use AREL column objects instead, which will ensure that the generated SQL is properly namespaced with the table name prefix.