### PR TITLE
`order` field for relationships

### DIFF
--- a/app/controllers/core_data_connector/public/v1/public_controller.rb
+++ b/app/controllers/core_data_connector/public/v1/public_controller.rb
@@ -11,7 +11,9 @@ module CoreDataConnector
           return item_class.none unless params[:project_ids].present?
 
           if nested_resource?
-            item_class.joins(build_base_sql)
+            item_class
+              .joins(build_base_sql)
+              .order(:order)
           elsif params[:id].present?
             item_class.where(uuid: params[:id])
           elsif params[:project_ids].present?
@@ -101,6 +103,7 @@ module CoreDataConnector
                               }
                             )
                             .select(Relationship.arel_table[:related_record_id].as('id'))
+                            .select(Relationship.arel_table[:order].as('order'))
 
           if params[:project_model_relationship_uuid].present?
             primary_query = primary_query
@@ -123,6 +126,7 @@ module CoreDataConnector
                               }
                             )
                             .select(Relationship.arel_table[:primary_record_id].as('id'))
+                            .select(Relationship.arel_table[:order].as('order'))
 
           if params[:project_model_relationship_uuid].present?
             related_query = related_query

--- a/app/controllers/core_data_connector/public/v1/public_controller.rb
+++ b/app/controllers/core_data_connector/public/v1/public_controller.rb
@@ -13,7 +13,7 @@ module CoreDataConnector
           if nested_resource?
             item_class
               .joins(build_base_sql)
-              .order(:order)
+              .order('record.order')
           elsif params[:id].present?
             item_class.where(uuid: params[:id])
           elsif params[:project_ids].present?

--- a/app/controllers/core_data_connector/relationships_controller.rb
+++ b/app/controllers/core_data_connector/relationships_controller.rb
@@ -25,17 +25,21 @@ module CoreDataConnector
       # Relationships should always to scoped to a project model relationship. For inverse relationships, we'll
       # use the related record.
       if params[:inverse]
-        query = Relationship.where(
-          project_model_relationship_id: params[:project_model_relationship_id],
-          related_record_id: params[:record_id],
-          related_record_type: params[:record_type]
-        )
+        query = Relationship
+          .where(
+            project_model_relationship_id: params[:project_model_relationship_id],
+            related_record_id: params[:record_id],
+            related_record_type: params[:record_type]
+          )
+          .order(:order)
       else
-        query = Relationship.where(
-          project_model_relationship_id: params[:project_model_relationship_id],
-          primary_record_id: params[:record_id],
-          primary_record_type: params[:record_type]
-        )
+        query = Relationship
+          .where(
+            project_model_relationship_id: params[:project_model_relationship_id],
+            primary_record_id: params[:record_id],
+            primary_record_type: params[:record_type]
+          )
+          .order(:order)
       end
 
       # Include preloads for the different model types

--- a/app/controllers/core_data_connector/relationships_controller.rb
+++ b/app/controllers/core_data_connector/relationships_controller.rb
@@ -31,7 +31,6 @@ module CoreDataConnector
             related_record_id: params[:record_id],
             related_record_type: params[:record_type]
           )
-          .order(:order)
       else
         query = Relationship
           .where(
@@ -39,7 +38,6 @@ module CoreDataConnector
             primary_record_id: params[:record_id],
             primary_record_type: params[:record_type]
           )
-          .order(:order)
       end
 
       # Include preloads for the different model types

--- a/app/policies/core_data_connector/relationship_policy.rb
+++ b/app/policies/core_data_connector/relationship_policy.rb
@@ -50,6 +50,7 @@ module CoreDataConnector
         :primary_record_type,
         :related_record_id,
         :related_record_type,
+        :order,
         user_defined: {}
       ]
     end

--- a/app/serializers/core_data_connector/relationships_serializer.rb
+++ b/app/serializers/core_data_connector/relationships_serializer.rb
@@ -2,9 +2,9 @@ module CoreDataConnector
   class RelationshipsSerializer < BaseSerializer
     include UserDefinedFields::FieldableSerializer
 
-    index_attributes :id, :primary_record_id, :primary_record_type, :related_record_id, :related_record_type,
+    index_attributes :id, :primary_record_id, :primary_record_type, :related_record_id, :related_record_type, :order,
                      primary_record: FactorySerializer, related_record: FactorySerializer
-    show_attributes :id, :primary_record_id, :primary_record_type, :related_record_id, :related_record_type,
+    show_attributes :id, :primary_record_id, :primary_record_type, :related_record_id, :related_record_type, :order,
                     primary_record: FactorySerializer, related_record: FactorySerializer
   end
 end

--- a/db/migrate/20250407150531_add_order_to_relationships.rb
+++ b/db/migrate/20250407150531_add_order_to_relationships.rb
@@ -1,5 +1,5 @@
 class AddOrderToRelationships < ActiveRecord::Migration[7.0]
   def change
-    add_column :core_data_connector_relationships, :order, :integer, default: 0
+    add_column :core_data_connector_relationships, :order, :integer
   end
 end

--- a/db/migrate/20250407150531_add_order_to_relationships.rb
+++ b/db/migrate/20250407150531_add_order_to_relationships.rb
@@ -1,0 +1,5 @@
+class AddOrderToRelationships < ActiveRecord::Migration[7.0]
+  def change
+    add_column :core_data_connector_relationships, :order, :integer
+  end
+end

--- a/db/migrate/20250407150531_add_order_to_relationships.rb
+++ b/db/migrate/20250407150531_add_order_to_relationships.rb
@@ -1,5 +1,5 @@
 class AddOrderToRelationships < ActiveRecord::Migration[7.0]
   def change
-    add_column :core_data_connector_relationships, :order, :integer
+    add_column :core_data_connector_relationships, :order, :integer, default: 0
   end
 end


### PR DESCRIPTION
# Summary

- adds a new optional integer `order` field to the `core_data_connector_relationships` table
- updates `RelationshipsController` and `Public::V1::PublicController` to sort related records by `order`