### PR TITLE
CDC #330 - Remove duplicates

### DIFF
--- a/app/services/core_data_connector/import_analyze/event.rb
+++ b/app/services/core_data_connector/import_analyze/event.rb
@@ -8,7 +8,7 @@ module CoreDataConnector
 
       class_methods do
         def group_by_columns
-          [Event.arel_table[:name]]
+          [CoreDataConnector::Event.arel_table[:name]]
         end
       end
     end

--- a/app/services/core_data_connector/import_analyze/instance.rb
+++ b/app/services/core_data_connector/import_analyze/instance.rb
@@ -12,7 +12,7 @@ module CoreDataConnector
         end
 
         def group_by_columns
-          [SourceName.arel_table[:name]]
+          [CoreDataConnector::SourceName.arel_table[:name]]
         end
       end
     end

--- a/app/services/core_data_connector/import_analyze/item.rb
+++ b/app/services/core_data_connector/import_analyze/item.rb
@@ -12,7 +12,7 @@ module CoreDataConnector
         end
 
         def group_by_columns
-          [SourceName.arel_table[:name]]
+          [CoreDataConnector::SourceName.arel_table[:name]]
         end
       end
     end

--- a/app/services/core_data_connector/import_analyze/organization.rb
+++ b/app/services/core_data_connector/import_analyze/organization.rb
@@ -12,7 +12,7 @@ module CoreDataConnector
         end
 
         def group_by_columns
-          [OrganizationName.arel_table[:name]]
+          [CoreDataConnector::OrganizationName.arel_table[:name]]
         end
       end
     end

--- a/app/services/core_data_connector/import_analyze/person.rb
+++ b/app/services/core_data_connector/import_analyze/person.rb
@@ -12,7 +12,10 @@ module CoreDataConnector
         end
 
         def group_by_columns
-          [PersonName.arel_table[:last_name], PersonName.arel_table[:first_name]]
+          [
+            CoreDataConnector::PersonName.arel_table[:last_name],
+            CoreDataConnector::PersonName.arel_table[:first_name]
+          ]
         end
       end
     end

--- a/app/services/core_data_connector/import_analyze/place.rb
+++ b/app/services/core_data_connector/import_analyze/place.rb
@@ -12,7 +12,7 @@ module CoreDataConnector
         end
 
         def group_by_columns
-          [PlaceName.arel_table[:name]]
+          [CoreDataConnector::PlaceName.arel_table[:name]]
         end
       end
     end

--- a/app/services/core_data_connector/import_analyze/taxonomy.rb
+++ b/app/services/core_data_connector/import_analyze/taxonomy.rb
@@ -8,7 +8,7 @@ module CoreDataConnector
 
       class_methods do
         def group_by_columns
-          [Taxonomy.arel_table[:name]]
+          [CoreDataConnector::Taxonomy.arel_table[:name]]
         end
       end
     end

--- a/app/services/core_data_connector/import_analyze/work.rb
+++ b/app/services/core_data_connector/import_analyze/work.rb
@@ -12,7 +12,7 @@ module CoreDataConnector
         end
 
         def group_by_columns
-          [SourceName.arel_table[:name]]
+          [CoreDataConnector::SourceName.arel_table[:name]]
         end
       end
     end


### PR DESCRIPTION
This pull request fixes a bug that occurs when attempting to use the "Remove duplicates" toggle for "events.csv" or "taxonomies.csv". The group by columns in the `import_analyze` service were not name spaced, and as a result, were throwing an error for models with the same name as the module. For consistency, all columns have been prefixed with the `CoreDataConnector` module.