### PR TITLE
Add map library fetch and endpoint (CDC #380)

### DIFF
--- a/app/controllers/core_data_connector/projects_controller.rb
+++ b/app/controllers/core_data_connector/projects_controller.rb
@@ -176,6 +176,16 @@ module CoreDataConnector
       end
     end
 
+    def map_library
+      project = Project.find(params[:id])
+      authorize project, :map_library?
+
+      library = MapLibrary.new(project.map_library_url)
+      json = library.fetch_library || []
+
+      render json: json, status: :ok
+    end
+
     protected
 
     # If we're not looking for "discoverable" projects, use base query defined by the policy. Otherwise, return

--- a/app/policies/core_data_connector/project_policy.rb
+++ b/app/policies/core_data_connector/project_policy.rb
@@ -82,6 +82,13 @@ module CoreDataConnector
       false
     end
 
+    # A user can view any project's map library for which they are a member.
+    def map_library?
+      return true if current_user.admin?
+
+      project_member?
+    end
+
     # A user can update a project if they are an admin or an owner of the project.
     def update?
       return true if current_user.admin?

--- a/app/services/core_data_connector/map_library.rb
+++ b/app/services/core_data_connector/map_library.rb
@@ -1,0 +1,16 @@
+module CoreDataConnector
+  class MapLibrary
+    include Http::Requestable
+
+    def initialize(map_library_url)
+      @map_library_url = map_library_url
+    end
+
+    def fetch_library
+      params = {}
+      send_request(@map_library_url, method: :get, params: params) do |body|
+        JSON.parse(body)
+      end
+    end
+  end
+end

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -47,6 +47,7 @@ module Admin
         post :import_analyze, on: :member
         post :import_configuration, on: :member
         post :import_data, on: :member
+        get :map_library, on: :member
       end
 
       resources :record_merges, only: [:index, :destroy]


### PR DESCRIPTION
## In this PR

Per https://github.com/performant-software/core-data-cloud/pull/383#discussion_r1951595693:
- Add `/project/:id/map_library` endpoint, which sends a GET request to the project's map library URL and returns the result