### PR TITLE
CDC #371 - Import user defined fields

### DIFF
--- a/app/services/core_data_connector/import/base.rb
+++ b/app/services/core_data_connector/import/base.rb
@@ -76,7 +76,7 @@ module CoreDataConnector
 
         execute <<-SQL.squish
           UPDATE #{table_name}
-             SET user_defined = user_defined || json_strip_nulls(json_build_object(#{expression}))::jsonb
+             SET user_defined = COALESCE(user_defined, '{}') || json_strip_nulls(json_build_object(#{expression}))::jsonb
         SQL
 
         # Sets the "Select" and "FuzzyDate" user-defined types to JSONB

--- a/app/services/core_data_connector/import/events.rb
+++ b/app/services/core_data_connector/import/events.rb
@@ -152,15 +152,16 @@ module CoreDataConnector
       end
 
       def transform
-        super
-
         execute <<-SQL.squish
           UPDATE #{table_name} z_events
              SET event_id = events.id,
                  user_defined = events.user_defined
             FROM core_data_connector_events events
            WHERE events.uuid = z_events.uuid
+             AND z_events.uuid IS NOT NULL
         SQL
+
+        super
 
         execute <<-SQL.squish
           UPDATE #{table_name} z_events

--- a/app/services/core_data_connector/import/instances.rb
+++ b/app/services/core_data_connector/import/instances.rb
@@ -83,15 +83,16 @@ module CoreDataConnector
       end
 
       def transform
-        super
-
         execute <<-SQL.squish
           UPDATE #{table_name} z_instances
              SET instance_id = instances.id,
                  user_defined = instances.user_defined
             FROM core_data_connector_instances instances
            WHERE instances.uuid = z_instances.uuid
+             AND z_instances.uuid IS NOT NULL
         SQL
+
+        super
       end
 
       protected

--- a/app/services/core_data_connector/import/items.rb
+++ b/app/services/core_data_connector/import/items.rb
@@ -83,15 +83,16 @@ module CoreDataConnector
       end
 
       def transform
-        super
-
         execute <<-SQL.squish
           UPDATE #{table_name} z_items
              SET item_id = items.id,
                  user_defined = items.user_defined
             FROM core_data_connector_items items
            WHERE items.uuid = z_items.uuid
+             AND z_items.uuid IS NOT NULL
         SQL
+
+        super
       end
 
       protected

--- a/app/services/core_data_connector/import/organizations.rb
+++ b/app/services/core_data_connector/import/organizations.rb
@@ -83,15 +83,16 @@ module CoreDataConnector
       end
 
       def transform
-        super
-
         execute <<-SQL.squish
           UPDATE #{table_name} z_organizations
              SET organization_id = organizations.id,
                  user_defined = organizations.user_defined
             FROM core_data_connector_organizations organizations
            WHERE organizations.uuid = z_organizations.uuid
+             AND z_organizations.uuid IS NOT NULL
         SQL
+
+        super
       end
 
       protected

--- a/app/services/core_data_connector/import/people.rb
+++ b/app/services/core_data_connector/import/people.rb
@@ -86,15 +86,16 @@ module CoreDataConnector
       end
 
       def transform
-        super
-
         execute <<-SQL.squish
           UPDATE #{table_name} z_people
              SET person_id = people.id,
                  user_defined = people.user_defined
             FROM core_data_connector_people people
            WHERE people.uuid = z_people.uuid
+             AND z_people.uuid IS NOT NULL
         SQL
+
+        super
       end
 
       protected

--- a/app/services/core_data_connector/import/places.rb
+++ b/app/services/core_data_connector/import/places.rb
@@ -101,15 +101,16 @@ module CoreDataConnector
       end
 
       def transform
-        super
-
         execute <<-SQL.squish
           UPDATE #{table_name} z_places
              SET place_id = places.id,
                  user_defined = places.user_defined
             FROM core_data_connector_places places
            WHERE places.uuid = z_places.uuid
+             AND z_places.uuid IS NOT NULL
         SQL
+
+        super
       end
 
       protected

--- a/app/services/core_data_connector/import/taxonomies.rb
+++ b/app/services/core_data_connector/import/taxonomies.rb
@@ -58,14 +58,15 @@ module CoreDataConnector
       end
 
       def transform
-        super
-
         execute <<-SQL.squish
           UPDATE #{table_name} z_taxonomies
              SET taxonomy_id = taxonomies.id
             FROM core_data_connector_taxonomies taxonomies
            WHERE taxonomies.uuid = z_taxonomies.uuid
+             AND z_taxonomies.uuid IS NOT NULL
         SQL
+
+        super
       end
 
       protected

--- a/app/services/core_data_connector/import/works.rb
+++ b/app/services/core_data_connector/import/works.rb
@@ -83,15 +83,16 @@ module CoreDataConnector
       end
 
       def transform
-        super
-
         execute <<-SQL.squish
           UPDATE #{table_name} z_works
              SET work_id = works.id,
                  user_defined = works.user_defined
             FROM core_data_connector_works works
            WHERE works.uuid = z_works.uuid
+             AND z_works.uuid IS NOT NULL
         SQL
+
+        super
       end
 
       protected

--- a/app/services/core_data_connector/import_analyze/import.rb
+++ b/app/services/core_data_connector/import_analyze/import.rb
@@ -293,7 +293,7 @@ module CoreDataConnector
           key = Helper.uuid_to_column_name(user_defined_field.uuid)
           value = csv[key]
 
-          next unless value.present?
+          csv[key] = nil and next unless value.present?
 
           # Since the "to_export_csv" method will serialize JSON to strings, we'll convert it back to JSON
           # here in order to do proper comparison on the client.

--- a/app/services/core_data_connector/import_analyze/import.rb
+++ b/app/services/core_data_connector/import_analyze/import.rb
@@ -291,9 +291,15 @@ module CoreDataConnector
 
         user_defined_fields.each do |user_defined_field|
           key = Helper.uuid_to_column_name(user_defined_field.uuid)
-          value = csv[key]
 
-          csv[key] = nil and next unless value.present?
+          # If the value exists in the hash, extract it. Otherwise add the key to the hash with a nil value.
+          if csv.key?(key)
+            value = csv[key]
+          else
+            csv[key] = nil
+          end
+
+          next unless value.present?
 
           # Since the "to_export_csv" method will serialize JSON to strings, we'll convert it back to JSON
           # here in order to do proper comparison on the client.


### PR DESCRIPTION
This pull request fixes two separate issues that were occurring when importing records that contain user-defined fields:

1. When a record had previously been imported and merged with another record, the import would result in an exception due to a mismatch in the number of columns after analyzing the CSV files. The row returned from the server would not contain columns for user-defined fields with `nil` values, while existing and new records would. If the first record in the CSV happened to be imported previously and merged, the import would fail. The solution here was to update the `record_to_csv` method to add those empty user-defined field values to the resulting object.
2. Importing of user-defined field values would result in the `user_defined` column not being updated if the existing column was `NULL`. There were two things fixed here:
  a. A `COALESCE` function was added to the code that evaluates the existing value
  b. We updated the `user_defined` value on the temporary tables to execute _before_ the `super` call, in order to ensure the value is populated