### PR TITLE
CDC #438 - Nested routes

### DIFF
--- a/app/controllers/concerns/core_data_connector/public/v1/nestable_controller.rb
+++ b/app/controllers/concerns/core_data_connector/public/v1/nestable_controller.rb
@@ -14,7 +14,7 @@ module CoreDataConnector
           before_action :set_current_record
 
           def nested_resource?
-            NESTABLE_PARAMS.any? { |p| params[p].present? } && current_record.present?
+            NESTABLE_PARAMS.any? { |p| params[p].present? }
           end
 
           private

--- a/app/controllers/core_data_connector/public/v0/public_controller.rb
+++ b/app/controllers/core_data_connector/public/v0/public_controller.rb
@@ -8,8 +8,10 @@ module CoreDataConnector
         protected
 
         def base_query
-          if nested_resource?
+          if nested_resource? && current_record.present?
             item_class.where(build_base_sql)
+          elsif nested_resource?
+            item_class.none
           elsif params[:project_ids].present?
             item_class.all_records_by_project(params[:project_ids])
           else

--- a/app/controllers/core_data_connector/public/v1/public_controller.rb
+++ b/app/controllers/core_data_connector/public/v1/public_controller.rb
@@ -10,10 +10,10 @@ module CoreDataConnector
         def base_query
           return item_class.none unless params[:project_ids].present?
 
-          if nested_resource?
-            item_class
-              .joins(build_base_sql)
-              .order('record.order')
+          if nested_resource? && current_record.present?
+            item_class.joins(build_base_sql).order('record.order')
+          elsif nested_resource?
+            item_class.none
           elsif params[:id].present?
             item_class.where(uuid: params[:id])
           elsif params[:project_ids].present?
@@ -27,7 +27,7 @@ module CoreDataConnector
         def preloads(query)
           super
 
-          return unless nested_resource?
+          return unless nested_resource? && current_record.present?
 
           primary_scope = Relationship
                             .joins(project_model_relationship: :related_model)


### PR DESCRIPTION
This pull request fixes an issue with the nested routes in the public API. The problem was that requests for related records for a record that doesn't exist (e.g. `GET /places/abcdefg/events`) will return all records in the project.

The solution was to remove the `current_record.present?` check from the `nested_resource?` method. This way we can take separate action if the request is for a nested resource and the base record does not exist.