### PR TITLE
Add map_library_url to project permitted attributes, serializer (CDC #380)

### DIFF
--- a/app/policies/core_data_connector/project_policy.rb
+++ b/app/policies/core_data_connector/project_policy.rb
@@ -91,7 +91,7 @@ module CoreDataConnector
 
     # Allowed create/update attributes.
     def permitted_attributes
-      [:name, :description, :discoverable, :faircopy_cloud_url, :faircopy_cloud_project_model_id]
+      [:name, :description, :discoverable, :faircopy_cloud_url, :faircopy_cloud_project_model_id, :map_library_url]
     end
 
     private

--- a/app/serializers/core_data_connector/projects_serializer.rb
+++ b/app/serializers/core_data_connector/projects_serializer.rb
@@ -1,6 +1,6 @@
 module CoreDataConnector
   class ProjectsSerializer < BaseSerializer
-    index_attributes :id, :name, :description, :discoverable, :faircopy_cloud_url, :faircopy_cloud_project_model_id
-    show_attributes :id, :name, :description, :discoverable, :faircopy_cloud_url, :faircopy_cloud_project_model_id
+    index_attributes :id, :name, :description, :discoverable, :faircopy_cloud_url, :map_library_url, :faircopy_cloud_project_model_id
+    show_attributes :id, :name, :description, :discoverable, :faircopy_cloud_url, :map_library_url, :faircopy_cloud_project_model_id
   end
 end

--- a/db/migrate/20250204210235_add_map_library_url_to_core_data_connector_projects.rb
+++ b/db/migrate/20250204210235_add_map_library_url_to_core_data_connector_projects.rb
@@ -1,0 +1,5 @@
+class AddMapLibraryUrlToCoreDataConnectorProjects < ActiveRecord::Migration[7.0]
+  def change
+    add_column :core_data_connector_projects, :map_library_url, :string
+  end
+end


### PR DESCRIPTION
## In this PR

Per performant-software/core-data-cloud#380:
- For `Project`, add `map_library_url` as create/update attribute, index/show serializer attribute