### PR TITLE
Clerk fixes

### DIFF
--- a/app/controllers/concerns/core_data_connector/clerk_authenticatable.rb
+++ b/app/controllers/concerns/core_data_connector/clerk_authenticatable.rb
@@ -37,8 +37,11 @@ module CoreDataConnector
         sso_id: clerk_user.id,
         email: clerk_user.email_addresses.first.email_address,
         name: [clerk_user.first_name, clerk_user.last_name].join(" "),
-        role: 'member'
+        role: 'member',
+        # satisfy the Rails validator even though we won't be using this password
+        password: Users::Passwords.generate_user_password
       )
+
       user.save!
 
       user

--- a/app/controllers/concerns/core_data_connector/clerk_authenticatable.rb
+++ b/app/controllers/concerns/core_data_connector/clerk_authenticatable.rb
@@ -51,6 +51,10 @@ module CoreDataConnector
       clerk_client.users.get(user_id: clerk_id).user
     end
 
+    def get_clerk_role(clerk_user)
+      clerk_user.public_metadata["role"]
+    end
+
     def clerk_client
       @clerk_client ||= Clerk::SDK.new(secret_key: ENV.fetch("CLERK_SECRET_KEY"))
     end

--- a/app/controllers/core_data_connector/users_controller.rb
+++ b/app/controllers/core_data_connector/users_controller.rb
@@ -55,7 +55,7 @@ module CoreDataConnector
       # default to guest, which means users can't create projects
       role = 'guest'
 
-      if sso_user.private_metadata['is_performant'] == true
+      if sso_user.private_metadata['is_global_admin'] == true
         # *we* should be CD admins (and no one else!)
         role = 'admin'
       else

--- a/app/controllers/core_data_connector/users_controller.rb
+++ b/app/controllers/core_data_connector/users_controller.rb
@@ -52,10 +52,29 @@ module CoreDataConnector
     end
 
     def update_user_from_sso(local_user, sso_user)
+      # default to guest, which means users can't create projects
+      role = 'guest'
+
+      if sso_user.private_metadata['is_performant'] == true
+        # *we* should be CD admins (and no one else!)
+        role = 'admin'
+      else
+        # get user's role from their main organization membership role
+        org_memberships = clerk_client.users.get_organization_memberships(user_id: sso_user.id)
+        main_org = org_memberships.organization_memberships.data.first
+
+        org_role = main_org.role
+
+        # org admins are Performant Studio customers who should be able to create projects,
+        # which means they get the member system role in Core Data
+        role = 'member' if org_role == 'org:admin'
+      end
+
       local_user.update(
         sso_id: sso_user.id,
         name: build_name(sso_user.first_name, sso_user.last_name),
-        avatar_url: sso_user.profile_image_url
+        avatar_url: sso_user.profile_image_url,
+        role: role
       )
     end
 

--- a/app/controllers/core_data_connector/users_controller.rb
+++ b/app/controllers/core_data_connector/users_controller.rb
@@ -47,6 +47,8 @@ module CoreDataConnector
       elsif last.present?
         name = last
       end
+
+      name
     end
 
     def update_user_from_sso(local_user, sso_user)

--- a/app/services/core_data_connector/users/clerk_migration.rb
+++ b/app/services/core_data_connector/users/clerk_migration.rb
@@ -26,15 +26,26 @@ module CoreDataConnector
 
             is_new_user = false
 
+            email_domain = user.email.split('@').last
+
             if clerk_user.nil?
               is_new_user = true
               first_name, last_name = user.split_name
+
+              is_performant = email_domain == 'performantsoftware.com'
+
+              private_metadata = {}
+
+              if is_performant
+                private_metadata[:is_performant] = true
+              end
 
               create_request = Clerk::Models::Operations::CreateUserRequest.new(
                 email_address: [user.email],
                 first_name: first_name,
                 last_name: last_name,
-                skip_password_requirement: true
+                skip_password_requirement: true,
+                private_metadata: private_metadata
               )
 
               response = clerk.users.create(request: create_request)
@@ -42,9 +53,8 @@ module CoreDataConnector
               Rails.logger.info "#{user.email} created in Clerk"
             end
 
-            email_domain = user.email.split('@').last
-
-            org_id = org_domains[email_domain]
+            # Default to Performant Software
+            org_id = org_domains[email_domain] || org_domains['performantsoftware.com']
 
             if org_id
               if is_new_user

--- a/app/services/core_data_connector/users/clerk_migration.rb
+++ b/app/services/core_data_connector/users/clerk_migration.rb
@@ -17,7 +17,7 @@ module CoreDataConnector
           org_domains[name] = org.id
         end
 
-        User.where(sso_id: nil).find_each do |user|
+        User.where(sso_id: nil).limit(100).find_each do |user|
           begin
             sleep 2
             list_request = Clerk::Models::Operations::GetUserListRequest.new(email_address: [user.email])
@@ -32,12 +32,12 @@ module CoreDataConnector
               is_new_user = true
               first_name, last_name = user.split_name
 
-              is_performant = email_domain == 'performantsoftware.com'
+              is_global_admin = email_domain == ENV['CLERK_MIGRATION_GLOBAL_ADMIN_DOMAIN']
 
               private_metadata = {}
 
-              if is_performant
-                private_metadata[:is_performant] = true
+              if is_global_admin
+                private_metadata[:is_global_admin] = true
               end
 
               create_request = Clerk::Models::Operations::CreateUserRequest.new(
@@ -50,35 +50,32 @@ module CoreDataConnector
 
               response = clerk.users.create(request: create_request)
               clerk_user = response.user
-              Rails.logger.info "#{user.email} created in Clerk"
+              puts "#{user.email} created in Clerk"
             end
 
-            # Default to Performant Software
-            org_id = org_domains[email_domain] || org_domains['performantsoftware.com']
+            org_id = org_domains[email_domain] || org_domains[ENV['CLERK_MIGRATION_DEFAULT_DOMAIN']]
 
-            if org_id
-              if is_new_user
-                needs_membership = true
-              else
-                membership_request = Clerk::Models::Operations::ListOrganizationMembershipsRequest.new(organization_id: org_id)
-                memberships = clerk.organization_memberships.list(request: membership_request)
-                needs_membership = !memberships.organization_memberships.data.any? { |m| m.organization.id == org_id }
-              end
+            if is_new_user
+              needs_membership = true
+            else
+              membership_request = Clerk::Models::Operations::ListOrganizationMembershipsRequest.new(organization_id: org_id)
+              memberships = clerk.organization_memberships.list(request: membership_request)
+              needs_membership = !memberships.organization_memberships.data.any? { |m| m.organization.id == org_id }
+            end
 
-              if needs_membership
-                org_member_request_body = {
-                  user_id: clerk_user.id,
-                  role: 'org:member'
-                }
-                clerk.organization_memberships.create(body: org_member_request_body, organization_id: org_id)
+            if needs_membership
+              org_member_request_body = {
+                user_id: clerk_user.id,
+                role: 'org:member'
+              }
+              clerk.organization_memberships.create(body: org_member_request_body, organization_id: org_id)
 
-                Rails.logger.info "#{user.email} added to organization: #{email_domain}"
-              end
+              puts "#{user.email} added to organization: #{org_id}"
             end
 
             user.update!(sso_id: clerk_user.id)
           rescue StandardError => e
-            Rails.logger.info "Error migrating user #{user.email}: #{e.message}"
+            puts "Error migrating user #{user.email}: #{e.message}"
           end
         end
       end
@@ -98,11 +95,11 @@ module CoreDataConnector
         users.user_list.each do |user|
           sleep 2
           clerk.users.delete(user_id: user.id)
-          Rails.logger.info "Deleted user #{user.id} with email #{user.email_addresses.first.email_address}"
+          puts "Deleted user #{user.id} with email #{user.email_addresses.first.email_address}"
         end
 
         User.update_all(sso_id: nil)
-        Rails.logger.info "Cleared sso_id for all users"
+        puts "Cleared sso_id for all users"
       end
     end
   end


### PR DESCRIPTION
# Summary

This PR addresses various requests for changes and a couple things I noticed as I worked. There will be an accompanying `core-data-cloud` PR later today but I think it's fine to treat this PR independently.

## Features
* update the `update_user_from_sso` method (used by the `me` endpoint) to set the user's Core Data role based on their Clerk role
  * if the user has the `is_performant` private metadata boolean set to `true`, they're an *admin* (see below for more about this field)
  * if the user has the `admin` role in their first Clerk org, they're a *member* (i.e. they are allowed to create CD projects)
  * otherwise, the user is a *guest* (i.e. they can't create new CD projects, but admins/members can invite them to projects)

I don't like that this adds another Clerk API request to the `me` logic but there doesn't seem to be a way to avoid it, and the slowdown doesn't seem noticeable.

## Fixes
* generate a local password for newly created Clerk users to get around password reset requirement (https://github.com/performant-software/core-data-cloud/issues/587)
* fix issue where `name` wasn't actually being returned by `build_name`

## Migration task
* put every user whose email domain doesn't match any other organization into the Performant organization
* add new `is_performant` metadata field for users with `performantsoftware.com` email domains 