### PR TITLE
Clerk fixes round 2

### DIFF
--- a/app/controllers/concerns/core_data_connector/clerk_authenticatable.rb
+++ b/app/controllers/concerns/core_data_connector/clerk_authenticatable.rb
@@ -39,7 +39,8 @@ module CoreDataConnector
         name: [clerk_user.first_name, clerk_user.last_name].join(" "),
         role: 'member',
         # satisfy the Rails validator even though we won't be using this password
-        password: Users::Passwords.generate_user_password
+        password: Users::Passwords.generate_user_password,
+        require_password_change: false
       )
 
       user.save!

--- a/app/controllers/core_data_connector/users_controller.rb
+++ b/app/controllers/core_data_connector/users_controller.rb
@@ -36,7 +36,9 @@ module CoreDataConnector
 
       update_user_from_sso(@current_user, clerk_user)
 
-      render json: @current_user, status: :ok
+      serializer = UsersSerializer.new
+
+      render json: serializer.render_show(@current_user), status: :ok
     end
 
     def build_name(first, last)
@@ -59,15 +61,12 @@ module CoreDataConnector
         # *we* should be CD admins (and no one else!)
         role = 'admin'
       else
-        # get user's role from their main organization membership role
         org_memberships = clerk_client.users.get_organization_memberships(user_id: sso_user.id)
-        main_org = org_memberships.organization_memberships.data.first
-
-        org_role = main_org.role
-
         # org admins are Performant Studio customers who should be able to create projects,
         # which means they get the member system role in Core Data
-        role = 'member' if org_role == 'org:admin'
+        if org_memberships.organization_memberships.data.any? { |o| o.role == 'org:admin' }
+          role = 'member'
+        end
       end
 
       local_user.update(

--- a/app/services/core_data_connector/users/clerk_migration.rb
+++ b/app/services/core_data_connector/users/clerk_migration.rb
@@ -53,7 +53,7 @@ module CoreDataConnector
               puts "#{user.email} created in Clerk"
             end
 
-            org_id = org_domains[email_domain] || org_domains[ENV['CLERK_MIGRATION_DEFAULT_DOMAIN']]
+            org_id = org_domains[email_domain]
 
             if is_new_user
               needs_membership = true
@@ -64,13 +64,21 @@ module CoreDataConnector
             end
 
             if needs_membership
-              org_member_request_body = {
-                user_id: clerk_user.id,
-                role: 'org:member'
-              }
-              clerk.organization_memberships.create(body: org_member_request_body, organization_id: org_id)
-
-              puts "#{user.email} added to organization: #{org_id}"
+              if org_id
+                org_member_request_body = {
+                  user_id: clerk_user.id,
+                  role: 'org:member'
+                }
+                clerk.organization_memberships.create(body: org_member_request_body, organization_id: org_id)
+                puts "#{user.email} added to organization: #{org_id}"
+              else
+                org_create_request = Clerk::Models::Operations::CreateOrganizationRequest.new(
+                  name: "#{user.name}'s Organization",
+                  created_by: clerk_user.id
+                )
+                clerk.organizations.create(request: org_create_request)
+                puts "#{user.email} created organization: #{org_id}"
+              end
             end
 
             user.update!(sso_id: clerk_user.id)

--- a/app/services/core_data_connector/users/clerk_migration.rb
+++ b/app/services/core_data_connector/users/clerk_migration.rb
@@ -77,7 +77,7 @@ module CoreDataConnector
                   created_by: clerk_user.id
                 )
                 clerk.organizations.create(request: org_create_request)
-                puts "#{user.email} created organization: #{org_id}"
+                puts "#{user.email} created a personal organization"
               end
             end
 


### PR DESCRIPTION
# Summary

Just like the last time, this should be split into multiple PRs but to save time I'm bunching them all together.

* use `render_show` from the users serializer for the `me` endpoint response instead of just sending the user object
* in the migration script, create a personal organization for users if their email domain doesn't match the existing orgs
* add `require_password_reset: false` to the `User.new` call inside `create_user_from_clerk` to be extra sure the user doesn't require a password reset