### PR TITLE
Add user-defined fields to Taxonomy (CDC #398)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,6 +251,7 @@ PLATFORMS
   arm64-darwin-22
   arm64-darwin-24
   x86_64-darwin-19
+  x86_64-darwin-23
 
 DEPENDENCIES
   core_data_connector!

--- a/app/models/core_data_connector/taxonomy.rb
+++ b/app/models/core_data_connector/taxonomy.rb
@@ -8,6 +8,7 @@ module CoreDataConnector
     include Mergeable
     include Ownable
     include Relateable
+    include UserDefinedFields::Fieldable
     include Search::Taxonomy
   end
 end

--- a/app/models/core_data_connector/taxonomy.rb
+++ b/app/models/core_data_connector/taxonomy.rb
@@ -10,5 +10,8 @@ module CoreDataConnector
     include Relateable
     include UserDefinedFields::Fieldable
     include Search::Taxonomy
+
+    # User defined fields parent
+    resolve_defineable -> (taxonomy) { taxonomy.project_model }
   end
 end

--- a/app/policies/core_data_connector/taxonomy_policy.rb
+++ b/app/policies/core_data_connector/taxonomy_policy.rb
@@ -16,6 +16,7 @@ module CoreDataConnector
 
     def permitted_attributes
       [ *ownable_attributes,
+        user_defined: {},
         :name
       ]
     end

--- a/app/policies/core_data_connector/taxonomy_policy.rb
+++ b/app/policies/core_data_connector/taxonomy_policy.rb
@@ -16,8 +16,8 @@ module CoreDataConnector
 
     def permitted_attributes
       [ *ownable_attributes,
-        user_defined: {},
-        :name
+        :name,
+        user_defined: {}
       ]
     end
 

--- a/app/serializers/core_data_connector/taxonomies_serializer.rb
+++ b/app/serializers/core_data_connector/taxonomies_serializer.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class TaxonomiesSerializer < BaseSerializer
     include OwnableSerializer
+    include UserDefinedFields::FieldableSerializer
 
     index_attributes :id, :name
     show_attributes :id, :name

--- a/app/services/core_data_connector/import/taxonomies.rb
+++ b/app/services/core_data_connector/import/taxonomies.rb
@@ -17,6 +17,7 @@ module CoreDataConnector
           UPDATE core_data_connector_taxonomies taxonomies
             SET  z_taxonomy_id = z_taxonomies.id,
                  name = z_taxonomies.name,
+                 user_defined = z_taxonomies.user_defined,
                  import_id = z_taxonomies.import_id,
                  updated_at = current_timestamp
            FROM #{table_name} z_taxonomies
@@ -33,6 +34,7 @@ module CoreDataConnector
             uuid,
             z_taxonomy_id,
             name,
+            user_defined,
             import_id,
             created_at, 
             updated_at
@@ -41,6 +43,7 @@ module CoreDataConnector
                  z_taxonomies.uuid,
                  z_taxonomies.id,
                  z_taxonomies.name,
+                 z_taxonomies.user_defined,
                  z_taxonomies.import_id,
                  current_timestamp,
                  current_timestamp
@@ -60,7 +63,8 @@ module CoreDataConnector
       def transform
         execute <<-SQL.squish
           UPDATE #{table_name} z_taxonomies
-             SET taxonomy_id = taxonomies.id
+             SET taxonomy_id = taxonomies.id,
+                 user_defined = taxonomies.user_defined
             FROM core_data_connector_taxonomies taxonomies
            WHERE taxonomies.uuid = z_taxonomies.uuid
              AND z_taxonomies.uuid IS NOT NULL
@@ -87,6 +91,9 @@ module CoreDataConnector
         }, {
           name: 'taxonomy_id',
           type: 'INTEGER'
+        }, {
+          name: 'user_defined',
+          type: 'JSONB'
         }, {
           name: 'import_id',
           type: 'UUID'

--- a/db/migrate/20250226175155_add_user_defined_fields_to_core_data_connector_taxonomies.rb
+++ b/db/migrate/20250226175155_add_user_defined_fields_to_core_data_connector_taxonomies.rb
@@ -1,0 +1,11 @@
+class AddUserDefinedFieldsToCoreDataConnectorTaxonomies < ActiveRecord::Migration[7.0]
+  def up
+    add_column :core_data_connector_taxonomies, :user_defined, :jsonb, default: {}
+    add_index :core_data_connector_taxonomies, :user_defined, using: :gin
+  end
+
+  def down
+    remove_index :core_data_connector_taxonomies, :user_defined
+    remove_column :core_data_connector_taxonomies, :user_defined
+  end
+end


### PR DESCRIPTION
## In this PR

Per performant-software/core-data-cloud#398:
- Add column and index for `user_defined` `jsonb` field to `core_data_connector_taxonomies`
- Update `Taxonomy` model, serializer, policy, and import processor to handle UDFs