### PR TITLE
CDC #482 - Import multiple names

### DIFF
--- a/app/models/concerns/core_data_connector/nameable.rb
+++ b/app/models/concerns/core_data_connector/nameable.rb
@@ -8,9 +8,11 @@ module CoreDataConnector
         if options && options[:as]
           self.send(:has_many, name.to_sym, dependent: :destroy, as: options[:as])
           has_one :primary_name, -> { where(primary: true) }, class_name: name.to_s.classify, as: options[:as]
+          has_many :ordered_names, -> { order(primary: :desc) }, class_name: name.to_s.classify, as: options[:as]
         else
           self.send(:has_many, name.to_sym, dependent: :destroy)
           has_one :primary_name, -> { where(primary: true) }, class_name: name.to_s.classify
+          has_many :ordered_names, -> { order(primary: :desc) }, class_name: name.to_s.classify
         end
 
         # Nested attributes

--- a/app/services/concerns/core_data_connector/export/nameable.rb
+++ b/app/services/concerns/core_data_connector/export/nameable.rb
@@ -1,0 +1,17 @@
+module CoreDataConnector
+  module Export
+    module Nameable
+      extend ActiveSupport::Concern
+
+      NAME_DELIMITER = ';'
+
+      included do
+
+        def format_name(attr = :name)
+          ordered_names.map(&attr).join(NAME_DELIMITER)
+        end
+
+      end
+    end
+  end
+end

--- a/app/services/concerns/core_data_connector/import/nameable.rb
+++ b/app/services/concerns/core_data_connector/import/nameable.rb
@@ -1,0 +1,32 @@
+module CoreDataConnector
+  module Import
+    module Nameable
+      extend ActiveSupport::Concern
+
+      NAME_DELIMITER = ';'
+
+      included do
+
+        def transform_names
+          execute <<-SQL.squish
+            WITH 
+  
+            record_names AS (
+  
+            SELECT id, ARRAY(SELECT trim(BOTH ' ' FROM unnest(string_to_array(name, '#{NAME_DELIMITER}')))) as names
+              FROM #{table_name}
+  
+            )
+  
+            UPDATE #{table_name} z_table
+               SET primary_name = record_names.names[1],
+                   additional_names = record_names.names[2:array_length(record_names.names, 1)]
+              FROM record_names
+             WHERE record_names.id = z_table.id
+          SQL
+        end
+
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/export/base.rb
+++ b/app/services/core_data_connector/export/base.rb
@@ -8,7 +8,7 @@ module CoreDataConnector
           name, options = attrs
 
           @export_attrs ||= []
-          @export_attrs << { name: name, block: block}.merge(options || {})
+          @export_attrs << { name: name, block: block }.merge(options || {})
         end
 
         def export_attributes

--- a/app/services/core_data_connector/export/instance.rb
+++ b/app/services/core_data_connector/export/instance.rb
@@ -5,18 +5,19 @@ module CoreDataConnector
 
       class_methods do
         def export_preloads
-          [:primary_name]
+          [:ordered_names]
         end
       end
 
       included do
         # Includes
         include Base
+        include Nameable
 
         # Export attributes
         export_attribute :project_model_id
         export_attribute :uuid
-        export_attribute :name
+        export_attribute(:name) { format_name }
       end
     end
   end

--- a/app/services/core_data_connector/export/item.rb
+++ b/app/services/core_data_connector/export/item.rb
@@ -5,18 +5,19 @@ module CoreDataConnector
 
       class_methods do
         def export_preloads
-          [:primary_name]
+          [:ordered_names]
         end
       end
 
       included do
         # Includes
         include Base
+        include Nameable
 
         # Export attributes
         export_attribute :project_model_id
         export_attribute :uuid
-        export_attribute :name
+        export_attribute(:name) { format_name }
       end
     end
   end

--- a/app/services/core_data_connector/export/organization.rb
+++ b/app/services/core_data_connector/export/organization.rb
@@ -5,18 +5,19 @@ module CoreDataConnector
 
       class_methods do
         def export_preloads
-          [:primary_name]
+          [:ordered_names]
         end
       end
 
       included do
         # Includes
         include Base
+        include Nameable
 
         # Export attributes
         export_attribute :project_model_id
         export_attribute :uuid
-        export_attribute :name
+        export_attribute(:name) { format_name }
         export_attribute :description
       end
     end

--- a/app/services/core_data_connector/export/person.rb
+++ b/app/services/core_data_connector/export/person.rb
@@ -5,20 +5,21 @@ module CoreDataConnector
 
       class_methods do
         def export_preloads
-          [:primary_name]
+          [:ordered_names]
         end
       end
 
       included do
         # Includes
         include Base
+        include Nameable
 
         # Export attributes
         export_attribute :project_model_id
         export_attribute :uuid
-        export_attribute :last_name
-        export_attribute :first_name
-        export_attribute :middle_name
+        export_attribute(:last_name) { format_name :last_name }
+        export_attribute(:first_name) { format_name :first_name }
+        export_attribute(:middle_name) { format_name :middle_name }
         export_attribute :biography
       end
     end

--- a/app/services/core_data_connector/export/place.rb
+++ b/app/services/core_data_connector/export/place.rb
@@ -9,26 +9,21 @@ module CoreDataConnector
         end
 
         def export_preloads
-          [:primary_name]
+          [:ordered_names]
         end
       end
 
       included do
         # Includes
         include Base
+        include Nameable
 
         # Export attributes
         export_attribute :project_model_id
         export_attribute :uuid
-        export_attribute :name
-
-        export_attribute(:latitude) do
-          geometry_center&.y
-        end
-
-        export_attribute(:longitude) do
-          geometry_center&.x
-        end
+        export_attribute(:name) { format_name }
+        export_attribute(:latitude) { geometry_center&.y }
+        export_attribute(:longitude) { geometry_center&.x }
       end
     end
   end

--- a/app/services/core_data_connector/export/work.rb
+++ b/app/services/core_data_connector/export/work.rb
@@ -5,7 +5,7 @@ module CoreDataConnector
 
       class_methods do
         def export_preloads
-          [:primary_name]
+          [:ordered_names]
         end
       end
 
@@ -16,7 +16,7 @@ module CoreDataConnector
         # Export attributes
         export_attribute :project_model_id
         export_attribute :uuid
-        export_attribute :name
+        export_attribute(:name) { format_name }
       end
     end
   end

--- a/app/services/core_data_connector/import/instances.rb
+++ b/app/services/core_data_connector/import/instances.rb
@@ -1,12 +1,15 @@
 module CoreDataConnector
   module Import
     class Instances < Base
+      # Includes
+      include Nameable
+
       def cleanup
         super
 
         execute <<-SQL.squish
           UPDATE core_data_connector_instances
-            SET z_instance_id = NULL
+             SET z_instance_id = NULL
         SQL
 
         execute <<-SQL.squish
@@ -17,72 +20,113 @@ module CoreDataConnector
       def load
         super
 
+        # Update existing instances
+        execute <<-SQL.squish
+          UPDATE core_data_connector_instances instances
+             SET z_instance_id = z_instances.id,
+                 user_defined = z_instances.user_defined,
+                 import_id = z_instances.import_id,
+                 updated_at = current_timestamp
+            FROM #{table_name} z_instances
+           WHERE z_instances.instance_id = instances.id
+        SQL
+
+        # Insert new instances
         execute <<-SQL.squish
           WITH
- 
-          update_instances AS (
-
-            UPDATE core_data_connector_instances instances
-               SET z_instance_id = z_instances.id,
-                   user_defined = z_instances.user_defined,
-                   import_id = z_instances.import_id,
-                   updated_at = current_timestamp
-              FROM #{table_name} z_instances
-             WHERE z_instances.instance_id = instances.id
-
+  
+          insert_instances AS (
+  
+          INSERT INTO core_data_connector_instances (
+            project_model_id,
+            uuid,
+            z_instance_id,
+            user_defined,
+            import_id,
+            created_at,
+            updated_at
           )
+          SELECT z_instances.project_model_id,
+                 z_instances.uuid,
+                 z_instances.id,
+                 z_instances.user_defined,
+                 z_instances.import_id,
+                 current_timestamp,
+                 current_timestamp
+            FROM #{table_name} z_instances
+           WHERE z_instances.instance_id IS NULL
+          RETURNING id AS instance_id, z_instance_id
+  
+          )
+  
+          UPDATE #{table_name} z_instances
+             SET instance_id = insert_instances.instance_id
+            FROM insert_instances
+           WHERE insert_instances.z_instance_id = z_instances.id
+        SQL
 
+        # Insert new source_names
+        execute <<-SQL.squish
+          WITH 
+  
+          all_instance_names AS (
+            
+          SELECT z_instances.instance_id AS instance_id, z_instances.primary_name AS name
+            FROM #{table_name} z_instances
+           UNION ALL
+          SELECT z_instances.instance_id AS instance_id, unnest(z_instances.additional_names) AS name
+            FROM #{table_name} z_instances
+          
+          )
+  
+          INSERT INTO core_data_connector_source_names (
+            nameable_id, 
+            nameable_type, 
+            name, 
+            created_at, 
+            updated_at
+          )
+          SELECT all_instance_names.instance_id, 
+                 'CoreDataConnector::Instance', 
+                 all_instance_names.name, 
+                 current_timestamp, 
+                 current_timestamp
+            FROM all_instance_names
+           WHERE NOT EXISTS ( SELECT 1
+                                FROM core_data_connector_source_names source_names
+                               WHERE source_names.nameable_id = all_instance_names.instance_id
+                                 AND source_names.nameable_type = 'CoreDataConnector::Instance'
+                                 AND source_names.name = all_instance_names.name )
+        SQL
+
+        # Reset "primary" indicator for all source_names to FALSE
+        execute <<-SQL.squish
           UPDATE core_data_connector_source_names source_names
-             SET name = z_instances.name
+             SET "primary" = FALSE,
+                 updated_at = current_timestamp
             FROM #{table_name} z_instances
            WHERE z_instances.instance_id = source_names.nameable_id
              AND source_names.nameable_type = 'CoreDataConnector::Instance'
-             AND source_names.primary = TRUE
         SQL
 
+        # Set the "primary" indicator for source_names to TRUE
         execute <<-SQL.squish
-        WITH
-
-        insert_instances AS (
-
-        INSERT INTO core_data_connector_instances (
-          project_model_id,
-          uuid,
-          z_instance_id,
-          user_defined,
-          import_id,
-          created_at,
-          updated_at
-        )
-        SELECT z_instances.project_model_id,
-               z_instances.uuid,
-               z_instances.id,
-               z_instances.user_defined,
-               z_instances.import_id,
-               current_timestamp,
-               current_timestamp
-          FROM #{table_name} z_instances
-         WHERE z_instances.instance_id IS NULL
-        RETURNING id AS instance_id, z_instance_id
-
-        )
-
-        INSERT INTO core_data_connector_source_names (
-          nameable_id,
-          nameable_type,
-          name,
-          "primary",
-          created_at,
-          updated_at
-        )
-        SELECT insert_instances.instance_id, 
-               'CoreDataConnector::Instance',
-               z_instances.name,
-               TRUE,
-               current_timestamp,
-               current_timestamp
-          FROM insert_instances
-          JOIN #{table_name} z_instances on z_instances.id = insert_instances.z_instance_id
+          WITH 
+                
+          primary_instance_names AS (
+              
+          SELECT z_instances.instance_id AS instance_id, z_instances.primary_name AS name
+            FROM #{table_name} z_instances
+  
+          )
+  
+          UPDATE core_data_connector_source_names source_names
+             SET "primary" = TRUE,
+                 updated_at = current_timestamp
+            FROM primary_instance_names
+           WHERE primary_instance_names.instance_id = source_names.nameable_id
+             AND primary_instance_names.name = source_names.name
+             AND source_names.nameable_type = 'CoreDataConnector::Instance'
         SQL
       end
 
@@ -95,6 +139,8 @@ module CoreDataConnector
            WHERE instances.uuid = z_instances.uuid
              AND z_instances.uuid IS NOT NULL
         SQL
+
+        transform_names
 
         super
       end
@@ -117,6 +163,12 @@ module CoreDataConnector
         }, {
           name: 'instance_id',
           type: 'INTEGER'
+        }, {
+          name: 'primary_name',
+          type: 'VARCHAR'
+        }, {
+          name: 'additional_names',
+          type: 'TEXT[]'
         }, {
           name: 'user_defined',
           type: 'JSONB'

--- a/app/services/core_data_connector/import/people.rb
+++ b/app/services/core_data_connector/import/people.rb
@@ -17,32 +17,19 @@ module CoreDataConnector
       def load
         super
 
+        # Update existing people
         execute <<-SQL.squish
-          WITH
-              
-          update_people AS (
-          
-            UPDATE core_data_connector_people people
-               SET z_person_id = z_people.id,
-                   biography = z_people.biography,
-                   user_defined = z_people.user_defined,
-                   import_id = z_people.import_id,
-                   updated_at = current_timestamp
-              FROM #{table_name} z_people
-             WHERE z_people.person_id = people.id
-              
-          )
-
-          UPDATE core_data_connector_person_names person_names
-             SET last_name = z_people.last_name,
-                 first_name = z_people.first_name,
-                 middle_name = z_people.middle_name,
+          UPDATE core_data_connector_people people
+             SET z_person_id = z_people.id,
+                 biography = z_people.biography,
+                 user_defined = z_people.user_defined,
+                 import_id = z_people.import_id,
                  updated_at = current_timestamp
-           FROM #{table_name} z_people
-          WHERE z_people.person_id = person_names.person_id
-            AND person_names.primary = TRUE
+            FROM #{table_name} z_people
+           WHERE z_people.person_id = people.id
         SQL
 
+        # Insert new people
         execute <<-SQL.squish
           WITH 
           
@@ -70,22 +57,94 @@ module CoreDataConnector
            WHERE z_people.person_id IS NULL
           RETURNING id AS person_id, z_person_id
 
-          ),
-
-          insert_person_names AS (
-
-          INSERT INTO core_data_connector_person_names (person_id, last_name, first_name, middle_name, "primary", created_at, updated_at)
-          SELECT insert_people.person_id, z_people.last_name, z_people.first_name, z_people.middle_name, TRUE, current_timestamp, current_timestamp
-            FROM insert_people
-            JOIN #{table_name} z_people ON z_people.id = insert_people.z_person_id
-          RETURNING id
-
           )
 
           UPDATE #{table_name} z_people
              SET person_id = insert_people.person_id
             FROM insert_people
            WHERE insert_people.z_person_id = z_people.id
+        SQL
+
+        # Insert new person_names
+        execute <<-SQL.squish
+          WITH 
+ 
+          all_person_names AS (
+            
+          SELECT z_people.person_id AS person_id, 
+                 z_people.primary_last_name AS last_name,
+                 z_people.primary_first_name AS first_name,
+                 z_people.primary_middle_name AS middle_name
+            FROM #{table_name} z_people
+           UNION ALL
+          SELECT z_people.person_id AS person_id, 
+                 unnest(z_people.additional_last_names) AS last_name,
+                 unnest(z_people.additional_first_names) AS first_name,
+                 unnest(z_people.additional_middle_names) AS middle_name
+            FROM #{table_name} z_people
+          
+          )
+
+          INSERT INTO core_data_connector_person_names (
+            person_id, 
+            last_name,
+            first_name,
+            middle_name, 
+            created_at, 
+            updated_at
+          )
+          SELECT all_person_names.person_id, 
+                 all_person_names.last_name,
+                 all_person_names.first_name,
+                 all_person_names.middle_name, 
+                 current_timestamp, 
+                 current_timestamp
+            FROM all_person_names
+           WHERE NOT EXISTS ( SELECT 1
+                                FROM core_data_connector_person_names person_names
+                               WHERE person_names.person_id = all_person_names.person_id
+                                 AND ( person_names.last_name = all_person_names.last_name 
+                                  OR ( person_names.last_name IS NULL AND all_person_names.last_name IS NULL ))
+                                 AND ( person_names.first_name = all_person_names.first_name
+                                  OR ( person_names.first_name IS NULL AND all_person_names.first_name IS NULL ))
+                                 AND ( person_names.middle_name = all_person_names.middle_name 
+                                  OR ( person_names.middle_name IS NULL AND all_person_names.middle_name IS NULL )))
+        SQL
+
+        # Reset all person_names "primary" indicator to FALSE
+        execute <<-SQL.squish
+          UPDATE core_data_connector_person_names person_names
+             SET "primary" = FALSE,
+                 updated_at = current_timestamp
+            FROM #{table_name} z_people
+           WHERE z_people.person_id = person_names.person_id
+        SQL
+
+        # Set person_names "primary" indicator to TRUE
+        execute <<-SQL.squish
+          WITH 
+              
+          primary_person_names AS (
+              
+          SELECT z_people.person_id AS person_id, 
+                 z_people.primary_last_name AS last_name,
+                 z_people.primary_first_name AS first_name,
+                 z_people.primary_middle_name AS middle_name
+            FROM #{table_name} z_people
+
+          )
+
+          UPDATE core_data_connector_person_names person_names
+             SET "primary" = TRUE,
+                 updated_at = current_timestamp
+            FROM primary_person_names
+           WHERE primary_person_names.person_id = person_names.person_id
+             AND ( person_names.last_name = primary_person_names.last_name 
+              OR ( person_names.last_name IS NULL AND primary_person_names.last_name IS NULL ))
+             AND ( person_names.first_name = primary_person_names.first_name
+              OR ( person_names.first_name IS NULL AND primary_person_names.first_name IS NULL ))
+             AND ( person_names.middle_name = primary_person_names.middle_name 
+              OR ( person_names.middle_name IS NULL AND primary_person_names.middle_name IS NULL ))
         SQL
       end
 
@@ -98,6 +157,30 @@ module CoreDataConnector
            WHERE people.uuid = z_people.uuid
              AND z_people.uuid IS NOT NULL
         SQL
+
+        execute <<-SQL.squish
+          WITH 
+
+          record_names AS (
+
+          SELECT id, 
+                 ARRAY(SELECT nullif(trim(BOTH ' ' FROM unnest(string_to_array(last_name, '#{Nameable::NAME_DELIMITER}'))), '')) as last_names,
+                 ARRAY(SELECT nullif(trim(BOTH ' ' FROM unnest(string_to_array(first_name, '#{Nameable::NAME_DELIMITER}'))), '')) as first_names,
+                 ARRAY(SELECT nullif(trim(BOTH ' ' FROM unnest(string_to_array(middle_name, '#{Nameable::NAME_DELIMITER}'))), '')) as middle_names
+            FROM #{table_name}
+
+          )
+
+          UPDATE #{table_name} z_people
+             SET primary_last_name = record_names.last_names[1],
+                 primary_first_name = record_names.first_names[1],
+                 primary_middle_name = record_names.middle_names[1],
+                 additional_last_names = record_names.last_names[2:array_length(record_names.last_names, 1)],
+                 additional_first_names = record_names.first_names[2:array_length(record_names.first_names, 1)],
+                 additional_middle_names = record_names.middle_names[2:array_length(record_names.middle_names, 1)]
+            FROM record_names
+           WHERE record_names.id = z_people.id
+          SQL
 
         super
       end
@@ -132,6 +215,24 @@ module CoreDataConnector
          }, {
            name: 'person_id',
            type: 'INTEGER'
+         }, {
+           name: 'primary_last_name',
+           type: 'VARCHAR'
+         }, {
+           name: 'primary_first_name',
+           type: 'VARCHAR'
+         }, {
+           name: 'primary_middle_name',
+           type: 'VARCHAR'
+         }, {
+           name: 'additional_last_names',
+           type: 'TEXT[]'
+         }, {
+           name: 'additional_first_names',
+           type: 'TEXT[]'
+         }, {
+           name: 'additional_middle_names',
+           type: 'TEXT[]'
          }, {
            name: 'user_defined',
            type: 'JSONB'

--- a/app/services/core_data_connector/import/places.rb
+++ b/app/services/core_data_connector/import/places.rb
@@ -1,6 +1,9 @@
 module CoreDataConnector
   module Import
     class Places < Base
+      # Includes
+      include Nameable
+
       def cleanup
         super
 
@@ -19,30 +22,20 @@ module CoreDataConnector
       def load
         super
 
+        # Update existing places
         execute <<-SQL.squish
           WITH
               
           update_places AS (
           
-            UPDATE core_data_connector_places places
-               SET z_place_id = z_places.id,
-                   user_defined = z_places.user_defined,
-                   import_id = z_places.import_id,
-                   updated_at = current_timestamp
-              FROM #{table_name} z_places
-             WHERE z_places.place_id = places.id
+          UPDATE core_data_connector_places places
+             SET z_place_id = z_places.id,
+                 user_defined = z_places.user_defined,
+                 import_id = z_places.import_id,
+                 updated_at = current_timestamp
+            FROM #{table_name} z_places
+           WHERE z_places.place_id = places.id
               
-          ),
-
-          update_place_names AS (
-
-            UPDATE core_data_connector_place_names place_names
-               SET name = z_places.name,
-                   updated_at = current_timestamp
-              FROM #{table_name} z_places
-             WHERE z_places.place_id = place_names.place_id
-               AND place_names.primary = TRUE
-
           )
 
           UPDATE core_data_connector_place_geometries place_geometries
@@ -52,6 +45,7 @@ module CoreDataConnector
            WHERE z_places.place_id = place_geometries.place_id
         SQL
 
+        # Insert new places
         execute <<-SQL.squish
           WITH 
 
@@ -79,16 +73,6 @@ module CoreDataConnector
 
           ),
 
-          insert_place_names AS (
-
-          INSERT INTO core_data_connector_place_names (place_id, name, "primary", created_at, updated_at)
-          SELECT insert_places.place_id, z_places.name, TRUE, current_timestamp, current_timestamp
-            FROM insert_places
-            JOIN #{table_name} z_places ON z_places.id = insert_places.z_place_id
-          RETURNING id
-
-          ),
-
           insert_place_geometries AS (
 
           INSERT INTO core_data_connector_place_geometries (place_id, geometry, created_at, updated_at)
@@ -104,6 +88,57 @@ module CoreDataConnector
             FROM insert_places
            WHERE insert_places.z_place_id = z_places.id
         SQL
+
+        # Insert new place_names
+        execute <<-SQL.squish
+          WITH 
+ 
+          all_place_names AS (
+            
+          SELECT z_places.place_id AS place_id, z_places.primary_name AS name
+            FROM #{table_name} z_places
+           UNION ALL
+          SELECT z_places.place_id AS place_id, unnest(z_places.additional_names) AS name
+            FROM #{table_name} z_places
+          
+          )
+
+          INSERT INTO core_data_connector_place_names (place_id, name, created_at, updated_at)
+          SELECT all_place_names.place_id, all_place_names.name, current_timestamp, current_timestamp
+            FROM all_place_names
+           WHERE NOT EXISTS ( SELECT 1
+                                FROM core_data_connector_place_names place_names
+                               WHERE place_names.place_id = all_place_names.place_id
+                                 AND place_names.name = all_place_names.name )
+        SQL
+
+        # Reset all place_names "primary" indicator to FALSE
+        execute <<-SQL.squish
+          UPDATE core_data_connector_place_names place_names
+             SET "primary" = FALSE,
+                 updated_at = current_timestamp
+            FROM #{table_name} z_places
+           WHERE z_places.place_id = place_names.place_id
+        SQL
+
+        # Set place_names "primary" indicator to TRUE
+        execute <<-SQL.squish
+          WITH 
+              
+          primary_place_names AS (
+              
+          SELECT z_places.place_id AS place_id, z_places.primary_name AS name
+            FROM #{table_name} z_places
+
+          )
+
+          UPDATE core_data_connector_place_names place_names
+             SET "primary" = TRUE,
+                 updated_at = current_timestamp
+            FROM primary_place_names
+           WHERE primary_place_names.place_id = place_names.place_id
+             AND primary_place_names.name = place_names.name
+        SQL
       end
 
       def transform
@@ -115,6 +150,8 @@ module CoreDataConnector
            WHERE places.uuid = z_places.uuid
              AND z_places.uuid IS NOT NULL
         SQL
+
+        transform_names
 
         super
       end
@@ -145,6 +182,12 @@ module CoreDataConnector
          }, {
            name: 'place_id',
            type: 'INTEGER',
+        }, {
+           name: 'primary_name',
+           type: 'VARCHAR'
+        }, {
+           name: 'additional_names',
+           type: 'TEXT[]'
         }, {
            name: 'user_defined',
            type: 'JSONB'


### PR DESCRIPTION
This pull request implements the ability to import multiple names per record in the `.csv` files for models that support multiple names. 

The `name` column can be used to include multiple names using a semicolon as the delimiter (e.g. "Boston, MA; Beantown").

In the case of `people.csv`, the names are split across the `last_name`, `first_name`, and `middle_name` fields, but the same principle can be applied.