### PR TITLE
CDC #358 - Organizations API endpoint

### DIFF
--- a/app/controllers/concerns/core_data_connector/public/v1/nestable_controller.rb
+++ b/app/controllers/concerns/core_data_connector/public/v1/nestable_controller.rb
@@ -4,7 +4,7 @@ module CoreDataConnector
       module NestableController
         extend ActiveSupport::Concern
 
-        NESTABLE_PARAMS = %i(event_id instance_id item_id person_id place_id work_id)
+        NESTABLE_PARAMS = %i(event_id instance_id item_id organization_id person_id place_id work_id)
 
         included do
           # Member attributes
@@ -26,6 +26,8 @@ module CoreDataConnector
               @current_record = Instance.find_by_uuid(params[:instance_id])
             elsif params[:item_id].present?
               @current_record = Item.find_by_uuid(params[:item_id])
+            elsif params[:organization_id].present?
+              @current_record = Organization.find_by_uuid(params[:organization_id])
             elsif params[:person_id].present?
               @current_record = Person.find_by_uuid(params[:person_id])
             elsif params[:place_id].present?

--- a/config/routes/public/v1.rb
+++ b/config/routes/public/v1.rb
@@ -44,6 +44,19 @@ module Public
               resources :works, only: :index
             end
 
+            resources :organizations do
+              resources :events, only: :index
+              resources :instances, only: :index
+              resources :items, only: :index
+              resources :manifests
+              resources :media_contents, only: :index
+              resources :organizations, only: :index
+              resources :people, only: :index
+              resources :places, only: :index
+              resources :taxonomies, only: :index
+              resources :works, only: :index
+            end
+
             resources :people do
               resources :events, only: :index
               resources :instances, only: :index


### PR DESCRIPTION
This pull request adds the missing `/public/v1/organizations` API endpoint. Since the controllers exist, I believe this route was omitted in error.