### PR TITLE
Metadata and ordering for related media contents in manifests

### DIFF
--- a/app/controllers/concerns/core_data_connector/manifests_controller.rb
+++ b/app/controllers/concerns/core_data_connector/manifests_controller.rb
@@ -8,6 +8,7 @@ module CoreDataConnector
       # Actions
       after_action :update_manifests_on_upload, only: :upload
       after_action :update_manifests_on_delete, only: :destroy
+      after_action :update_manifests_on_update, only: :update
       before_action :set_record_for_manifest, only: :destroy
 
       private
@@ -42,6 +43,20 @@ module CoreDataConnector
         service.reset_manifests_by_type(@record.class, {
           id: @record.id,
           project_model_relationship_id: @project_model_relationship_id,
+          limit: ENV['IIIF_MANIFEST_ITEM_LIMIT']
+        })
+      end
+
+      # After updating a relationship, generate the manifests for the target models
+      def update_manifests_on_update
+        relationship = Relationship.find(params[:id])
+
+        record = record_to_update(relationship)
+
+        service = Iiif::Manifest.new
+        service.reset_manifests_by_type(record.class, {
+          id: record.id,
+          project_model_relationship_id: relationship.project_model_relationship_id,
           limit: ENV['IIIF_MANIFEST_ITEM_LIMIT']
         })
       end

--- a/app/models/core_data_connector/media_content.rb
+++ b/app/models/core_data_connector/media_content.rb
@@ -10,6 +10,10 @@ module CoreDataConnector
     include TripleEyeEffable::Resourceable
     include UserDefinedFields::Fieldable
 
+    def metadata
+      self.user_defined.to_json
+    end
+
     # User defined fields parent
     resolve_defineable -> (media_content) { media_content.project_model }
   end

--- a/app/models/core_data_connector/media_content.rb
+++ b/app/models/core_data_connector/media_content.rb
@@ -11,7 +11,20 @@ module CoreDataConnector
     include UserDefinedFields::Fieldable
 
     def metadata
-      self.user_defined.to_json
+      udf_uuids = self.user_defined.keys
+
+      udfs = UserDefinedFields::UserDefinedField.where(uuid: udf_uuids)
+
+      values = []
+
+      udfs.each do |udf|
+        values.push({
+          label: udf[:column_name],
+          value: self.user_defined[udf[:uuid]]
+        })
+      end
+
+      values.to_json
     end
 
     # User defined fields parent

--- a/app/services/core_data_connector/iiif/manifest.rb
+++ b/app/services/core_data_connector/iiif/manifest.rb
@@ -124,6 +124,7 @@ module CoreDataConnector
       def apply_preloads(query, options)
         relationships_scope = Relationship
                                 .where(related_record_type: MediaContent.to_s)
+                                .order(:order)
 
         if options[:project_model_relationship_id].present?
           relationships_scope = relationships_scope.where(
@@ -145,6 +146,7 @@ module CoreDataConnector
                                         .where(project_model_relationship: {
                                           allow_inverse: true
                                         })
+                                        .order(:order)
 
         if options[:project_model_relationship_id].present?
           related_relationships_scope = related_relationships_scope.where(


### PR DESCRIPTION
# Summary

* adds a new `metadata` method to the media contents model that sends a JSON string of the record's user-defined fields
* orders the `resources` array sent to IIIF Cloud based on the `order` value of the relationship records (see #142)