### PR TITLE
Use `REACT_APP_SSO_REDIRECT_URI` env variable for token request

### DIFF
--- a/app/controllers/core_data_connector/sso_controller.rb
+++ b/app/controllers/core_data_connector/sso_controller.rb
@@ -19,7 +19,7 @@ module CoreDataConnector
         client_id: ENV['SSO_CLIENT_ID'],
         client_secret: ENV['SSO_CLIENT_SECRET'],
         grant_type: 'authorization_code',
-        redirect_uri: request.original_url.split('?')[0]
+        redirect_uri: ENV['REACT_APP_SSO_REDIRECT_URI']
       }
 
       token_req = Typhoeus::Request.new(


### PR DESCRIPTION
# Summary

When `SsoController` sends Keycloak the login code to get the user's token, it has to include a `redirect_uri` paramter that exactly matches the one provided by the client. To get that URL, we were previously using `request.original_url.split('?')[0]`, which apparently didn't work on the deployed version of the site.

This PR replaces that line with just reading the `REACT_APP_SSO_REDIRECT_URI` environment variable. This is the same variable that the client gets its `redirect_uri` value from, so it should always match.