### PR TITLE
CDC #357 - Related place coordinates

### DIFF
--- a/app/controllers/concerns/core_data_connector/public/v1/nestable_controller.rb
+++ b/app/controllers/concerns/core_data_connector/public/v1/nestable_controller.rb
@@ -4,7 +4,7 @@ module CoreDataConnector
       module NestableController
         extend ActiveSupport::Concern
 
-        NESTABLE_PARAMS = %i(event_id instance_id item_id person_id place_id work_id)
+        NESTABLE_PARAMS = %i(event_id instance_id item_id organization_id person_id place_id work_id)
 
         included do
           # Member attributes
@@ -26,6 +26,8 @@ module CoreDataConnector
               @current_record = Instance.find_by_uuid(params[:instance_id])
             elsif params[:item_id].present?
               @current_record = Item.find_by_uuid(params[:item_id])
+            elsif params[:organization_id].present?
+              @current_record = Organization.find_by_uuid(params[:organization_id])
             elsif params[:person_id].present?
               @current_record = Person.find_by_uuid(params[:person_id])
             elsif params[:place_id].present?

--- a/app/models/core_data_connector/relationship.rb
+++ b/app/models/core_data_connector/relationship.rb
@@ -29,6 +29,10 @@ module CoreDataConnector
     belongs_to :inverse_related_taxonomy, -> { where(Relationship.arel_table.name => { primary_record_type: Taxonomy.to_s }) }, class_name: Taxonomy.to_s, foreign_key: :primary_record_id, optional: true
     belongs_to :inverse_related_work, -> { where(Relationship.arel_table.name => { primary_record_type: Work.to_s }) }, class_name: Work.to_s, foreign_key: :primary_record_id, optional: true
 
+    # Place relationships
+    belongs_to :related_place_with_centroid, -> { merge(Place.with_centroid) }, class_name: Place.to_s, foreign_key: :related_record_id, optional: true
+    belongs_to :inverse_related_place_with_centroid, -> { merge(Place.with_centroid) }, class_name: Place.to_s, foreign_key: :primary_record_id, optional: true
+
     # Delegates
     delegate :project_id, to: :project_model_relationship
 

--- a/app/services/core_data_connector/search/place.rb
+++ b/app/services/core_data_connector/search/place.rb
@@ -7,10 +7,6 @@ module CoreDataConnector
         def preloads
           [:primary_name, :place_names, :place_geometry]
         end
-
-        def search_query(query)
-          query.merge(self.with_centroid)
-        end
       end
 
       included do
@@ -29,12 +25,8 @@ module CoreDataConnector
         end
 
         search_attribute(:coordinates) do
-          # Since the "geometry_center" attribute is defined in the select statement above, ensure that it exists
-          # before calling.
-          next unless self.respond_to?(:geometry_center)
-
           # Return if the "geometry_center" attribute is not defined
-          next unless geometry_center.present?
+          next unless self.respond_to?(:geometry_center) && geometry_center.present?
 
           [geometry_center.y, geometry_center.x]
         end

--- a/config/routes/public/v1.rb
+++ b/config/routes/public/v1.rb
@@ -44,6 +44,19 @@ module Public
               resources :works, only: :index
             end
 
+            resources :organizations do
+              resources :events, only: :index
+              resources :instances, only: :index
+              resources :items, only: :index
+              resources :manifests
+              resources :media_contents, only: :index
+              resources :organizations, only: :index
+              resources :people, only: :index
+              resources :places, only: :index
+              resources :taxonomies, only: :index
+              resources :works, only: :index
+            end
+
             resources :people do
               resources :events, only: :index
               resources :instances, only: :index


### PR DESCRIPTION
This pull request updates the search module to include the `coordinates` field for related place records. In order to accomplish this, we defined a couple new relationships in `relationship.rb` for the `relationship` -> `place` record that uses a scope to include the centroid for the related place.

This pull request also updates the `update` call to Typesense to convert any field with "coordinates" in the name from a `float[]` to `geopoint[]`.

**Note:** This pull request also includes the changes in [#358](https://github.com/performant-software/core-data-cloud/issues/358).