### PR TITLE
Indexing start and end years instead of timestamps

### DIFF
--- a/app/services/core_data_connector/search/event.rb
+++ b/app/services/core_data_connector/search/event.rb
@@ -17,12 +17,20 @@ module CoreDataConnector
         search_attribute :name, facet: true
         search_attribute :description
 
-        search_attribute(:start_date, facet: true) do
+        search_attribute(:start_date) do
           resolve_date start_date
         end
 
-        search_attribute(:end_date, facet: true) do
+        search_attribute(:end_date) do
           resolve_date end_date
+        end
+
+        search_attribute(:start_year, facet: true) do
+          resolve_year start_date
+        end
+
+        search_attribute(:end_year, facet: true) do
+          resolve_year end_date
         end
 
         private
@@ -30,7 +38,13 @@ module CoreDataConnector
         def resolve_date(date)
           return [] unless date.present?
 
-          [date.start_date&.to_fs(:year)&.to_i, date.end_date&.to_fs(:year)&.to_i]
+          [date.start_date&.to_time&.to_i, date.end_date&.to_time&.to_i]
+        end
+
+        def resolve_year(date)
+          return [] unless date.present?
+
+          [date.start_date&.strftime('%Y')&.to_i, date.end_date&.strftime('%Y')&.to_i]
         end
 
       end

--- a/app/services/core_data_connector/search/event.rb
+++ b/app/services/core_data_connector/search/event.rb
@@ -30,7 +30,7 @@ module CoreDataConnector
         def resolve_date(date)
           return [] unless date.present?
 
-          [date.start_date&.to_time&.to_i, date.end_date&.to_time&.to_i]
+          [date.start_date&.to_fs(:year)&.to_i, date.end_date&.to_fs(:year)&.to_i]
         end
 
       end

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,1 +1,0 @@
-Time::DATE_FORMATS[:year] = '%Y'

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,0 +1,1 @@
+Time::DATE_FORMATS[:year] = '%Y'


### PR DESCRIPTION
### In this PR
My initial attempt to convert the `start_date` and `end_date` fields for `events` to integer years when indexing in Typesense.