### PR TITLE
CDC #501 - Identifiers

### DIFF
--- a/app/models/core_data_connector/web_identifier.rb
+++ b/app/models/core_data_connector/web_identifier.rb
@@ -10,6 +10,10 @@ module CoreDataConnector
     # Callbacks
     before_create :find_identifier
 
+    # Delegates
+    delegate :project, to: :web_authority, allow_nil: true
+    delegate :project_id, to: :web_authority, allow_nil: true
+
     def self.all_records_by_project(project_id)
       WebIdentifier
         .joins(:web_authority)

--- a/app/policies/core_data_connector/web_authority_policy.rb
+++ b/app/policies/core_data_connector/web_authority_policy.rb
@@ -37,11 +37,11 @@ module CoreDataConnector
       !project.archived? && member?
     end
 
-    # A user can view a web authority if they are an admin user or the owner of the project.
+    # A user can view a web authority if they are an admin user or a member of the project.
     def show?
       return true if current_user.admin?
 
-      !project.archived? && owner?
+      !project.archived? && member?
     end
 
     # A user can update a web authority if they are an admin user or the owner of the project.
@@ -74,7 +74,7 @@ module CoreDataConnector
         .exists?
     end
 
-    # A user can view web authorities for any project they own.
+    # A user can view web authorities for any project for which they are a member.
     class Scope < BaseScope
       def resolve
         return scope.all if current_user.admin?
@@ -84,7 +84,6 @@ module CoreDataConnector
             .joins(:project)
             .where(UserProject.arel_table[:project_id].eq(WebAuthority.arel_table[:project_id]))
             .where(user_id: current_user.id)
-            .where(role: UserProject::ROLE_OWNER)
             .where.not(project: { archived: true })
             .arel
             .exists

--- a/app/policies/core_data_connector/web_identifier_policy.rb
+++ b/app/policies/core_data_connector/web_identifier_policy.rb
@@ -5,8 +5,8 @@ module CoreDataConnector
     def initialize(current_user, web_identifier)
       @current_user = current_user
       @web_identifier = web_identifier
-      @project_id = web_identifier&.web_authority&.project
-      @project_id = web_identifier&.web_authority&.project_id
+      @project = web_identifier&.project
+      @project_id = web_identifier&.project_id
     end
 
     # A user can create a web identifier if they are an admin user or member of owning the project.


### PR DESCRIPTION
This pull request fixes a bug where "Editor" users were unable to add identifiers to records. The issue was that the `web_authority` policy was only allowing "Owner" users to list/view records.