### PR TITLE
Update relationship manifests when a `MediaContent` record's UDFs are updated

### DIFF
--- a/app/models/core_data_connector/media_content.rb
+++ b/app/models/core_data_connector/media_content.rb
@@ -10,6 +10,31 @@ module CoreDataConnector
     include TripleEyeEffable::Resourceable
     include UserDefinedFields::Fieldable
 
+    after_save :update_manifests
+
+    def update_manifests
+      self.related_relationships.each do |relationship|
+        if relationship.primary_record_type == 'CoreDataConnector::MediaContent'
+          model_class = relationship.related_record_type.constantize
+        else
+          model_class = relationship.primary_record_type.constantize
+        end
+
+        if relationship.primary_record_id == self.id
+          related_record_id = relationship.related_record_id
+        else
+          related_record_id = relationship.primary_record_id
+        end
+
+        service = Iiif::Manifest.new
+        service.reset_manifests_by_type(model_class, {
+          id: related_record_id,
+          project_model_relationship_id: relationship.project_model_relationship_id,
+          limit: ENV['IIIF_MANIFEST_ITEM_LIMIT']
+        })
+      end
+    end
+
     def metadata
       if !self.user_defined || self.user_defined.keys.count == 0
         return '[]'

--- a/app/models/core_data_connector/media_content.rb
+++ b/app/models/core_data_connector/media_content.rb
@@ -21,14 +21,14 @@ module CoreDataConnector
 
     def update_relationship_manifests(relationship, service, is_primary)
       if is_primary
-        model_class = relationship.related_record_type.constantize
+        related_model = relationship.related_record_type.constantize
         related_record_id = relationship.related_record_id
       else
-        model_class = relationship.primary_record_type.constantize
+        related_model = relationship.primary_record_type.constantize
         related_record_id = relationship.primary_record_id
       end
 
-      service.reset_manifests_by_type(model_class, {
+      service.reset_manifests_by_type(related_model, {
         id: related_record_id,
         project_model_relationship_id: relationship.project_model_relationship_id,
         limit: ENV['IIIF_MANIFEST_ITEM_LIMIT']


### PR DESCRIPTION
# Summary

This PR updates the `MediaContent` model to call the `reset_manifests_by_type` method of `Iiif::Manifest` when a media content record is updated to regenerate the associated manifest.

In other words, when you update a user-defined field on an image, any manifests containing that image will be updated to contain the new UDF value.