### PR TITLE
Optional polygon indexing for Typesense Rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ bundle exec rake typesense:delete -- -h host -p port -r protocol -a api_key -c c
 
 #### Index documents into a collection
 ```bash
-bundle exec rake typesense:index -- -h host -p port -r protocol -a api_key -c collection_name -m model_ids
+bundle exec rake typesense:index -- -h host -p port -r protocol -a api_key -c collection_name -m model_ids --polygons
 ```
 
 **Note:** This task expects the entire collection to be indexed. Any records not included in the batch will be removed from the index.

--- a/app/models/core_data_connector/place.rb
+++ b/app/models/core_data_connector/place.rb
@@ -40,5 +40,16 @@ module CoreDataConnector
       left_joins(:place_geometry)
         .select(arel_table[Arel.star], function)
     end
+
+    # WIP
+    def self.simplified_polygon
+      function = Arel::Nodes::NamedFunction.new(
+        'st_simplify',
+        [PlaceGeometry.arel_table[:geometry]]
+      ).as('geometry')
+
+      left_joins(:place_geometry)
+        .select(arel_table[Arel.star], function)
+    end
   end
 end

--- a/app/models/core_data_connector/place.rb
+++ b/app/models/core_data_connector/place.rb
@@ -41,12 +41,11 @@ module CoreDataConnector
         .select(arel_table[Arel.star], function)
     end
 
-    # WIP
-    def self.simplified_polygon
+    def self.with_simplified_geometry(tolerance = 0.01)
       function = Arel::Nodes::NamedFunction.new(
         'st_simplify',
-        [PlaceGeometry.arel_table[:geometry]]
-      ).as('geometry')
+        [PlaceGeometry.arel_table[:geometry], Arel::Nodes.build_quoted(tolerance)]
+      ).as('simplified_geometry')
 
       left_joins(:place_geometry)
         .select(arel_table[Arel.star], function)

--- a/app/services/core_data_connector/search/base.rb
+++ b/app/services/core_data_connector/search/base.rb
@@ -313,7 +313,7 @@ module CoreDataConnector
 
         # Uses the specified attributes to create a JSON object. We'll skip relationships by default as to
         # not create an infinite loop while serializing related records.
-        def to_search_json(skip_relationships = true)
+        def to_search_json(skip_relationships: true, polygons: false)
           hash = {}
 
           # Add attributes defined by the concrete-class
@@ -322,7 +322,11 @@ module CoreDataConnector
 
             # Extract the value for the attribute
             if attr[:block].present?
-              value = instance_eval(&attr[:block])
+              if name == :geometry
+                value = instance_exec(self, polygons, &attr[:block] )
+              else
+                value = instance_eval(&attr[:block])
+              end
             else
               value = self.send(attr[:name])
             end

--- a/app/services/core_data_connector/search/base.rb
+++ b/app/services/core_data_connector/search/base.rb
@@ -313,7 +313,7 @@ module CoreDataConnector
 
         # Uses the specified attributes to create a JSON object. We'll skip relationships by default as to
         # not create an infinite loop while serializing related records.
-        def to_search_json(skip_relationships: true, polygons: false)
+        def to_search_json(options)
           hash = {}
 
           # Add attributes defined by the concrete-class
@@ -323,7 +323,7 @@ module CoreDataConnector
             # Extract the value for the attribute
             if attr[:block].present?
               if name == :geometry
-                value = instance_exec(self, polygons, &attr[:block] )
+                value = instance_exec(self, options, &attr[:block] )
               else
                 value = instance_eval(&attr[:block])
               end
@@ -348,10 +348,10 @@ module CoreDataConnector
           projects = []
 
           # Include related records
-          build_relationships hash, projects unless skip_relationships
-
-          # Only include project information for the base record
-          if !skip_relationships
+          if options[:include_relationships]
+            build_relationships hash, projects
+          else
+            # Only include project information for the base record
             # Add the owning project to the list of all projects
             add_project(projects, project_model.project)
 
@@ -425,7 +425,7 @@ module CoreDataConnector
 
           hash[key] << relationship
                          .inverse_related_place_with_centroid
-                         .to_search_json
+                         .to_search_json(include_relationships: false)
                          .merge(user_defined)
                          .merge({ inverse: true })
         end
@@ -443,7 +443,7 @@ module CoreDataConnector
 
           hash[key] << relationship
                          .primary_record
-                         .to_search_json
+                         .to_search_json(include_relationships: false)
                          .merge(user_defined)
                          .merge({ inverse: true })
         end
@@ -461,7 +461,7 @@ module CoreDataConnector
 
           hash[key] << relationship
                          .related_place_with_centroid
-                         .to_search_json
+                         .to_search_json(include_relationships: false)
                          .merge(user_defined)
                          .merge({ inverse: false })
         end
@@ -479,7 +479,7 @@ module CoreDataConnector
 
           hash[key] << relationship
                          .related_record
-                         .to_search_json
+                         .to_search_json(include_relationships: false)
                          .merge(user_defined)
                          .merge({ inverse: false })
         end

--- a/app/services/core_data_connector/search/place.rb
+++ b/app/services/core_data_connector/search/place.rb
@@ -24,8 +24,12 @@ module CoreDataConnector
           place_names.map(&:name)
         end
 
-        search_attribute(:geometry) do
-          Geometry.to_geojson(place_geometry&.geometry)
+        search_attribute(:geometry) do |place, polygons|
+          if polygons
+            next Geometry.to_geojson(place_geometry&.geometry)
+          elsif self.respond_to?(:geometry_center) && geometry_center.present?
+            next Geometry.to_geojson(geometry_center)
+          end
         end
 
         search_attribute(:coordinates) do
@@ -35,7 +39,6 @@ module CoreDataConnector
           [geometry_center.y, geometry_center.x]
         end
       end
-
     end
   end
 end

--- a/app/services/core_data_connector/search/place.rb
+++ b/app/services/core_data_connector/search/place.rb
@@ -26,8 +26,8 @@ module CoreDataConnector
           place_names.map(&:name)
         end
 
-        search_attribute(:geometry) do |place, polygons|
-          if polygons && self.respond_to?(:simplified_geometry) && simplified_geometry.present?
+        search_attribute(:geometry) do |place, options|
+          if options[:polygons] && self.respond_to?(:simplified_geometry) && simplified_geometry.present?
             next Geometry.to_geojson(self.simplified_geometry)
           elsif self.respond_to?(:geometry_center) && geometry_center.present?
             next Geometry.to_geojson(geometry_center)

--- a/app/services/core_data_connector/search/place.rb
+++ b/app/services/core_data_connector/search/place.rb
@@ -9,7 +9,9 @@ module CoreDataConnector
         end
 
         def search_query(query)
-          query.merge(self.with_centroid)
+          query = query.merge(self.with_centroid)
+
+          query.merge(self.with_simplified_geometry)
         end
       end
 
@@ -25,8 +27,8 @@ module CoreDataConnector
         end
 
         search_attribute(:geometry) do |place, polygons|
-          if polygons
-            next Geometry.to_geojson(place_geometry&.geometry)
+          if polygons && self.respond_to?(:simplified_geometry) && simplified_geometry.present?
+            next Geometry.to_geojson(self.simplified_geometry)
           elsif self.respond_to?(:geometry_center) && geometry_center.present?
             next Geometry.to_geojson(geometry_center)
           end

--- a/lib/tasks/typesense.rake
+++ b/lib/tasks/typesense.rake
@@ -43,7 +43,7 @@ namespace :typesense do
   desc 'Index documents into Typesense'
   task index: :environment do
     options = Typesense::Options.parse(ARGV) do |opts, options|
-      opts.banner = 'Usage: typesense:index -- --host --port --protocol --api-key --collection-name --project-models'
+      opts.banner = 'Usage: typesense:index -- --host --port --protocol --api-key --collection-name --project-models --polygons'
       opts.on('-m', '--project-models ARG', Array) { |ids| options[:project_model_ids] = ids.map(&:to_i) }
     end
 
@@ -55,7 +55,9 @@ namespace :typesense do
       collection_name: options[:collection_name]
     )
 
-    helper.index options[:project_model_ids]
+    polygons = options[:polygons] || false
+
+    helper.index options[:project_model_ids], polygons
   end
 
   desc 'Updates the Typesense collection'

--- a/lib/tasks/typesense.rake
+++ b/lib/tasks/typesense.rake
@@ -55,9 +55,7 @@ namespace :typesense do
       collection_name: options[:collection_name]
     )
 
-    polygons = options[:polygons] || false
-
-    helper.index options[:project_model_ids], polygons
+    helper.index options[:project_model_ids], { polygons: options[:polygons] || false }
   end
 
   desc 'Updates the Typesense collection'

--- a/lib/typesense/helper.rb
+++ b/lib/typesense/helper.rb
@@ -62,7 +62,7 @@ module Typesense
       client.collections[collection_name].delete
     end
 
-    def index(project_model_ids)
+    def index(project_model_ids, polygons)
       collection = client.collections[collection_name]
 
       # Query project_models and build a hash of class names to arrays if project_model IDs
@@ -88,7 +88,7 @@ module Typesense
         ids = model_classes[model_class]
 
         klass.for_search(ids) do |records|
-          documents = records.map { |r| r.to_search_json(false).merge(import_attributes) }
+          documents = records.map { |r| r.to_search_json(skip_relationships: false, polygons: polygons).merge(import_attributes) }
           collection.documents.import(documents, action: 'emplace')
         end
       end

--- a/lib/typesense/helper.rb
+++ b/lib/typesense/helper.rb
@@ -62,8 +62,10 @@ module Typesense
       client.collections[collection_name].delete
     end
 
-    def index(project_model_ids, polygons)
+    def index(project_model_ids, options)
       collection = client.collections[collection_name]
+
+      options[:include_relationships] = false
 
       # Query project_models and build a hash of class names to arrays if project_model IDs
       model_classes = CoreDataConnector::ProjectModel
@@ -88,7 +90,7 @@ module Typesense
         ids = model_classes[model_class]
 
         klass.for_search(ids) do |records|
-          documents = records.map { |r| r.to_search_json(skip_relationships: false, polygons: polygons).merge(import_attributes) }
+          documents = records.map { |r| r.to_search_json(options).merge(import_attributes) }
           collection.documents.import(documents, action: 'emplace')
         end
       end

--- a/lib/typesense/options.rb
+++ b/lib/typesense/options.rb
@@ -12,6 +12,7 @@ module Typesense
       opts.on('-r', '--protocol ARG', String) { |protocol| options[:protocol] = protocol }
       opts.on('-a', '--api-key ARG', String) { |api_key| options[:api_key] = api_key }
       opts.on('-c', '--collection-name ARG', String) { |collection| options[:collection_name] = collection }
+      opts.on('--polygons') { options[:polygons] = true }
 
       args = opts.order!(args) {}
       opts.parse!(args)


### PR DESCRIPTION
# Summary

Finishing this pretty late in the day so it will remain a draft until I can look it over in the morning.

This PR:

- updates the default indexing behavior for places to index the centroid into the `geometry` field instead of the full polygon, by default
- updates the `typesense:index` Rake task to accept a new `--polygons` argument. If provided, a simplified version of the place's polygon will be indexed into `geometry`
- refactors `skip_relationships` to fit it alongside `polygons` in a new `options` object that the TS methods can pass around
  - I also renamed `skip_relationships` to `include_relationships` to avoid getting tripped up by double negatives