### PR TITLE
CDC #353 - Import duplicates

### DIFF
--- a/app/services/core_data_connector/import_analyze/import.rb
+++ b/app/services/core_data_connector/import_analyze/import.rb
@@ -233,6 +233,8 @@ module CoreDataConnector
       end
 
       def find_merges_by_uuid(klass, uuids)
+        return {} unless klass.ancestors.include?(Mergeable)
+
         merges_by_uuid = {}
 
         query = klass.all


### PR DESCRIPTION
This pull request fixes an issue analyzing an import that contains a `relationships.csv` file. The analysis loads of the merge records for the currently file, however `relationships` records are not mergeable. The solution was to add a check at the top of the `find_merges_by_uuid` method.