### PR TITLE
Update to `faircopy_cloud_url` constructor for FCC2 compatibility

### DIFF
--- a/app/models/concerns/core_data_connector/fcc_importable.rb
+++ b/app/models/concerns/core_data_connector/fcc_importable.rb
@@ -8,7 +8,7 @@ module CoreDataConnector
         project = project_model.project
         return nil unless project_model.id == project.faircopy_cloud_project_model_id
 
-        "#{project.faircopy_cloud_url}/documents/#{faircopy_cloud_id}/csv"
+        "#{project.faircopy_cloud_url}/#{faircopy_cloud_id}/csv"
       end
     end
   end


### PR DESCRIPTION
### In this PR
This PR updates how the `faircopy_cloud_url` from which FairData fetches the CSVs created by FCC is constructed to allow more flexibility. This should allow for backwards compatibility with minimal disruption; existing projects will need to add `/documents` to the end of the configured FairCopy Cloud URL in the project settings, but no other changes should be needed. For new projects on FCC2, the FCC URL set in the project settings should be `https://beta-api.faircopy.cloud/<projectID>/tei_documents`. (Or whatever the appropriate host name is.)