### PR TITLE
Fix missing `coordinates` field by adding `search_query` method back to `Search::Place`

### DIFF
--- a/app/services/core_data_connector/search/base.rb
+++ b/app/services/core_data_connector/search/base.rb
@@ -186,6 +186,9 @@ module CoreDataConnector
           # Base query
           query = all_records_by_project_model(project_model_ids)
 
+          # Concrete class query
+          query = search_query(query) if self.respond_to?(:search_query)
+
           query.find_in_batches(batch_size: 1000) do |records|
             # Apply the preloads for the current batch
             apply_preloads records, project_model_ids

--- a/app/services/core_data_connector/search/place.rb
+++ b/app/services/core_data_connector/search/place.rb
@@ -7,6 +7,10 @@ module CoreDataConnector
         def preloads
           [:primary_name, :place_names, :place_geometry]
         end
+
+        def search_query(query)
+          query.merge(self.with_centroid)
+        end
       end
 
       included do


### PR DESCRIPTION
# Summary

This PR adds back the `search_query` method (and the call to it that occurred in `Search::Base` that was accidentally removed in https://github.com/performant-software/core-data-connector/pull/122.

It might be possible to refactor this so `search_query` is only called on Places instead of running the `if self.respond_to?(:search_query)` check on all models, but I guess we can't add a `for_search` to `Search::Place` that adds the coordinates and then calls `super` because `Search::Place` isn't actually a subclass of `Search::Base`?