### PR TITLE
CDC #450 - Mail safe

### DIFF
--- a/app/models/core_data_connector/user_project.rb
+++ b/app/models/core_data_connector/user_project.rb
@@ -21,7 +21,7 @@ module CoreDataConnector
     validates :user_id, uniqueness: { scope: :project_id, message: I18n.t('errors.user_projects.unique') }
 
     # Callbacks
-    after_create :send_invitation
+    after_commit :send_invitation, on: :create
     before_validation :find_or_create_user, on: :create
 
     private


### PR DESCRIPTION
This pull request fixes a timing issue that occurs when creating an user and attempting to send an invitation. The user was being created successfully, but the invitation mailer was being called before the record was committed to the database, resulting in a `Error while trying to deserialize arguments` error in the mailer.

The solution was to move the invitation call to the `after_commit` callback when the record is created to ensure it is in the database.