### PR TITLE
Set `index` to `false` for `geometry` object in typesense

### DIFF
--- a/lib/typesense/helper.rb
+++ b/lib/typesense/helper.rb
@@ -30,6 +30,12 @@ module Typesense
         name: collection_name,
         enable_nested_fields: true,
         fields: [{
+          name: 'geometry',
+          type: 'object',
+          index: false,
+          facet: false,
+          optional: true
+        }, {
           name: 'coordinates',
           type: 'geopoint',
           facet: false,


### PR DESCRIPTION
# Summary

This PR improves Typesense index performance and API payloads by setting the `index` attribute to `false` for the `geometry` object when places are indexed.

The `index` attribute being disabled prevents Typesense from doing any processing on the value (e.g. tokenization, etc.), but keeps it on the disk and in search API responses. This optimization is particularly relevant for polygon data, as `geometry` can be 1 MB or more in those cases.