### PR TITLE
CDC #470 - Storage keys

### DIFF
--- a/app/models/core_data_connector/media_content.rb
+++ b/app/models/core_data_connector/media_content.rb
@@ -10,7 +10,31 @@ module CoreDataConnector
     include TripleEyeEffable::Resourceable
     include UserDefinedFields::Fieldable
 
+    # Delegates
+    delegate :storage_key, to: :project, allow_nil: true
+
+    # Callbacks
     after_save :update_manifests
+
+    # User defined fields parent
+    resolve_defineable -> (media_content) { media_content.project_model }
+
+    def metadata
+      if !self.user_defined || self.user_defined.keys.count == 0
+        return '[]'
+      end
+
+      fields = UserDefinedFields::UserDefinedField.where(uuid: self.user_defined.keys).map do |udf|
+        {
+          label: udf[:column_name],
+          value: self.user_defined[udf[:uuid]]
+        }
+      end
+
+      fields.to_json
+    end
+
+    private
 
     def update_manifests
       iiif_service = Iiif::Manifest.new
@@ -34,23 +58,5 @@ module CoreDataConnector
         limit: ENV['IIIF_MANIFEST_ITEM_LIMIT']
       })
     end
-
-    def metadata
-      if !self.user_defined || self.user_defined.keys.count == 0
-        return '[]'
-      end
-
-      fields = UserDefinedFields::UserDefinedField.where(uuid: self.user_defined.keys).map do |udf|
-        {
-          label: udf[:column_name],
-          value: self.user_defined[udf[:uuid]]
-        }
-      end
-
-      fields.to_json
-    end
-
-    # User defined fields parent
-    resolve_defineable -> (media_content) { media_content.project_model }
   end
 end

--- a/app/models/core_data_connector/project.rb
+++ b/app/models/core_data_connector/project.rb
@@ -4,5 +4,11 @@ module CoreDataConnector
     has_many :project_models, dependent: :destroy
     has_many :user_projects, dependent: :destroy
     has_many :web_authorities, dependent: :destroy
+
+    def storage_key
+      return nil unless use_storage_key?
+
+      uuid
+    end
   end
 end

--- a/db/migrate/20250724125222_add_uuid_to_projects.rb
+++ b/db/migrate/20250724125222_add_uuid_to_projects.rb
@@ -1,0 +1,5 @@
+class AddUuidToProjects < ActiveRecord::Migration[8.0]
+  def change
+    add_column :core_data_connector_projects, :uuid, :uuid, default: 'gen_random_uuid()', null: false
+  end
+end

--- a/db/migrate/20250724125258_add_use_storage_key_to_projects.rb
+++ b/db/migrate/20250724125258_add_use_storage_key_to_projects.rb
@@ -1,0 +1,5 @@
+class AddUseStorageKeyToProjects < ActiveRecord::Migration[8.0]
+  def change
+    add_column :core_data_connector_projects, :use_storage_key, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20250724135202_update_projects_use_storage_key_default.rb
+++ b/db/migrate/20250724135202_update_projects_use_storage_key_default.rb
@@ -1,0 +1,5 @@
+class UpdateProjectsUseStorageKeyDefault < ActiveRecord::Migration[8.0]
+  def change
+    change_column_default :core_data_connector_projects, :use_storage_key, from: false, to: true
+  end
+end


### PR DESCRIPTION
This pull request adds the `uuid` and `use_storage_key` columns to the `projects` table. The idea here is that we'll generate a unique identifier for each project created and store all of the media associated with that project in S3 under a folder identified by the `uuid` value.

The reason we're initially setting the `use_storage_key` value to "false" then flipping it to "true" is so that existing projects can continue to _not_ use a storage key and we won't be required to rename any existing objects, but new projects will have their objects separated into folders.

@jamiefolsom - Any thoughts on whether we need to migrate the S3 objects for existing projects into folders?