### PR TITLE
CDC #412 - Import analyze

### DIFF
--- a/app/services/core_data_connector/import_analyze/import.rb
+++ b/app/services/core_data_connector/import_analyze/import.rb
@@ -65,7 +65,8 @@ module CoreDataConnector
                 data[filename][:data] << {
                   import: merge_row_hash,
                   db: merge_row_hash,
-                  merged: merge_record.record_merges.map { |rm| rm.merged_uuid }
+                  merged: merge_record.record_merges.map { |rm| rm.merged_uuid },
+                  result: merge_row_hash
                 }
               end
             end

--- a/app/services/core_data_connector/import_analyze/import.rb
+++ b/app/services/core_data_connector/import_analyze/import.rb
@@ -46,7 +46,8 @@ module CoreDataConnector
             data[filename][:data] << {
               import: row_hash,
               db: db,
-              merged: merged
+              merged: merged,
+              result: db || row_hash
             }
 
             # If the current record has been merged and removed, add a row for the record existing in the database. The


### PR DESCRIPTION
This pull request adds an additional `result` object to the payload of the `analyze` method in the `import_analyze` service. This object will be defaulted to the value of the Core Data record, if one exists. If a Core Data record does not exist, this will default to the values from the CSV file.

The front-end should use this object to manipulate values and send back to the server to be imported.