### PR TITLE
CDC #375 - User-defined type

### DIFF
--- a/app/serializers/core_data_connector/public/v1/user_defined_serializer.rb
+++ b/app/serializers/core_data_connector/public/v1/user_defined_serializer.rb
@@ -37,6 +37,7 @@ module CoreDataConnector
 
             hash[field.uuid] = {
               label: field.column_name,
+              type: field.data_type,
               value: value
             }
           end


### PR DESCRIPTION
This pull request adds the `type` attribute to the `UserDefinedSerializer`. This will allow consumers to determine how to handle the field value.