### PR TITLE
Adding `media_contents` endpoint

### DIFF
--- a/app/controllers/concerns/core_data_connector/public/v1/nestable_controller.rb
+++ b/app/controllers/concerns/core_data_connector/public/v1/nestable_controller.rb
@@ -4,7 +4,7 @@ module CoreDataConnector
       module NestableController
         extend ActiveSupport::Concern
 
-        NESTABLE_PARAMS = %i(event_id instance_id item_id media_content_id organization_id person_id place_id work_id)
+        NESTABLE_PARAMS = %i(event_id instance_id item_id organization_id person_id place_id work_id)
 
         included do
           # Member attributes
@@ -26,8 +26,6 @@ module CoreDataConnector
               @current_record = Instance.find_by_uuid(params[:instance_id])
             elsif params[:item_id].present?
               @current_record = Item.find_by_uuid(params[:item_id])
-            elsif params[:media_content_id].present?
-              @current_record = MediaContent.find_by_uuid(params[:media_content_id])
             elsif params[:organization_id].present?
               @current_record = Organization.find_by_uuid(params[:organization_id])
             elsif params[:person_id].present?

--- a/app/controllers/concerns/core_data_connector/public/v1/nestable_controller.rb
+++ b/app/controllers/concerns/core_data_connector/public/v1/nestable_controller.rb
@@ -4,7 +4,7 @@ module CoreDataConnector
       module NestableController
         extend ActiveSupport::Concern
 
-        NESTABLE_PARAMS = %i(event_id instance_id item_id organization_id person_id place_id work_id)
+        NESTABLE_PARAMS = %i(event_id instance_id item_id media_content_id organization_id person_id place_id work_id)
 
         included do
           # Member attributes
@@ -26,6 +26,8 @@ module CoreDataConnector
               @current_record = Instance.find_by_uuid(params[:instance_id])
             elsif params[:item_id].present?
               @current_record = Item.find_by_uuid(params[:item_id])
+            elsif params[:media_content_id].present?
+              @current_record = MediaContent.find_by_uuid(params[:media_content_id])
             elsif params[:organization_id].present?
               @current_record = Organization.find_by_uuid(params[:organization_id])
             elsif params[:person_id].present?

--- a/config/routes/public/v1.rb
+++ b/config/routes/public/v1.rb
@@ -44,7 +44,7 @@ module Public
               resources :works, only: :index
             end
 
-            resources :media_contents
+            resources :media_contents, only: :index
 
             resources :organizations do
               resources :events, only: :index

--- a/config/routes/public/v1.rb
+++ b/config/routes/public/v1.rb
@@ -44,6 +44,18 @@ module Public
               resources :works, only: :index
             end
 
+            resources :media_contents do
+              resources :events, only: :index
+              resources :instances, only: :index
+              resources :items, only: :index
+              resources :manifests
+              resources :media_contents, only: :index
+              resources :organizations, only: :index
+              resources :people, only: :index
+              resources :places, only: :index
+              resources :taxonomies, only: :index
+              resources :works, only: :index
+
             resources :organizations do
               resources :events, only: :index
               resources :instances, only: :index

--- a/config/routes/public/v1.rb
+++ b/config/routes/public/v1.rb
@@ -44,17 +44,7 @@ module Public
               resources :works, only: :index
             end
 
-            resources :media_contents do
-              resources :events, only: :index
-              resources :instances, only: :index
-              resources :items, only: :index
-              resources :manifests
-              resources :media_contents, only: :index
-              resources :organizations, only: :index
-              resources :people, only: :index
-              resources :places, only: :index
-              resources :taxonomies, only: :index
-              resources :works, only: :index
+            resources :media_contents
 
             resources :organizations do
               resources :events, only: :index


### PR DESCRIPTION
### In this PR
An attempt to add a `/public/v1/media_contents` endpoint that takes a `project_ids` parameter. See https://github.com/performant-software/core-data-cloud/issues/401

### Notes
I am modeling this off of the recent addition of the `/organizations` endpoint, and as best I can tell from poking around the code this should work the same way; but I'm not super familiar with the code and am not currently set up to test locally, so I might have missed something.