### PR TITLE
CDC #488 - Object prefixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'faker', '~> 3.2.1'
 gem 'fuzzy_dates', git: 'https://github.com/performant-software/fuzzy-dates.git', tag: 'v0.1.1'
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.3'
 gem 'resource_api', git: 'https://github.com/performant-software/resource-api.git', tag: 'v0.5.15'
-gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.2.6'
+gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.2.7'
 gem 'user_defined_fields', git: 'https://github.com/performant-software/user-defined-fields.git', tag: 'v0.1.14'
 gem 'sqlite3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,8 +28,8 @@ GIT
 
 GIT
   remote: https://github.com/performant-software/triple-eye-effable.git
-  revision: 924c64241ab2151c9e0e4ea002b352051e838008
-  tag: v0.2.6
+  revision: 2fc8e3705f57e0b165e6c144523ab1aad723f3f8
+  tag: v0.2.7
   specs:
     triple_eye_effable (0.1.0)
       httparty (~> 0.20.0)


### PR DESCRIPTION
This pull request updates the `triple_eye_effable` gem to the latest version to fix an issue with objects being nested under the `/` prefix.