### PR TITLE
CDC #353 - Import duplicates

### DIFF
--- a/app/services/core_data_connector/merge/merger.rb
+++ b/app/services/core_data_connector/merge/merger.rb
@@ -58,22 +58,22 @@ module CoreDataConnector
 
         # Add the manifests to the new record
         manifests.each { |manifest| manifest.manifestable = new_record }
-        new_record.manifests = manifests
+        new_record.manifests.build(manifests.map(&:as_json))
 
         # Add the merges to the new record
         record_merges.each { |record_merge| record_merge.mergeable = new_record }
-        new_record.record_merges = record_merges
+        new_record.record_merges.build(record_merges.map(&:as_json))
 
         # Add the relationships to the new record
         relationships.each { |relationship| relationship.primary_record = new_record }
-        new_record.relationships = relationships
+        new_record.relationships.build(relationships.map(&:as_json))
 
         related_relationships.each { |relationship| relationship.related_record = new_record }
-        new_record.related_relationships = related_relationships
+        new_record.related_relationships.build(related_relationships.map(&:as_json))
 
         # Add web identifiers to the new record
         web_identifiers.each { |web_identifier| web_identifier.identifiable = new_record }
-        new_record.web_identifiers = web_identifiers
+        new_record.web_identifiers.build(web_identifiers.map(&:as_json))
 
         # Save the new record
         success = new_record.save


### PR DESCRIPTION
This pull request fixes two issues with the `import_analyze` and `merge` services:

## Import Analyze
The `import_analyze` service was not including records that had been merged by a previous import if they were not contained within the current import. The solution here was to add an additional row for the existing record (complete with merged UUIDs) which will then correctly appear as a merged record.

![Screenshot 2025-01-16 at 11 55 22 AM](https://github.com/user-attachments/assets/990e346e-21fb-44da-aa95-db69fe6358c7)
![Screenshot 2025-01-16 at 11 55 25 AM](https://github.com/user-attachments/assets/978766a3-637e-4c88-a163-14c44637624f)

## Merge
The `merge` service was using `=` to set new related records, which was immediately saving to the database. This caused callbacks to be executed, which was erroneously deleting records. We've updated the service to use `build` instead, which will _not_ make calls directly to the database, but wait for us to save the parent record.
