### PR TITLE
CDC #336 - Import Error

### DIFF
--- a/app/services/core_data_connector/export/base.rb
+++ b/app/services/core_data_connector/export/base.rb
@@ -44,7 +44,7 @@ module CoreDataConnector
         private
 
         def add_user_defined_fields(hash, user_defined_fields)
-          return unless user_defined_fields.present? && self.respond_to?(:user_defined)
+          return unless user_defined_fields.present? && self.respond_to?(:user_defined) && user_defined.present?
 
           user_defined_fields.each do |user_defined_field|
             key = ImportAnalyze::Helper.uuid_to_column_name(user_defined_field.uuid)

--- a/app/services/core_data_connector/import/base.rb
+++ b/app/services/core_data_connector/import/base.rb
@@ -76,7 +76,7 @@ module CoreDataConnector
 
         execute <<-SQL.squish
           UPDATE #{table_name}
-             SET user_defined = json_strip_nulls(json_build_object(#{expression}))
+             SET user_defined = jsonb_strip_nulls(jsonb_build_object(#{expression}))
         SQL
 
         # Sets the "Select" and "FuzzyDate" user-defined types to JSONB
@@ -88,6 +88,7 @@ module CoreDataConnector
             UPDATE #{table_name}
                SET user_defined = jsonb_set(user_defined, '{#{column[:uuid]}}', (user_defined->>'#{column[:uuid]}')::jsonb)
              WHERE user_defined->>'#{column[:uuid]}' IS NOT NULL
+               AND user_defined->>'#{column[:uuid]}' != ''
           SQL
         end
       end

--- a/app/services/core_data_connector/import_analyze/policy.rb
+++ b/app/services/core_data_connector/import_analyze/policy.rb
@@ -13,16 +13,17 @@ module CoreDataConnector
       def has_analyze_access?(files)
         return true if current_user.admin?
 
-        project_model_ids = files.except(Import::FILE_RELATIONSHIPS)
-                                 .values
-                                 .map{ |v| v[:data]&.map{ |d| d[:import][:project_model_id] } }
-                                 .flatten
-                                 .uniq
+        project_model_ids = files
+                              &.except(Import::FILE_RELATIONSHIPS)
+                              &.values
+                              &.map{ |v| v[:data]&.map{ |d| d[:import][:project_model_id] } }
+                              &.flatten
+                              &.uniq
 
         project_model_relationship_ids = (files.dig(Import::FILE_RELATIONSHIPS, :data) || [])
-                                           .map{ |v| v[:import][:project_model_relationship_id] }
-                                           .flatten
-                                           .uniq
+                                           &.map{ |v| v[:import][:project_model_relationship_id] }
+                                           &.flatten
+                                           &.uniq
 
         has_access?(project_model_ids, project_model_relationship_ids)
       end
@@ -32,13 +33,14 @@ module CoreDataConnector
       def has_import_access?(files)
         return true if current_user.admin?
 
-        project_model_ids = files.except(Import::FILE_RELATIONSHIPS)
-                                 .values
-                                 .map{ |v| v.map{ |d| d['project_model_id'] } }
-                                 .flatten
-                                 .uniq
+        project_model_ids = files
+                              &.except(Import::FILE_RELATIONSHIPS)
+                              &.values
+                              &.map{ |v| v['data']&.map{ |d| d['project_model_id'] } }
+                              &.flatten
+                              &.uniq
 
-        project_model_relationship_ids = files[Import::FILE_RELATIONSHIPS]
+        project_model_relationship_ids = (files.dig(Import::FILE_RELATIONSHIPS, :data) || [])
                                            &.map{ |v| v['project_model_relationship_id'] }
                                            &.uniq
 


### PR DESCRIPTION
This pull request fixes several bugs with the import process:

1. When importing from FairCopy.cloud, there was an issue with the way the payload was expected to be structured when checking permissions. Because of this, this issue was only experienced by non-admin users.
2. There was more general importing issue that occurred when the `user_defined` column on a record was `nil`.
3. There was also an issue importing "FuzzyDate" and "Select" type user-defined fields. If the data in the `user_defined` column was stored as an empty string, there was an issue with converting the values to JSON.