### PR TITLE
Enable faceting for primary place names

### DIFF
--- a/app/services/core_data_connector/search/place.rb
+++ b/app/services/core_data_connector/search/place.rb
@@ -18,7 +18,7 @@ module CoreDataConnector
         include Base
 
         # Search attributes
-        search_attribute :name
+        search_attribute :name, facet: true
 
         search_attribute(:names, facet: true) do
           place_names.map(&:name)


### PR DESCRIPTION
# Summary

As per #163, Places were the only model that was missing faceting for primary names (as opposed to *all* names). La Supplique from Sapientia requires this, so here we are.