### PR TITLE
Area-based polygon simplification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /log/*.log
 /pkg/
 /tmp/
+.idea

--- a/app/services/core_data_connector/typesense.rb
+++ b/app/services/core_data_connector/typesense.rb
@@ -10,7 +10,7 @@ module CoreDataConnector
         num_retries: 10,
         healthcheck_interval_seconds: 1,
         retry_interval_seconds: 0.01,
-        connection_timeout_seconds: 10,
+        connection_timeout_seconds: 30,
         logger: Logger.new($stdout),
         log_level: Logger::INFO
       )


### PR DESCRIPTION
# Summary

#140 added the ability to index simplified versions of polygons, but the tolerance level passed to `st_simplify` was linear to make sure that really small polygons (e.g. city blocks) do not get overly simplified. This meant that large polygons like countries were not simplified as aggressively as they should have been.

In this PR, I've added a formula that simplifies large polygons more aggressively than small polygons.

## Math note

The `tolerance` parameter is a distance value. I still have no idea what unit it represents - it must be whatever PostGIS's default is, which seems to be some sort of abstract grid system. But anyway, the higher the tolerance goes, the simpler the polygons get.

The approach I used here sets the scale tolerance based on the square root of the polygon's area. As far as I can tell, the rate of change for $f(n) = \sqrt{n}$ approaches 0 as *n* increases. This means that the smoothing algorithm should be very conservative for small polygons like cities, and then crank up pretty aggressively beyond that, before leveling out and becoming more consistently applied across country-sized polygons (i.e. there shouldn't be a huge difference in smoothing aggressiveness between the US and France).