### PR TITLE
CDC #440 - User types

### DIFF
--- a/app/controllers/core_data_connector/user_projects_controller.rb
+++ b/app/controllers/core_data_connector/user_projects_controller.rb
@@ -1,7 +1,7 @@
 module CoreDataConnector
   class UserProjectsController < ApplicationController
     # Search attributes
-    search_attributes 'users.name', 'users.email', 'projects.name', 'projects.description'
+    search_attributes 'core_data_connector_users.name', 'core_data_connector_users.email', 'core_data_connector_projects.name', 'core_data_connector_projects.description'
 
     # Joins
     joins :user, :project

--- a/app/models/core_data_connector/user.rb
+++ b/app/models/core_data_connector/user.rb
@@ -1,5 +1,16 @@
 module CoreDataConnector
   class User < ApplicationRecord
+    # Roles
+    ROLE_ADMIN = 'admin'
+    ROLE_MEMBER = 'member'
+    ROLE_GUEST = 'guest'
+
+    ALLOWED_ROLES = [
+      ROLE_ADMIN,
+      ROLE_MEMBER,
+      ROLE_GUEST
+    ]
+
     # Domains that have SSO enabled
     SSO_DOMAINS = ENV['REACT_APP_SSO_DOMAINS'] ? ENV['REACT_APP_SSO_DOMAINS'].split(',') : []
 
@@ -9,11 +20,27 @@ module CoreDataConnector
     # JWT
     has_secure_password
 
+    # Actions
     before_validation :set_sso_password, on: :create
 
     # Validations
-    validates :email, uniqueness: true
     validate :validate_sso_password
+    validates :email, uniqueness: true
+    validates :role, inclusion:  { in: ALLOWED_ROLES, message: I18n.t('errors.users.roles') }
+
+    def admin?
+      role === ROLE_ADMIN
+    end
+
+    def guest?
+      role === ROLE_GUEST
+    end
+
+    def member?
+      role === ROLE_MEMBER
+    end
+
+    private
 
     # Add a long, random password for accounts created via SSO
     def set_sso_password

--- a/app/models/core_data_connector/user_project.rb
+++ b/app/models/core_data_connector/user_project.rb
@@ -16,6 +16,7 @@ module CoreDataConnector
     attr_accessor :name, :email, :password, :password_confirmation
 
     # Validations
+    validate :validate_project_owner
     validates :role, inclusion:  { in: ALLOWED_ROLES, message: I18n.t('errors.user_projects.roles') }
     validates :user_id, uniqueness: { scope: :project_id, message: I18n.t('errors.user_projects.unique') }
 
@@ -52,6 +53,19 @@ module CoreDataConnector
         password: password,
         password_confirmation: password_confirmation
       )
+    end
+
+    # Validates that the project has at least one owner
+    def validate_project_owner
+      return unless role == ROLE_EDITOR
+
+      has_owner = project
+                    .user_projects
+                    .where(role: ROLE_OWNER)
+                    .where.not(id: id)
+                    .exists?
+
+      errors.add(:role, I18n.t('errors.user_projects.role_owner')) unless has_owner
     end
   end
 end

--- a/app/models/core_data_connector/user_project.rb
+++ b/app/models/core_data_connector/user_project.rb
@@ -16,8 +16,8 @@ module CoreDataConnector
     attr_accessor :name, :email, :password, :password_confirmation
 
     # Validations
-    validates :role, inclusion:  { in: ALLOWED_ROLES, message: I18n.t('errors.user_project.roles') }
-    validates :user_id, uniqueness: { scope: :project_id, message: I18n.t('errors.user_project.unique') }
+    validates :role, inclusion:  { in: ALLOWED_ROLES, message: I18n.t('errors.user_projects.roles') }
+    validates :user_id, uniqueness: { scope: :project_id, message: I18n.t('errors.user_projects.unique') }
 
     # Callbacks
     before_update :reset_password
@@ -36,7 +36,8 @@ module CoreDataConnector
         user.assign_attributes(
           name: name,
           password: password,
-          password_confirmation: password_confirmation
+          password_confirmation: password_confirmation,
+          role: User::ROLE_GUEST
         )
       end
 

--- a/app/policies/core_data_connector/project_policy.rb
+++ b/app/policies/core_data_connector/project_policy.rb
@@ -21,9 +21,9 @@ module CoreDataConnector
       project_owner?
     end
 
-    # Any user can create a new project.
+    # Users with an "admin" or "member" role can create projects.
     def create?
-      true
+      current_user.admin? || current_user.member?
     end
 
     # A user can view any project for which they are a member.

--- a/app/policies/core_data_connector/user_policy.rb
+++ b/app/policies/core_data_connector/user_policy.rb
@@ -43,27 +43,12 @@ module CoreDataConnector
       params
     end
 
-    # A user can view another user if they have access to the same project.
+    # Only admin users can view users outside of a project context
     class Scope < BaseScope
       def resolve
         return scope.all if current_user.admin?
 
-        user_projects = UserProject.arel_table.alias('b')
-
-        scope.where(
-          UserProject
-            .where(UserProject.arel_table[:user_id].eq(User.arel_table[:id]))
-            .where(
-              UserProject
-                .arel_table
-                .project(1)
-                .from(user_projects)
-                .where(user_projects[:project_id].eq(UserProject.arel_table[:project_id]))
-                .where(user_projects[:user_id].eq(current_user.id))
-                .exists
-                .to_sql
-            ).arel.exists
-        )
+        scope.none
       end
     end
   end

--- a/app/policies/core_data_connector/user_policy.rb
+++ b/app/policies/core_data_connector/user_policy.rb
@@ -20,16 +20,16 @@ module CoreDataConnector
       current_user.admin?
     end
 
-    # Only admin users can view users outside the context of a project. Users can view themselves outside the
-    # context of a project.
+    # Only admin users can view users outside the context of a project. Users can view
+    # themselves outside the context of a project.
     def show?
       return true if current_user.admin?
 
       current_user.id == user.id
     end
 
-    # Only admin users can update users outside the context of a project. Users can update themselves outside the
-    # context of a project.
+    # Only admin users can update users outside the context of a project. Users can update
+    # themselves outside the context of a project.
     def update?
       return true if current_user.admin?
 
@@ -38,9 +38,7 @@ module CoreDataConnector
 
     # Allowed create/update attributes.
     def permitted_attributes
-      params = [:name, :email, :password, :password_confirmation]
-      params << :role if current_user.admin?
-      params
+      [:name, :email, :role, :password, :password_confirmation]
     end
 
     # Users can only view themselves outside of a project context.

--- a/app/policies/core_data_connector/user_policy.rb
+++ b/app/policies/core_data_connector/user_policy.rb
@@ -43,12 +43,12 @@ module CoreDataConnector
       params
     end
 
-    # Only admin users can view users outside of a project context
+    # Users can only view themselves outside of a project context.
     class Scope < BaseScope
       def resolve
         return scope.all if current_user.admin?
 
-        scope.none
+        User.where(id: current_user.id)
       end
     end
   end

--- a/app/policies/core_data_connector/user_policy.rb
+++ b/app/policies/core_data_connector/user_policy.rb
@@ -39,7 +39,7 @@ module CoreDataConnector
     # Allowed create/update attributes.
     def permitted_attributes
       params = [:name, :email, :password, :password_confirmation]
-      params << :admin if current_user.admin?
+      params << :role if current_user.admin?
       params
     end
 

--- a/app/serializers/core_data_connector/users_serializer.rb
+++ b/app/serializers/core_data_connector/users_serializer.rb
@@ -1,6 +1,6 @@
 module CoreDataConnector
   class UsersSerializer < BaseSerializer
-    index_attributes :id, :name, :email, :admin
-    show_attributes :id, :name, :email, :admin, user_projects: UserProjectsSerializer
+    index_attributes :id, :name, :email, :role
+    show_attributes :id, :name, :email, :role, user_projects: UserProjectsSerializer
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -111,6 +111,7 @@ en:
       import_configuration: "Configuration file required"
       import_data: "Importable contents required"
     user_projects:
+      role_owner: "Projects must have an owner."
       roles: "Invalid role"
       unique: "This user cannot be added to the same project multiple times."
     users:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,6 +78,12 @@ en:
       show?: "You do not have permission to view this taxonomy."
       update?: "You do not have permission to update this taxonomy."
 
+    core_data_connector/user_project_policy:
+      create?: "You do not have permission to create an add users to this project."
+      delete?: "You do not have permission to delete users from this project."
+      show?: "You do not have permission to view users in this project."
+      update?: "You do not have permission to update users in this project."
+
     core_data_connector/work_policy:
       create?: "You do not have permission to create a work."
       delete?: "You do not have permission to delete this work."
@@ -104,10 +110,14 @@ en:
       authorize: "You do not have permission to import these records. Please contact your system administrator."
       import_configuration: "Configuration file required"
       import_data: "Importable contents required"
+    user_projects:
+      roles: "Invalid role"
+      unique: "This user cannot be added to the same project multiple times."
     users:
+      not_found: "User not found"
       password:
         sso: "Cannot reset passwords for SSO users"
-      not_found: "User not found"
+      roles: "Invalid role"
     web_authorities_controller:
       find:
         identifier: "An identifier is required"

--- a/db/migrate/20250529183028_add_role_to_users.rb
+++ b/db/migrate/20250529183028_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :core_data_connector_users, :role, :string
+  end
+end

--- a/db/migrate/20250529183706_set_role_on_users.rb
+++ b/db/migrate/20250529183706_set_role_on_users.rb
@@ -1,0 +1,27 @@
+class SetRoleOnUsers < ActiveRecord::Migration[7.0]
+  def change
+    execute <<-SQL.squish
+      UPDATE core_data_connector_users users
+         SET role = 'member'
+       WHERE EXISTS ( SELECT 1
+                        FROM core_data_connector_user_projects user_projects
+                       WHERE user_projects.user_id = users.id
+                         AND user_projects.role = 'owner' )
+    SQL
+
+    execute <<-SQL.squish
+      UPDATE core_data_connector_users users
+         SET role = 'guest'
+       WHERE NOT EXISTS ( SELECT 1
+                            FROM core_data_connector_user_projects user_projects
+                           WHERE user_projects.user_id = users.id
+                             AND user_projects.role = 'owner' )
+    SQL
+
+    execute <<-SQL.squish
+      UPDATE core_data_connector_users
+         SET role = 'admin'
+       WHERE admin IS TRUE
+    SQL
+  end
+end

--- a/db/migrate/20250602115106_set_default_role_on_user_projects.rb
+++ b/db/migrate/20250602115106_set_default_role_on_user_projects.rb
@@ -1,0 +1,6 @@
+class SetDefaultRoleOnUserProjects < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :core_data_connector_user_projects, :role, 'editor'
+    change_column_null :core_data_connector_user_projects, :role, false
+  end
+end

--- a/db/migrate/20250603111744_remove_admin_from_users.rb
+++ b/db/migrate/20250603111744_remove_admin_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveAdminFromUsers < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :core_data_connector_users, :admin
+  end
+end


### PR DESCRIPTION
This pull request removes the `core_data_connector_users.admin` column in favor of `core_data_connector_users.role`. The `role` column can have three possible values:

- "admin" - Administrator user; Same functionality as the "admin" column previously
- "member" - User is allowed to create projects and add users to projects
- "guest" - User is allowed to modify data within a project; Cannot create projects or add users

The biggest change here is that we're moving the permission to add users to a project from a project-level permission (set by the project owner) to an application-level permission (set by an administrator).

For existing users: 
- Any user who currently has the `admin` column set to "true" will become an "Administrator"
- Any user who currently has an "Owner" role in a project will become a "Member"
- All other users will become a "Guest"

This pull request also fixes a couple of minor issues that were encountered along the way:

- Fixes a bug that occurred when searching for users within a project
- Adds a validation to ensure that every project has at least one owner
- Adds missing i18n translations for validation errors