### PR TITLE
CDC #474 - Import jobs

### DIFF
--- a/app/controllers/core_data_connector/items_controller.rb
+++ b/app/controllers/core_data_connector/items_controller.rb
@@ -15,7 +15,7 @@ module CoreDataConnector
 
     def analyze_import
       item = find_record(item_class)
-      authorize item if authorization_valid?
+      authorize item
 
       errors = nil
       data = nil
@@ -49,7 +49,7 @@ module CoreDataConnector
 
     def import
       item = find_record(item_class)
-      authorize item if authorization_valid?
+      authorize item
 
       begin
         service = ImportAnalyze::Helper.new
@@ -64,7 +64,7 @@ module CoreDataConnector
       if errors.nil? || errors.empty?
         render json: { }, status: :ok
       else
-        render json: { errors: errors }, status: :bad_request
+        render json: { errors: errors }, status: :unprocessable_entity
       end
     end
   end

--- a/app/controllers/core_data_connector/jobs_controller.rb
+++ b/app/controllers/core_data_connector/jobs_controller.rb
@@ -1,0 +1,31 @@
+module CoreDataConnector
+  class JobsController < ApplicationController
+    # Search attributes
+    search_attributes 'core_data_connector_users.name', 'core_data_connector_projects.name', :job_type
+
+    # Joins
+    joins :project, :user
+
+    # Preloads
+    preloads file_attachment: :blob
+    preloads :project, :user
+
+    protected
+
+    def apply_filters(query)
+      query = super
+
+      query = filter_project(query)
+
+      query
+    end
+
+    private
+
+    def filter_project(query)
+      return query unless params[:project_id].present?
+
+      query.where(project_id: params[:project_id])
+    end
+  end
+end

--- a/app/jobs/core_data_connector/import_csv_job.rb
+++ b/app/jobs/core_data_connector/import_csv_job.rb
@@ -1,0 +1,51 @@
+module CoreDataConnector
+  class ImportCsvJob < ApplicationJob
+
+    def perform(job_id)
+      job = Job.find(job_id)
+
+      # Update the job status
+      job.update(status: Job::JOB_STATUS_PROCESSING)
+
+      # Run the import for the uploaded file
+      success = nil
+      errors = []
+
+      job.file.open do |file|
+        begin
+          zip_importer = Import::ZipHelper.new
+          success, errors = zip_importer.import_zip(file)
+        rescue StandardError => error
+          errors = [error]
+        end
+      end
+
+      # Remove duplicate records, if specified
+      remove_duplicates job if success
+
+      # Update the job status
+      if success && errors.empty?
+        job.update(status: Job::JOB_STATUS_COMPLETED)
+      else
+        log_errors errors
+        job.update(status: Job::JOB_STATUS_FAILED)
+      end
+    end
+
+    private
+
+    def log_errors(errors)
+      errors.each do |error|
+        Rails.logger.error (["#{self.class} - #{error.class}: #{error.message}", error.backtrace]).join("\n")
+      end
+    end
+
+    def remove_duplicates(job)
+      return unless job.extra['filenames'].present?
+
+      service = ImportAnalyze::Import.new
+      service.remove_duplicates job.project_id, job.extra['filenames']
+    end
+
+  end
+end

--- a/app/models/core_data_connector/job.rb
+++ b/app/models/core_data_connector/job.rb
@@ -1,0 +1,35 @@
+module CoreDataConnector
+  class Job < ApplicationRecord
+    JOB_STATUS_INITIALIZING = 'initializing'
+    JOB_STATUS_PROCESSING = 'processing'
+    JOB_STATUS_COMPLETED = 'completed'
+    JOB_STATUS_FAILED = 'failed'
+
+    JOB_TYPE_IMPORT = 'import'
+
+    # Includes
+    include Rails.application.routes.url_helpers
+
+    # Relationships
+    belongs_to :project
+    belongs_to :user
+
+    # Active storage
+    has_one_attached :file
+
+    # Callbacks
+    after_create_commit :after_create
+
+    def download_url
+      return nil unless file.attached?
+
+      rails_blob_url file, disposition: 'attachment'
+    end
+
+    private
+
+    def after_create
+      ImportCsvJob.perform_later(id) if job_type == JOB_TYPE_IMPORT
+    end
+  end
+end

--- a/app/policies/core_data_connector/job_policy.rb
+++ b/app/policies/core_data_connector/job_policy.rb
@@ -1,0 +1,39 @@
+module CoreDataConnector
+  class JobPolicy < BasePolicy
+    attr_reader :current_user, :job
+
+    def initialize(current_user, job)
+      @current_user = current_user
+      @job = job
+    end
+
+    # Jobs cannot be created via the API.
+    def create?
+      false
+    end
+
+    # Only admin users can delete a job.
+    def destroy?
+      current_user.admin?
+    end
+
+    # Jobs cannot be viewed via the API.
+    def show?
+      false
+    end
+
+    # Jobs cannot be updated via the API.
+    def update?
+      false
+    end
+
+    # Admin users can view all jobs, other users can view no jobs.
+    class Scope < BaseScope
+      def resolve
+        return scope.all if current_user.admin?
+
+        scope.none
+      end
+    end
+  end
+end

--- a/app/policies/core_data_connector/user_policy.rb
+++ b/app/policies/core_data_connector/user_policy.rb
@@ -20,6 +20,11 @@ module CoreDataConnector
       current_user.admin?
     end
 
+    # Only admin users can view background jobs.
+    def jobs?
+      current_user.admin?
+    end
+
     # Only admin users can view users outside the context of a project. Users can view
     # themselves outside the context of a project.
     def show?

--- a/app/serializers/core_data_connector/jobs_serializer.rb
+++ b/app/serializers/core_data_connector/jobs_serializer.rb
@@ -1,0 +1,9 @@
+module CoreDataConnector
+  class JobsSerializer < BaseSerializer
+    index_attributes :id, :project_id, :user_id, :job_type, :status, :download_url, :created_at, :extra,
+                     project: ProjectsSerializer, user: UsersSerializer
+
+    show_attributes :id, :project_id, :user_id, :job_type, :status, :download_url, :created_at, :extra,
+                    project: ProjectsSerializer, user: UsersSerializer
+  end
+end

--- a/app/services/core_data_connector/import/events.rb
+++ b/app/services/core_data_connector/import/events.rb
@@ -29,7 +29,7 @@ module CoreDataConnector
 
         execute <<-SQL.squish
           UPDATE fuzzy_dates_fuzzy_dates fuzzy_dates
-             SET accuracy = #{FuzzyDates::FuzzyDate.accuraries['date']},
+             SET accuracy = #{FuzzyDates::FuzzyDate.accuracies['date']},
                  range = FALSE,
                  start_date = z_events.start_date_start_date,
                  end_date = z_events.start_date_end_date,
@@ -43,7 +43,7 @@ module CoreDataConnector
 
         execute <<-SQL.squish
           UPDATE fuzzy_dates_fuzzy_dates fuzzy_dates
-             SET accuracy = #{FuzzyDates::FuzzyDate.accuraries['date']},
+             SET accuracy = #{FuzzyDates::FuzzyDate.accuracies['date']},
                  range = FALSE,
                  start_date = z_events.end_date_start_date,
                  end_date = z_events.end_date_end_date,
@@ -103,7 +103,7 @@ module CoreDataConnector
           SELECT insert_events.event_id,
                  'CoreDataConnector::Event',
                  'start_date',
-                  #{FuzzyDates::FuzzyDate::accuraries['date']},
+                  #{FuzzyDates::FuzzyDate::accuracies['date']},
                   false,
                   z_events.start_date_start_date,
                   z_events.start_date_end_date,
@@ -132,7 +132,7 @@ module CoreDataConnector
           SELECT insert_events.event_id,
                  'CoreDataConnector::Event',
                  'end_date',
-                  #{FuzzyDates::FuzzyDate::accuraries['date']},
+                  #{FuzzyDates::FuzzyDate::accuracies['date']},
                   false,
                   z_events.end_date_start_date,
                   z_events.end_date_end_date,

--- a/app/services/core_data_connector/import_analyze/import.rb
+++ b/app/services/core_data_connector/import_analyze/import.rb
@@ -164,20 +164,20 @@ module CoreDataConnector
         zipfile_name
       end
 
-      def remove_duplicates(files, project_id)
+      def remove_duplicates(project_id, filenames)
+        return unless project_id.present? && filenames.present?
+
         service = Merge::Merger.new
 
-        files.keys.each do |filename|
-          next unless files[filename][:remove_duplicates].to_s.to_bool
-
+        filenames.each do |filename|
           klass = find_class(filename)
           grouped_duplicates = klass.find_duplicates(project_id)
 
           next if grouped_duplicates.empty?
 
           grouped_duplicates.each do |group|
-            primary = klass.preload(Helper::PRELOADS).find(group.primary_id)
-            duplicates = klass.preload(Helper::PRELOADS).where(id: group.duplicate_ids)
+            primary = klass.preload(ImportAnalyze::Helper::PRELOADS).find(group.primary_id)
+            duplicates = klass.preload(ImportAnalyze::Helper::PRELOADS).where(id: group.duplicate_ids)
 
             service.merge(primary, duplicates)
           end

--- a/app/services/core_data_connector/import_analyze/policy.rb
+++ b/app/services/core_data_connector/import_analyze/policy.rb
@@ -2,15 +2,16 @@ module CoreDataConnector
   module ImportAnalyze
     class Policy
 
-      attr_reader :current_user
+      attr_reader :current_user, :files
 
-      def initialize(current_user)
+      def initialize(current_user, files)
         @current_user = current_user
+        @files = files
       end
 
       # A user can analyze the set of files if they are an admin or have access to the project(s) containing all of the
       # models and relationships they are attempting to import.
-      def has_analyze_access?(files)
+      def has_analyze_access?
         return true if current_user.admin?
 
         project_model_ids = files
@@ -30,7 +31,7 @@ module CoreDataConnector
 
       # A user can import the set of files if they are an admin or have access to the project(s) containing all of the
       # models and relationships they are attempting to import.
-      def has_import_access?(files)
+      def has_import_access?
         return true if current_user.admin?
 
         project_model_ids = files

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -14,6 +14,8 @@ resources :items do
   post :merge, on: :collection
 end
 
+resources :jobs, only: :index
+
 resources :media_contents do
   post :merge, on: :collection
 end

--- a/db/migrate/20250725104315_create_core_data_connector_jobs.rb
+++ b/db/migrate/20250725104315_create_core_data_connector_jobs.rb
@@ -1,0 +1,12 @@
+class CreateCoreDataConnectorJobs < ActiveRecord::Migration[8.0]
+  def change
+    create_table :core_data_connector_jobs do |t|
+      t.references :project, null: false
+      t.references :user, null: false
+      t.string :job_type
+      t.string :status, default: 'initializing'
+      t.jsonb :extra, default: {}
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
This pull request makes the following changes to support running imports as background jobs:

- Creates the `core_data_connector_jobs` table
- Adds the `GET /core_data/jobs` API endpoint
- Refactors the import helpers to create `Job` records
- Adds the `ImportCsvJob` ActiveJob class
- Fixes a bug with the `FuzzyDate::accuracies` enum