### PR TITLE
Fix `update` function to have the correct type for coordinates field

### DIFF
--- a/lib/typesense/helper.rb
+++ b/lib/typesense/helper.rb
@@ -114,8 +114,8 @@ module Typesense
 
         if name.end_with?('_facet') && !field['facet']
           fields_to_update.push({ name: name, drop: true }, field.merge({ facet: true }))
-        elsif name.include?('coordinates') && !name.include?('geometry') && field['type'] != 'geopoint[]'
-          fields_to_update.push({ name: name, drop: true }, field.merge({ type: 'geopoint[]', sort: true }))
+        elsif name.include?('coordinates') && !name.include?('geometry') && field['type'] != 'geopoint'
+          fields_to_update.push({ name: name, drop: true }, field.merge({ type: 'geopoint', sort: true }))
         end
       end
 


### PR DESCRIPTION
### In this PR
Fixes a bug where the Typesense `update` task would fail for collections with place records because it attempts to change the type of the `coordinates` field to `GeoPoint[]` rather than `GeoPoint`, which does not match the data that's indexed from FairData with the `index` task.