### PR TITLE
CDC #321 - Import UDFs

### DIFF
--- a/app/services/core_data_connector/export/base.rb
+++ b/app/services/core_data_connector/export/base.rb
@@ -44,7 +44,7 @@ module CoreDataConnector
         private
 
         def add_user_defined_fields(hash, user_defined_fields)
-          return unless user_defined_fields.present? && self.respond_to?(:user_defined)
+          return unless user_defined_fields.present? && self.respond_to?(:user_defined) && self.user_defined.present?
 
           user_defined_fields.each do |user_defined_field|
             key = ImportAnalyze::Helper.uuid_to_column_name(user_defined_field.uuid)

--- a/app/services/core_data_connector/import/base.rb
+++ b/app/services/core_data_connector/import/base.rb
@@ -76,7 +76,7 @@ module CoreDataConnector
 
         execute <<-SQL.squish
           UPDATE #{table_name}
-             SET user_defined = json_strip_nulls(json_build_object(#{expression}))
+             SET user_defined = user_defined || json_strip_nulls(json_build_object(#{expression}))::jsonb
         SQL
 
         # Sets the "Select" and "FuzzyDate" user-defined types to JSONB

--- a/app/services/core_data_connector/import/events.rb
+++ b/app/services/core_data_connector/import/events.rb
@@ -156,7 +156,8 @@ module CoreDataConnector
 
         execute <<-SQL.squish
           UPDATE #{table_name} z_events
-             SET event_id = events.id
+             SET event_id = events.id,
+                 user_defined = events.user_defined
             FROM core_data_connector_events events
            WHERE events.uuid = z_events.uuid
         SQL

--- a/app/services/core_data_connector/import/instances.rb
+++ b/app/services/core_data_connector/import/instances.rb
@@ -87,7 +87,8 @@ module CoreDataConnector
 
         execute <<-SQL.squish
           UPDATE #{table_name} z_instances
-             SET instance_id = instances.id
+             SET instance_id = instances.id,
+                 user_defined = instances.user_defined
             FROM core_data_connector_instances instances
            WHERE instances.uuid = z_instances.uuid
         SQL

--- a/app/services/core_data_connector/import/items.rb
+++ b/app/services/core_data_connector/import/items.rb
@@ -87,7 +87,8 @@ module CoreDataConnector
 
         execute <<-SQL.squish
           UPDATE #{table_name} z_items
-             SET item_id = items.id
+             SET item_id = items.id,
+                 user_defined = items.user_defined
             FROM core_data_connector_items items
            WHERE items.uuid = z_items.uuid
         SQL

--- a/app/services/core_data_connector/import/organizations.rb
+++ b/app/services/core_data_connector/import/organizations.rb
@@ -87,7 +87,8 @@ module CoreDataConnector
 
         execute <<-SQL.squish
           UPDATE #{table_name} z_organizations
-             SET organization_id = organizations.id
+             SET organization_id = organizations.id,
+                 user_defined = organizations.user_defined
             FROM core_data_connector_organizations organizations
            WHERE organizations.uuid = z_organizations.uuid
         SQL

--- a/app/services/core_data_connector/import/people.rb
+++ b/app/services/core_data_connector/import/people.rb
@@ -90,7 +90,8 @@ module CoreDataConnector
 
         execute <<-SQL.squish
           UPDATE #{table_name} z_people
-             SET person_id = people.id
+             SET person_id = people.id,
+                 user_defined = people.user_defined
             FROM core_data_connector_people people
            WHERE people.uuid = z_people.uuid
         SQL

--- a/app/services/core_data_connector/import/places.rb
+++ b/app/services/core_data_connector/import/places.rb
@@ -105,7 +105,8 @@ module CoreDataConnector
 
         execute <<-SQL.squish
           UPDATE #{table_name} z_places
-             SET place_id = places.id
+             SET place_id = places.id,
+                 user_defined = places.user_defined
             FROM core_data_connector_places places
            WHERE places.uuid = z_places.uuid
         SQL

--- a/app/services/core_data_connector/import/relationships.rb
+++ b/app/services/core_data_connector/import/relationships.rb
@@ -121,7 +121,8 @@ module CoreDataConnector
 
         execute <<-SQL.squish
           UPDATE #{table_name} z_relationships
-             SET relationship_id = relationships.id
+             SET relationship_id = relationships.id,
+                 user_defined = relationships.user_defined
             FROM core_data_connector_relationships relationships
            WHERE relationships.uuid = z_relationships.uuid
              AND z_relationships.relationship_id IS NULL
@@ -129,7 +130,8 @@ module CoreDataConnector
 
         execute <<-SQL.squish
           UPDATE #{table_name} z_relationships
-             SET relationship_id = relationships.id
+             SET relationship_id = relationships.id,
+                 user_defined = relationships.user_defined
             FROM core_data_connector_relationships relationships
            WHERE relationships.primary_record_id = z_relationships.primary_record_id
              AND relationships.primary_record_type = z_relationships.primary_record_type

--- a/app/services/core_data_connector/import/taxonomies.rb
+++ b/app/services/core_data_connector/import/taxonomies.rb
@@ -62,8 +62,7 @@ module CoreDataConnector
 
         execute <<-SQL.squish
           UPDATE #{table_name} z_taxonomies
-             SET taxonomy_id = taxonomies.id,
-                 user_defined = taxonomies.user_defined
+             SET taxonomy_id = taxonomies.id
             FROM core_data_connector_taxonomies taxonomies
            WHERE taxonomies.uuid = z_taxonomies.uuid
         SQL

--- a/app/services/core_data_connector/import/taxonomies.rb
+++ b/app/services/core_data_connector/import/taxonomies.rb
@@ -62,7 +62,8 @@ module CoreDataConnector
 
         execute <<-SQL.squish
           UPDATE #{table_name} z_taxonomies
-             SET taxonomy_id = taxonomies.id
+             SET taxonomy_id = taxonomies.id,
+                 user_defined = taxonomies.user_defined
             FROM core_data_connector_taxonomies taxonomies
            WHERE taxonomies.uuid = z_taxonomies.uuid
         SQL

--- a/app/services/core_data_connector/import/works.rb
+++ b/app/services/core_data_connector/import/works.rb
@@ -87,7 +87,8 @@ module CoreDataConnector
 
         execute <<-SQL.squish
           UPDATE #{table_name} z_works
-             SET work_id = works.id
+             SET work_id = works.id,
+                 user_defined = works.user_defined
             FROM core_data_connector_works works
            WHERE works.uuid = z_works.uuid
         SQL


### PR DESCRIPTION
This pull request fixes a bug that occurs during the import process when all user-defined fields are not included in the CSVs. The import process will overwrite existing values that are not included as columns, resulting in lost data.

The solution here was to update existing records during the `transform` phase with any `user_defined` values, and union the existing values with the incoming values from the CSV files using the `||` operator.