### PR TITLE
CDC #481 - Reconciliation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,28 +71,71 @@ Data can be indexed into a Typesense search index using the following commands:
 
 #### Create a new collection
 ```bash
-bundle exec rake typesense:create -- -h host -p port -r protocol -a api_key -c collection_name
+bundle exec rake typesense:search:create -- -h host -p port -r protocol -a api_key -c collection_name
 ```
 
 #### Delete a collection
 ```bash
-bundle exec rake typesense:delete -- -h host -p port -r protocol -a api_key -c collection_name
+bundle exec rake typesense:search:delete -- -h host -p port -r protocol -a api_key -c collection_name
 ```
 
 #### Index documents into a collection
 ```bash
-bundle exec rake typesense:index -- -h host -p port -r protocol -a api_key -c collection_name -m model_ids --polygons
+bundle exec rake typesense:search:index -- -h host -p port -r protocol -a api_key -c collection_name -m model_ids --polygons
 ```
 
 **Note:** This task expects the entire collection to be indexed. Any records not included in the batch will be removed from the index.
 
 #### Update a collection
 ```bash
-bundle exec rake typesense:update -- -h host -p port -r protocol -a api_key -c collection_name
+bundle exec rake typesense:search:update -- -h host -p port -r protocol -a api_key -c collection_name
 ```
 
 **Note:** This task was added as a workaround for an issue in Typesense indexing nested facetable fields using auto-detection schema. This task should be run _after_ the indexing process to update the "facet" attribute on any fields that should be facetable.
 
+## Reconciliation API
+
+### Indexing Data
+
+Data can be indexed into a Typesense search index using the following commands. The search index is used as the data store for results returned from the Reconciliation API.
+
+#### Create a new collection
+```bash
+bundle exec rake typesense:reconcile:create -- -h host -p port -r protocol -a api_key -c collection_name
+```
+
+#### Delete a collection
+```bash
+bundle exec rake typesense:reconcile:delete -- -h host -p port -r protocol -a api_key -c collection_name
+```
+
+#### Index documents into a collection
+```bash
+bundle exec rake typesense:reconcile:index -- -h host -p port -r protocol -a api_key -c collection_name -m model_ids --polygons
+```
+
+**Note:** This task expects the entire collection to be indexed. Any records not included in the batch will be removed from the index.
+
+#### Update a collection
+```bash
+bundle exec rake typesense:reconcile:update -- -h host -p port -r protocol -a api_key -c collection_name
+```
+
+### Update Project
+
+In order to make requests to the Reconciliation API, the project record must be updated with Typesense credentials.
+
+### Requests
+
+Requests can be made to the Reconciliation API via the following URLs. Follow the [spec](https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.2-20230410/#structure-of-a-reconciliation-query) to see how queries and responses should be structured.
+
+```
+GET /core_data/reconcile/projects/:id
+```
+
+```
+POST /core_data/reconcile/projects/:id
+```
 
 ## Public API
 

--- a/app/controllers/core_data_connector/reconcile/projects_controller.rb
+++ b/app/controllers/core_data_connector/reconcile/projects_controller.rb
@@ -9,7 +9,7 @@ module CoreDataConnector
 
         render json: { }, status: :not_found and return unless valid_credentials? credentials
 
-        serializer = serializer_class.new
+        serializer = ProjectsSerializer.new
 
         # Per the spec, a request to the API without any parameters should return the service manifest
         render json: serializer.render_manifest, status: :ok and return unless params[:queries].present?
@@ -25,12 +25,6 @@ module CoreDataConnector
         items = manager.send_request(queries, credentials)
 
         render json: serializer.render_multiple(items), status: :ok
-      end
-
-      protected
-
-      def serializer_class
-        "CoreDataConnector::Reconcile::#{"#{controller_name}_serializer".classify}".constantize
       end
 
       private

--- a/app/controllers/core_data_connector/reconcile/projects_controller.rb
+++ b/app/controllers/core_data_connector/reconcile/projects_controller.rb
@@ -14,8 +14,15 @@ module CoreDataConnector
         # Per the spec, a request to the API without any parameters should return the service manifest
         render json: serializer.render_manifest, status: :ok and return unless params[:queries].present?
 
+        # Allow request body to be sent as application/json or x-www-form-urlencoded
+        if params[:queries].is_a?(String)
+          queries = JSON.parse(params[:queries]).deep_symbolize_keys
+        else
+          queries = params[:queries]
+        end
+
         manager = Reconcile::Manager.new
-        items = manager.send_request(params[:queries], credentials)
+        items = manager.send_request(queries, credentials)
 
         render json: serializer.render_multiple(items), status: :ok
       end

--- a/app/controllers/core_data_connector/reconcile/projects_controller.rb
+++ b/app/controllers/core_data_connector/reconcile/projects_controller.rb
@@ -1,0 +1,42 @@
+module CoreDataConnector
+  module Reconcile
+    class ProjectsController < ActionController::API
+
+      def show
+        # Validate that the requested project contains the necessary credentials to call the API
+        project = Project.find(params[:id])
+        credentials = project.reconciliation_credentials&.symbolize_keys
+
+        render json: { }, status: :not_found and return unless valid_credentials? credentials
+
+        serializer = serializer_class.new
+
+        # Per the spec, a request to the API without any parameters should return the service manifest
+        render json: serializer.render_manifest, status: :ok and return unless params[:queries].present?
+
+        manager = Reconcile::Manager.new
+        items = manager.send_request(params[:queries], credentials)
+
+        render json: serializer.render_multiple(items), status: :ok
+      end
+
+      protected
+
+      def serializer_class
+        "CoreDataConnector::Reconcile::#{"#{controller_name}_serializer".classify}".constantize
+      end
+
+      private
+
+      def valid_credentials?(credentials)
+        return false unless credentials.present?
+
+        parameters = %i(host protocol port api_key collection_name)
+        return false unless parameters.all? { |parameter| credentials[parameter].present? }
+
+        true
+      end
+
+    end
+  end
+end

--- a/app/models/core_data_connector/event.rb
+++ b/app/models/core_data_connector/event.rb
@@ -8,6 +8,7 @@ module CoreDataConnector
     include Manifestable
     include Mergeable
     include Ownable
+    include Reconcile::Event
     include Relateable
     include Search::Event
     include UserDefinedFields::Fieldable

--- a/app/models/core_data_connector/instance.rb
+++ b/app/models/core_data_connector/instance.rb
@@ -8,6 +8,7 @@ module CoreDataConnector
     include Mergeable
     include Nameable
     include Ownable
+    include Reconcile::Instance
     include Relateable
     include UserDefinedFields::Fieldable
     include Search::Instance

--- a/app/models/core_data_connector/item.rb
+++ b/app/models/core_data_connector/item.rb
@@ -9,6 +9,7 @@ module CoreDataConnector
     include Mergeable
     include Nameable
     include Ownable
+    include Reconcile::Item
     include Relateable
     include UserDefinedFields::Fieldable
     include Search::Item

--- a/app/models/core_data_connector/organization.rb
+++ b/app/models/core_data_connector/organization.rb
@@ -8,6 +8,7 @@ module CoreDataConnector
     include Mergeable
     include Nameable
     include Ownable
+    include Reconcile::Organization
     include Relateable
     include Search::Organization
     include UserDefinedFields::Fieldable

--- a/app/models/core_data_connector/person.rb
+++ b/app/models/core_data_connector/person.rb
@@ -8,6 +8,7 @@ module CoreDataConnector
     include Mergeable
     include Nameable
     include Ownable
+    include Reconcile::Person
     include Relateable
     include Search::Person
     include UserDefinedFields::Fieldable

--- a/app/models/core_data_connector/place.rb
+++ b/app/models/core_data_connector/place.rb
@@ -10,6 +10,7 @@ module CoreDataConnector
     include Mergeable
     include Nameable
     include Ownable
+    include Reconcile::Place
     include Relateable
     include Search::Place
     include UserDefinedFields::Fieldable

--- a/app/models/core_data_connector/taxonomy.rb
+++ b/app/models/core_data_connector/taxonomy.rb
@@ -7,6 +7,7 @@ module CoreDataConnector
     include Manifestable
     include Mergeable
     include Ownable
+    include Reconcile::Taxonomy
     include Relateable
     include UserDefinedFields::Fieldable
     include Search::Taxonomy

--- a/app/models/core_data_connector/work.rb
+++ b/app/models/core_data_connector/work.rb
@@ -8,6 +8,7 @@ module CoreDataConnector
     include Mergeable
     include Nameable
     include Ownable
+    include Reconcile::Work
     include Relateable
     include UserDefinedFields::Fieldable
     include Search::Work

--- a/app/policies/core_data_connector/project_policy.rb
+++ b/app/policies/core_data_connector/project_policy.rb
@@ -98,8 +98,18 @@ module CoreDataConnector
 
     # Allowed create/update attributes.
     def permitted_attributes
-      attributes = [:name, :description, :discoverable, :faircopy_cloud_url, :faircopy_cloud_project_model_id, :map_library_url]
+      attributes = [
+        :name,
+        :description,
+        :discoverable,
+        :faircopy_cloud_url,
+        :faircopy_cloud_project_model_id,
+        :map_library_url,
+        reconciliation_credentials: {}
+      ]
+
       attributes << :archived if current_user.admin?
+
       attributes
     end
 

--- a/app/serializers/core_data_connector/projects_serializer.rb
+++ b/app/serializers/core_data_connector/projects_serializer.rb
@@ -4,6 +4,6 @@ module CoreDataConnector
                      :faircopy_cloud_project_model_id, :archived
 
     show_attributes :id, :name, :description, :discoverable, :faircopy_cloud_url, :map_library_url,
-                    :faircopy_cloud_project_model_id, :archived
+                    :faircopy_cloud_project_model_id, :archived, :reconciliation_credentials
   end
 end

--- a/app/serializers/core_data_connector/reconcile/projects_serializer.rb
+++ b/app/serializers/core_data_connector/reconcile/projects_serializer.rb
@@ -1,0 +1,56 @@
+module CoreDataConnector
+  module Reconcile
+    class ProjectsSerializer < BaseSerializer
+
+      index_attributes :id, :name, :score, :match, :type
+
+      def render_multiple(searches)
+        searches.keys.inject({}) do |hash, key|
+          hash[key] = {
+            result: render_index(searches[key])
+          }
+
+          hash
+        end
+      end
+
+      def render_manifest
+        {
+          defaultTypes: [{
+            id: CoreDataConnector::Event.to_s,
+            name: CoreDataConnector::Event.name.demodulize,
+          }, {
+            id: CoreDataConnector::Instance.to_s,
+            name: CoreDataConnector::Instance.name.demodulize,
+          }, {
+            id: CoreDataConnector::Item.to_s,
+            name: CoreDataConnector::Item.name.demodulize,
+          }, {
+            id: CoreDataConnector::Organization.to_s,
+            name: CoreDataConnector::Organization.name.demodulize,
+          }, {
+            id: CoreDataConnector::Person.to_s,
+            name: CoreDataConnector::Person.name.demodulize,
+          }, {
+            id: CoreDataConnector::Place.to_s,
+            name: CoreDataConnector::Place.name.demodulize,
+          }, {
+            id: CoreDataConnector::Taxonomy.to_s,
+            name: CoreDataConnector::Taxonomy.name.demodulize,
+          }, {
+            id: CoreDataConnector::Work.to_s,
+            name: CoreDataConnector::Work.name.demodulize,
+          }],
+          identifierSpace: "#{ENV['HOSTNAME']}/core_data/public/v1",
+          name: I18n.t('services.reconcile.name'),
+          schemaSpace: "#{ENV['HOSTNAME']}/core_data/reconcile",
+          view: {
+            url: "#{ENV['HOSTNAME']}/core_data/public/v1/:entity/:id"
+          },
+          versions: ['0.2']
+        }
+      end
+
+    end
+  end
+end

--- a/app/serializers/core_data_connector/reconcile/projects_serializer.rb
+++ b/app/serializers/core_data_connector/reconcile/projects_serializer.rb
@@ -2,7 +2,7 @@ module CoreDataConnector
   module Reconcile
     class ProjectsSerializer < BaseSerializer
 
-      index_attributes :id, :name, :score, :match, :type
+      index_attributes :id, :name, :description, :score, :match, :type
 
       def render_multiple(searches)
         searches.keys.inject({}) do |hash, key|
@@ -44,10 +44,7 @@ module CoreDataConnector
           identifierSpace: "#{ENV['HOSTNAME']}/core_data/public/v1",
           name: I18n.t('services.reconcile.name'),
           schemaSpace: "#{ENV['HOSTNAME']}/core_data/reconcile",
-          view: {
-            url: "#{ENV['HOSTNAME']}/core_data/public/v1/:entity/:id"
-          },
-          versions: ['0.2']
+          versions: %w(0.1 0.2)
         }
       end
 

--- a/app/services/core_data_connector/reconcile/base.rb
+++ b/app/services/core_data_connector/reconcile/base.rb
@@ -5,7 +5,7 @@ module CoreDataConnector
 
       class_methods do
 
-        def apply_r_preloads(records)
+        def apply_reconcile_preloads(records)
           # Preload any associations from the concrete class
           if self.respond_to?(:preloads) && preloads.present?
             Preloader.new(
@@ -24,7 +24,7 @@ module CoreDataConnector
 
           query.find_in_batches(batch_size: 1000) do |records|
             # Apply the preloads for the current batch
-            apply_r_preloads records
+            apply_reconcile_preloads records
 
             # Call the block for the current batch
             block.call(records)

--- a/app/services/core_data_connector/reconcile/base.rb
+++ b/app/services/core_data_connector/reconcile/base.rb
@@ -1,0 +1,81 @@
+module CoreDataConnector
+  module Reconcile
+    module Base
+      extend ActiveSupport::Concern
+
+      class_methods do
+
+        def apply_r_preloads(records)
+          # Preload any associations from the concrete class
+          if self.respond_to?(:preloads) && preloads.present?
+            Preloader.new(
+              records: records,
+              associations: preloads
+            ).call
+          end
+        end
+
+        def for_reconcile(project_id, &block)
+          # Base query
+          query = all_records_by_project(project_id)
+
+          # Concrete class query
+          query = search_query(query) if self.respond_to?(:search_query)
+
+          query.find_in_batches(batch_size: 1000) do |records|
+            # Apply the preloads for the current batch
+            apply_r_preloads records
+
+            # Call the block for the current batch
+            block.call(records)
+          end
+        end
+
+        def reconcile_attribute(*attrs, &block)
+          name, options = attrs
+
+          @reconcile_attrs ||= []
+          @reconcile_attrs << { name: name, block: block}.merge(options || {})
+        end
+
+        def reconcile_attributes
+          @reconcile_attrs
+        end
+
+      end
+
+      included do
+        # Include the ID attributes as a string by default
+        reconcile_attribute(:id) { uuid }
+        reconcile_attribute(:record_id) { id.to_s }
+        reconcile_attribute :uuid
+        reconcile_attribute(:type) { self.class.to_s }
+
+        def to_reconcile_json
+          hash = {}
+
+          # Add attributes defined by the concrete-class
+          self.class.reconcile_attributes.each do |attr|
+            name = attr[:name]
+
+            # Extract the value for the attribute
+            if attr[:block].present?
+              value = instance_exec &attr[:block]
+            else
+              value = self.send(attr[:name])
+            end
+
+            # Skip the property of the value is empty
+            next if value.nil?
+
+            # Add the name/value pair to the JSON
+            hash[name] = value
+          end
+
+          hash
+        end
+      end
+
+    end
+  end
+end

--- a/app/services/core_data_connector/reconcile/event.rb
+++ b/app/services/core_data_connector/reconcile/event.rb
@@ -1,0 +1,53 @@
+module CoreDataConnector
+  module Reconcile
+    module Event
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def preloads
+          [:start_date, :end_date]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Search attributes
+        reconcile_attribute :name
+        reconcile_attribute :description
+
+        reconcile_attribute(:start_date) do
+          resolve_date start_date
+        end
+
+        reconcile_attribute(:end_date) do
+          resolve_date end_date
+        end
+
+        reconcile_attribute(:start_year) do
+          resolve_year start_date
+        end
+
+        reconcile_attribute(:end_year) do
+          resolve_year end_date
+        end
+
+        private
+
+        def resolve_date(date)
+          return [] unless date.present?
+
+          [date.start_date&.to_time&.to_i, date.end_date&.to_time&.to_i]
+        end
+
+        def resolve_year(date)
+          return [] unless date.present?
+
+          [date.start_date&.strftime('%Y')&.to_i, date.end_date&.strftime('%Y')&.to_i]
+        end
+
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/reconcile/instance.rb
+++ b/app/services/core_data_connector/reconcile/instance.rb
@@ -1,0 +1,30 @@
+module CoreDataConnector
+  module Reconcile
+    module Instance
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def preloads
+          [:primary_name, :source_names]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Search attributes
+        reconcile_attribute :name
+
+        reconcile_attribute(:name) do
+          primary_name.name
+        end
+
+        reconcile_attribute(:names) do
+          source_names.map(&:name)
+        end
+      end
+
+    end
+  end
+end

--- a/app/services/core_data_connector/reconcile/item.rb
+++ b/app/services/core_data_connector/reconcile/item.rb
@@ -1,0 +1,26 @@
+module CoreDataConnector
+  module Reconcile
+    module Item
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def preloads
+          [:primary_name, :source_names]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Search attributes
+        reconcile_attribute :name
+
+        reconcile_attribute(:names) do
+          source_names.map(&:name)
+        end
+      end
+
+    end
+  end
+end

--- a/app/services/core_data_connector/reconcile/manager.rb
+++ b/app/services/core_data_connector/reconcile/manager.rb
@@ -54,10 +54,10 @@ module CoreDataConnector
         attributes = {
           score: result['text_match'],
           match: false,
-          type: {
+          type: [{
             id: klass.to_s,
             name: klass.name.demodulize
-          }
+          }]
         }
 
         all_attributes = result['document'].merge(attributes).symbolize_keys

--- a/app/services/core_data_connector/reconcile/manager.rb
+++ b/app/services/core_data_connector/reconcile/manager.rb
@@ -18,7 +18,24 @@ module CoreDataConnector
       private
 
       def build_params(queries, collection)
-        { searches: queries.keys.map { |key| { collection:, q: queries[key][:query] } } }
+        searches = []
+
+        queries.keys.each do |key|
+          query = queries[key]
+
+          # Append "collection" and "query" parameters
+          search = { collection:, q: query[:query] }
+
+          # Append "filter_by" parameter, if present
+          search[:filter_by] = "type:#{query[:type]}" if query[:type].present?
+
+          # Append "limit" parameter, if present
+          search[:limit] = query[:limit] if query[:limit].present?
+
+          searches << search
+        end
+
+        { searches: }
       end
 
       def transform(response, keys)

--- a/app/services/core_data_connector/reconcile/manager.rb
+++ b/app/services/core_data_connector/reconcile/manager.rb
@@ -1,0 +1,61 @@
+module CoreDataConnector
+  module Reconcile
+    class Manager
+
+      def send_request(queries, credentials)
+        client = Typesense.create_client(**credentials.except(:collection_name))
+
+        common_params = {
+          query_by: 'name'
+        }
+
+        params = build_params(queries, credentials[:collection_name])
+        response = client.multi_search.perform(params, common_params)
+
+        transform response, queries.keys
+      end
+
+      private
+
+      def build_params(queries, collection)
+        { searches: queries.keys.map { |key| { collection:, q: queries[key][:query] } } }
+      end
+
+      def transform(response, keys)
+        json = {}
+
+        response['results'].each_with_index do |result, index|
+          json[keys[index]] = transform_results(result['hits'])
+        end
+
+        json
+      end
+
+      def transform_result(result)
+        klass = result['document']['type'].constantize
+
+        attributes = {
+          score: result['text_match'],
+          match: false,
+          type: {
+            id: klass.to_s,
+            name: klass.name.demodulize
+          }
+        }
+
+        all_attributes = result['document'].merge(attributes).symbolize_keys
+        transformed = ActiveSupport::InheritableOptions.new(all_attributes)
+
+        # For some reason, adding "present" to the constructor does not work
+        transformed.present = true
+
+        transformed
+      end
+
+      def transform_results(results)
+        results.map { |result| transform_result(result) }
+      end
+
+    end
+  end
+end

--- a/app/services/core_data_connector/reconcile/organization.rb
+++ b/app/services/core_data_connector/reconcile/organization.rb
@@ -1,0 +1,27 @@
+module CoreDataConnector
+  module Reconcile
+    module Organization
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def preloads
+          [:primary_name, :organization_names]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Search attributes
+        reconcile_attribute :name
+        reconcile_attribute :description
+
+        reconcile_attribute(:names) do
+          organization_names.map(&:name)
+        end
+      end
+
+    end
+  end
+end

--- a/app/services/core_data_connector/reconcile/person.rb
+++ b/app/services/core_data_connector/reconcile/person.rb
@@ -1,0 +1,36 @@
+module CoreDataConnector
+  module Reconcile
+    module Person
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def preloads
+          [:primary_name, :person_names]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Search attributes
+        reconcile_attribute(:description) do
+          biography
+        end
+
+        reconcile_attribute(:name) do
+          create_name primary_name
+        end
+
+        reconcile_attribute(:names, facet: true) do
+          person_names.map { |n| create_name(n) }
+        end
+
+        def create_name(person_name)
+          [person_name.first_name, person_name.middle_name, person_name.last_name].compact.join(' ')
+        end
+
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/reconcile/place.rb
+++ b/app/services/core_data_connector/reconcile/place.rb
@@ -1,0 +1,25 @@
+module CoreDataConnector
+  module Reconcile
+    module Place
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def preloads
+          [:primary_name, :place_names]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Search attributes
+        reconcile_attribute :name
+
+        reconcile_attribute(:names) do
+          place_names.map(&:name)
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/reconcile/taxonomy.rb
+++ b/app/services/core_data_connector/reconcile/taxonomy.rb
@@ -1,0 +1,15 @@
+module CoreDataConnector
+  module Reconcile
+    module Taxonomy
+      extend ActiveSupport::Concern
+
+      included do
+        # Includes
+        include Base
+
+        # Search attributes
+        reconcile_attribute :name
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/reconcile/work.rb
+++ b/app/services/core_data_connector/reconcile/work.rb
@@ -1,0 +1,26 @@
+module CoreDataConnector
+  module Reconcile
+    module Work
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def preloads
+          [:primary_name, :source_names]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Search attributes
+        reconcile_attribute :name
+
+        reconcile_attribute(:names) do
+          source_names.map(&:name)
+        end
+      end
+
+    end
+  end
+end

--- a/app/services/core_data_connector/typesense.rb
+++ b/app/services/core_data_connector/typesense.rb
@@ -1,0 +1,24 @@
+require 'typesense'
+
+module CoreDataConnector
+  class Typesense
+
+    def self.create_client(host:, port:, protocol:, api_key:)
+      ::Typesense::Client.new(
+        nodes: [{
+          host: host || 'localhost',
+          port: port|| 8108,
+          protocol: protocol || 'http'
+        }],
+        api_key: api_key || 'xyz',
+        num_retries: 10,
+        healthcheck_interval_seconds: 1,
+        retry_interval_seconds: 0.01,
+        connection_timeout_seconds: 10,
+        logger: Logger.new($stdout),
+        log_level: Logger::INFO
+      )
+    end
+
+  end
+end

--- a/app/services/core_data_connector/typesense.rb
+++ b/app/services/core_data_connector/typesense.rb
@@ -5,12 +5,8 @@ module CoreDataConnector
 
     def self.create_client(host:, port:, protocol:, api_key:)
       ::Typesense::Client.new(
-        nodes: [{
-          host: host || 'localhost',
-          port: port|| 8108,
-          protocol: protocol || 'http'
-        }],
-        api_key: api_key || 'xyz',
+        nodes: [{ host:, port:, protocol: }],
+        api_key:,
         num_retries: 10,
         healthcheck_interval_seconds: 1,
         retry_interval_seconds: 0.01,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -170,3 +170,5 @@ en:
       places:
         latitude: "Latitude"
         longitude: "Longitude"
+    reconcile:
+      name: "Core Data Cloud Reconciliation API"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,4 +11,7 @@ CoreDataConnector::Engine.routes.draw do
   # Public API endpoints
   draw(:v0)
   draw(:v1)
+
+  # Reconciliation API endpoints
+  draw(:reconcile)
 end

--- a/config/routes/reconcile.rb
+++ b/config/routes/reconcile.rb
@@ -1,0 +1,6 @@
+# Reconciliation API routes
+
+namespace :reconcile do
+  get 'projects/:id', to: 'projects#show'
+  post 'projects/:id', to: 'projects#show'
+end

--- a/db/migrate/20250806145312_add_reconciliation_credentials_to_projects.rb
+++ b/db/migrate/20250806145312_add_reconciliation_credentials_to_projects.rb
@@ -1,0 +1,5 @@
+class AddReconciliationCredentialsToProjects < ActiveRecord::Migration[8.0]
+  def change
+    add_column :core_data_connector_projects, :reconciliation_credentials, :jsonb, default: {}
+  end
+end

--- a/lib/core_data_connector/engine.rb
+++ b/lib/core_data_connector/engine.rb
@@ -10,6 +10,7 @@ module CoreDataConnector
         allow do
           origins '*'
           resource '/core_data/public/*', methods: :get
+          resource '/core_data/reconcile/*', methods: [:get, :post]
         end
       end
     end

--- a/lib/tasks/typesense.rake
+++ b/lib/tasks/typesense.rake
@@ -1,77 +1,142 @@
-require_relative '../typesense/helper'
 require_relative '../typesense/options'
+require_relative '../typesense/reconcile'
+require_relative '../typesense/search'
 
 namespace :typesense do
-  desc 'Creates a new Typesense collection'
-  task create: :environment do
-    options = Typesense::Options.parse(ARGV) do |opts|
-      opts.banner = 'Usage: typesense:create -- --host --port --protocol --api-key --collection-name'
+
+  namespace :reconcile do
+
+    desc 'Creates a new Typesense collection'
+    task create: :environment do
+      options = Typesense::Options.parse(ARGV) do |opts|
+        opts.banner = 'Usage: typesense:create -- --host --port --protocol --api-key --collection-name'
+      end
+
+      reconcile = Typesense::Reconcile.new(
+        host: options[:host],
+        port: options[:port],
+        protocol: options[:protocol],
+        api_key: options[:api_key],
+        collection_name: options[:collection_name]
+      )
+
+      reconcile.create
     end
 
-    helper = Typesense::Helper.new(
-      host: options[:host],
-      port: options[:port],
-      protocol: options[:protocol],
-      api_key: options[:api_key],
-      collection_name: options[:collection_name]
-    )
+    desc 'Deletes the Typesense collection'
+    task delete: :environment do
+      options = Typesense::Options.parse(ARGV) do |opts|
+        opts.banner = 'Usage: typesense:delete -- --host --port --protocol --api-key --collection-name'
+      end
 
-    helper.create
+      reconcile = Typesense::Reconcile.new(
+        host: options[:host],
+        port: options[:port],
+        protocol: options[:protocol],
+        api_key: options[:api_key],
+        collection_name: options[:collection_name]
+      )
+
+      begin
+        reconcile.delete
+      rescue
+        # Do nothing, collection doesn't exist yet
+      end
+    end
+
+    desc 'Index documents into Typesense'
+    task index: :environment do
+      options = Typesense::Options.parse(ARGV) do |opts, options|
+        opts.banner = 'Usage: typesense:index -- --host --port --protocol --api-key --collection-name --project-id'
+        opts.on('-j', '--project-id ARG', Integer) { |id| options[:project_id] = id&.to_i }
+      end
+
+      reconcile = Typesense::Reconcile.new(
+        host: options[:host],
+        port: options[:port],
+        protocol: options[:protocol],
+        api_key: options[:api_key],
+        collection_name: options[:collection_name]
+      )
+
+      reconcile.index options.slice(:project_id)
+    end
   end
 
-  desc 'Deletes the Typesense collection'
-  task delete: :environment do
-    options = Typesense::Options.parse(ARGV) do |opts|
-      opts.banner = 'Usage: typesense:delete -- --host --port --protocol --api-key --collection-name'
+  namespace :search do
+
+    desc 'Creates a new Typesense collection'
+    task create: :environment do
+      options = Typesense::Options.parse(ARGV) do |opts|
+        opts.banner = 'Usage: typesense:create -- --host --port --protocol --api-key --collection-name'
+      end
+
+      search = Typesense::Search.new(
+        host: options[:host],
+        port: options[:port],
+        protocol: options[:protocol],
+        api_key: options[:api_key],
+        collection_name: options[:collection_name]
+      )
+
+      search.create
     end
 
-    helper = Typesense::Helper.new(
-      host: options[:host],
-      port: options[:port],
-      protocol: options[:protocol],
-      api_key: options[:api_key],
-      collection_name: options[:collection_name]
-    )
+    desc 'Deletes the Typesense collection'
+    task delete: :environment do
+      options = Typesense::Options.parse(ARGV) do |opts|
+        opts.banner = 'Usage: typesense:delete -- --host --port --protocol --api-key --collection-name'
+      end
 
-    begin
-      helper.delete
-    rescue
-      # Do nothing, collection doesn't exist yet
-    end
-  end
+      search = Typesense::Search.new(
+        host: options[:host],
+        port: options[:port],
+        protocol: options[:protocol],
+        api_key: options[:api_key],
+        collection_name: options[:collection_name]
+      )
 
-  desc 'Index documents into Typesense'
-  task index: :environment do
-    options = Typesense::Options.parse(ARGV) do |opts, options|
-      opts.banner = 'Usage: typesense:index -- --host --port --protocol --api-key --collection-name --project-models --polygons'
-      opts.on('-m', '--project-models ARG', Array) { |ids| options[:project_model_ids] = ids.map(&:to_i) }
-    end
-
-    helper = Typesense::Helper.new(
-      host: options[:host],
-      port: options[:port],
-      protocol: options[:protocol],
-      api_key: options[:api_key],
-      collection_name: options[:collection_name]
-    )
-
-    helper.index options[:project_model_ids], { polygons: options[:polygons] || false }
-  end
-
-  desc 'Updates the Typesense collection'
-  task update: :environment do
-    options = Typesense::Options.parse(ARGV) do |opts|
-      opts.banner = 'Usage: typesense:create -- --host --port --protocol --api-key --collection-name'
+      begin
+        search.delete
+      rescue
+        # Do nothing, collection doesn't exist yet
+      end
     end
 
-    helper = Typesense::Helper.new(
-      host: options[:host],
-      port: options[:port],
-      protocol: options[:protocol],
-      api_key: options[:api_key],
-      collection_name: options[:collection_name]
-    )
+    desc 'Index documents into Typesense'
+    task index: :environment do
+      options = Typesense::Options.parse(ARGV) do |opts, options|
+        opts.banner = 'Usage: typesense:index -- --host --port --protocol --api-key --collection-name --project-models --polygons'
+        opts.on('-m', '--project-models ARG', Array) { |ids| options[:project_model_ids] = ids.map(&:to_i) }
+        opts.on('-g', '--polygons ARG', String) { |polygons| options[:polygons] = polygons.to_bool }
+      end
 
-    helper.update
+      search = Typesense::Search.new(
+        host: options[:host],
+        port: options[:port],
+        protocol: options[:protocol],
+        api_key: options[:api_key],
+        collection_name: options[:collection_name]
+      )
+
+      search.index options.slice(:project_model_ids, :polygons)
+    end
+
+    desc 'Updates the Typesense collection'
+    task update: :environment do
+      options = Typesense::Options.parse(ARGV) do |opts|
+        opts.banner = 'Usage: typesense:create -- --host --port --protocol --api-key --collection-name'
+      end
+
+      search = Typesense::Search.new(
+        host: options[:host],
+        port: options[:port],
+        protocol: options[:protocol],
+        api_key: options[:api_key],
+        collection_name: options[:collection_name]
+      )
+
+      search.update
+    end
   end
 end

--- a/lib/typesense/base.rb
+++ b/lib/typesense/base.rb
@@ -1,0 +1,50 @@
+require 'typesense'
+
+module Typesense
+  class Base
+    attr_reader :client, :collection_name
+
+    def initialize(host:, port:, protocol:, api_key:, collection_name:)
+      @client = Client.new(
+        nodes: [
+          {
+            host: host || 'localhost',
+            port: port|| 8108,
+            protocol: protocol || 'http'
+          }
+        ],
+        api_key: api_key || 'xyz',
+        num_retries: 10,
+        healthcheck_interval_seconds: 1,
+        retry_interval_seconds: 0.01,
+        connection_timeout_seconds: 10,
+        logger: Logger.new($stdout),
+        log_level: Logger::INFO
+      )
+
+      @collection_name = collection_name
+    end
+
+    def create
+      client.collections.create(schema)
+    end
+
+    def index(options)
+      # Implemented in sub-class
+    end
+
+    def delete
+      client.collections[collection_name].delete
+    end
+
+    def update
+      # Implemented in sub-class
+    end
+
+    protected
+
+    def schema
+      # Implemented in sub-class
+    end
+  end
+end

--- a/lib/typesense/base.rb
+++ b/lib/typesense/base.rb
@@ -5,23 +5,7 @@ module Typesense
     attr_reader :client, :collection_name
 
     def initialize(host:, port:, protocol:, api_key:, collection_name:)
-      @client = Client.new(
-        nodes: [
-          {
-            host: host || 'localhost',
-            port: port|| 8108,
-            protocol: protocol || 'http'
-          }
-        ],
-        api_key: api_key || 'xyz',
-        num_retries: 10,
-        healthcheck_interval_seconds: 1,
-        retry_interval_seconds: 0.01,
-        connection_timeout_seconds: 10,
-        logger: Logger.new($stdout),
-        log_level: Logger::INFO
-      )
-
+      @client = CoreDataConnector::Typesense.create_client(host:, port:, protocol:, api_key:)
       @collection_name = collection_name
     end
 

--- a/lib/typesense/options.rb
+++ b/lib/typesense/options.rb
@@ -12,7 +12,6 @@ module Typesense
       opts.on('-r', '--protocol ARG', String) { |protocol| options[:protocol] = protocol }
       opts.on('-a', '--api-key ARG', String) { |api_key| options[:api_key] = api_key }
       opts.on('-c', '--collection-name ARG', String) { |collection| options[:collection_name] = collection }
-      opts.on('--polygons') { options[:polygons] = true }
 
       args = opts.order!(args) {}
       opts.parse!(args)

--- a/lib/typesense/reconcile.rb
+++ b/lib/typesense/reconcile.rb
@@ -1,0 +1,51 @@
+require_relative 'base'
+
+module Typesense
+  class Reconcile < Base
+    attr_reader :client, :collection_name, :project
+
+    def create
+      client.collections.create(schema)
+    end
+
+    def delete
+      client.collections[collection_name].delete
+    end
+
+    def index(options)
+      collection = client.collections[collection_name]
+      project_id = options[:project_id]
+
+      index_model_class CoreDataConnector::Event, project_id, collection
+      index_model_class CoreDataConnector::Instance, project_id, collection
+      index_model_class CoreDataConnector::Item, project_id, collection
+      index_model_class CoreDataConnector::Organization, project_id, collection
+      index_model_class CoreDataConnector::Person, project_id, collection
+      index_model_class CoreDataConnector::Place, project_id, collection
+      index_model_class CoreDataConnector::Taxonomy, project_id, collection
+      index_model_class CoreDataConnector::Work, project_id, collection
+    end
+
+    protected
+
+    def schema
+      {
+        name: collection_name,
+        enable_nested_fields: false,
+        fields: [{
+          name: '.*',
+          type: 'auto'
+        }]
+      }
+    end
+
+    private
+
+    def index_model_class(klass, project_id, collection)
+      klass.for_reconcile(project_id) do |records|
+        documents = records.map(&:to_reconcile_json)
+        collection.documents.import(documents, action: 'emplace')
+      end
+    end
+  end
+end

--- a/lib/typesense/search.rb
+++ b/lib/typesense/search.rb
@@ -72,29 +72,29 @@ module Typesense
         name: collection_name,
         enable_nested_fields: true,
         fields: [{
-                   name: 'geometry',
-                   type: 'object',
-                   index: false,
-                   facet: false,
-                   optional: true
-                 }, {
-                   name: 'coordinates',
-                   type: 'geopoint',
-                   facet: false,
-                   optional: true
-                 }, {
-                   name: 'name',
-                   type: 'string',
-                   sort: true,
-                   optional: true
-                 }, {
-                   name: '.*_facet',
-                   type: 'auto',
-                   facet: true
-                 }, {
-                   name: '.*',
-                   type: 'auto'
-                 }]
+          name: 'geometry',
+          type: 'object',
+          index: false,
+          facet: false,
+          optional: true
+        }, {
+          name: 'coordinates',
+          type: 'geopoint',
+          facet: false,
+          optional: true
+        }, {
+          name: 'name',
+          type: 'string',
+          sort: true,
+          optional: true
+        }, {
+          name: '.*_facet',
+          type: 'auto',
+          facet: true
+        }, {
+          name: '.*',
+          type: 'auto'
+       }]
       }
     end
   end

--- a/lib/typesense/search.rb
+++ b/lib/typesense/search.rb
@@ -1,70 +1,13 @@
-require 'typesense'
+require_relative 'base'
 
 module Typesense
-  class Helper
+  class Search < Base
     attr_reader :client, :collection_name
 
-    def initialize(host:, port:, protocol:, api_key:, collection_name:)
-      @client = Client.new(
-        nodes: [
-          {
-            host: host || 'localhost',
-            port: port|| 8108,
-            protocol: protocol || 'http'
-          }
-        ],
-        api_key: api_key || 'xyz',
-        num_retries: 10,
-        healthcheck_interval_seconds: 1,
-        retry_interval_seconds: 0.01,
-        connection_timeout_seconds: 10,
-        logger: Logger.new($stdout),
-        log_level: Logger::INFO
-      )
-
-      @collection_name = collection_name
-    end
-
-    def create
-      schema = {
-        name: collection_name,
-        enable_nested_fields: true,
-        fields: [{
-          name: 'geometry',
-          type: 'object',
-          index: false,
-          facet: false,
-          optional: true
-        }, {
-          name: 'coordinates',
-          type: 'geopoint',
-          facet: false,
-          optional: true
-        }, {
-          name: 'name',
-          type: 'string',
-          sort: true,
-          optional: true
-        }, {
-          name: '.*_facet',
-          type: 'auto',
-          facet: true
-        }, {
-          name: '.*',
-          type: 'auto'
-        }]
-      }
-
-      client.collections.create(schema)
-    end
-
-    def delete
-      client.collections[collection_name].delete
-    end
-
-    def index(project_model_ids, options)
+    def index(options)
       collection = client.collections[collection_name]
 
+      project_model_ids = options.delete(:project_model_ids)
       options[:include_relationships] = true
 
       # Query project_models and build a hash of class names to arrays if project_model IDs
@@ -120,6 +63,39 @@ module Typesense
       end
 
       collection_schema.update({ fields: fields_to_update })
+    end
+
+    protected
+
+    def schema
+      {
+        name: collection_name,
+        enable_nested_fields: true,
+        fields: [{
+                   name: 'geometry',
+                   type: 'object',
+                   index: false,
+                   facet: false,
+                   optional: true
+                 }, {
+                   name: 'coordinates',
+                   type: 'geopoint',
+                   facet: false,
+                   optional: true
+                 }, {
+                   name: 'name',
+                   type: 'string',
+                   sort: true,
+                   optional: true
+                 }, {
+                   name: '.*_facet',
+                   type: 'auto',
+                   facet: true
+                 }, {
+                   name: '.*',
+                   type: 'auto'
+                 }]
+      }
     end
   end
 end


### PR DESCRIPTION
This pull request makes the following changes to support endpoint(s) for a [Reconciliation API](https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.2-20230410) service.

- Adds the `reconcile` service, which will function much like the `search` service. It will allow records to be normalized and put into a Typesense index for search use.
- Adds the `GET /core_data/reconcile/projects/:id` and `POST /core_data/reconcile/projects/:id` API endpoints. The endpoints will act as a pass through to accept parameters according to the Reconciliation API spec, reformat the parameters according to the Typesense API spec, receive the results from Typesense, and re-format the payload according to the Reconciliation API spec.
- Adds the `reconciliation_credentials` (JSON) column to `projects`. This will allow Typesense connection information to be added to a project, which will in turn allow the `/core_data/reconcile/projects/:id` endpoint to _not_ return a `404`.