### PR TITLE
Fix user-defined field validation for Events (#133)

### DIFF
--- a/app/models/core_data_connector/event.rb
+++ b/app/models/core_data_connector/event.rb
@@ -14,5 +14,8 @@ module CoreDataConnector
 
     # Fuzzy dates
     has_fuzzy_dates :start_date, :end_date
+
+    # User defined fields parent
+    resolve_defineable -> (event) { event.project_model }
   end
 end

--- a/app/models/core_data_connector/instance.rb
+++ b/app/models/core_data_connector/instance.rb
@@ -19,6 +19,6 @@ module CoreDataConnector
     delegate :name, to: :primary_name, allow_nil: true
 
     # User defined fields parent
-    resolve_defineable -> (organization) { organization.project_model }
+    resolve_defineable -> (instance) { instance.project_model }
   end
 end

--- a/app/models/core_data_connector/item.rb
+++ b/app/models/core_data_connector/item.rb
@@ -20,6 +20,6 @@ module CoreDataConnector
     delegate :name, to: :primary_name, allow_nil: true
 
     # User defined fields parent
-    resolve_defineable -> (organization) { organization.project_model }
+    resolve_defineable -> (item) { item.project_model }
   end
 end

--- a/app/models/core_data_connector/work.rb
+++ b/app/models/core_data_connector/work.rb
@@ -19,6 +19,6 @@ module CoreDataConnector
     delegate :name, to: :primary_name, allow_nil: true
 
     # User defined fields parent
-    resolve_defineable -> (organization) { organization.project_model }
+    resolve_defineable -> (work) { work.project_model }
   end
 end


### PR DESCRIPTION
## In this PR

Per #133:
- Implement `resolve_definable` for Events so that UDF validation will only apply to Events of the same project model.

Also:
- Update argument names for other `resolve_defineable` implementations to match the `Fieldable` classes' class names.