### PR TITLE
Fuzzy places

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -324,6 +324,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   arm64-darwin-24
   x86_64-linux
 

--- a/app/controllers/core_data_connector/users_controller.rb
+++ b/app/controllers/core_data_connector/users_controller.rb
@@ -32,6 +32,8 @@ module CoreDataConnector
 
       return unless @current_user
 
+      puts "Attempting to authenticate user #{@current_user.id}"
+
       clerk_user = get_clerk_data(@current_user.sso_id)
 
       update_user_from_sso(@current_user, clerk_user)

--- a/app/policies/core_data_connector/place_policy.rb
+++ b/app/policies/core_data_connector/place_policy.rb
@@ -21,7 +21,7 @@ module CoreDataConnector
       [ *ownable_attributes,
         user_defined: {},
         place_names_attributes: [:id, :name, :primary, :_destroy],
-        place_geometry_attributes: [:id, :geometry_json, :_destroy],
+        place_geometry_attributes: [:id, :geometry_json, :_destroy, properties: {}],
         place_layers_attributes: [:id, :name, :layer_type, :url, :content, :_destroy]
       ]
     end

--- a/app/serializers/core_data_connector/place_geometries_serializer.rb
+++ b/app/serializers/core_data_connector/place_geometries_serializer.rb
@@ -1,6 +1,6 @@
 module CoreDataConnector
   class PlaceGeometriesSerializer < BaseSerializer
-    index_attributes :id, geometry_json: -> (pg, *rest) { pg.to_geojson }
-    show_attributes :id, geometry_json: -> (pg, *rest) { pg.to_geojson }
+    index_attributes :id, :properties, geometry_json: -> (pg, *rest) { pg.to_geojson }
+    show_attributes :id, :properties, geometry_json: -> (pg, *rest) { pg.to_geojson }
   end
 end

--- a/app/serializers/core_data_connector/public/v1/place_geometries_serializer.rb
+++ b/app/serializers/core_data_connector/public/v1/place_geometries_serializer.rb
@@ -2,8 +2,8 @@ module CoreDataConnector
   module Public
     module V1
       class PlaceGeometriesSerializer < BaseSerializer
-        index_attributes geometry_json: -> (pg, *rest) { pg.to_geojson }
-        show_attributes geometry_json: -> (pg, *rest) { pg.to_geojson }
+        index_attributes :properties, geometry_json: -> (pg, *rest) { pg.to_geojson }
+        show_attributes :properties, geometry_json: -> (pg, *rest) { pg.to_geojson }
       end
     end
   end

--- a/app/services/core_data_connector/export/place.rb
+++ b/app/services/core_data_connector/export/place.rb
@@ -24,6 +24,9 @@ module CoreDataConnector
         export_attribute(:name) { format_name }
         export_attribute(:latitude) { geometry_center&.y }
         export_attribute(:longitude) { geometry_center&.x }
+        export_attribute(:properties) do
+          JSON.generate(place_geometry&.properties) if place_geometry&.properties
+        end
       end
     end
   end

--- a/app/services/core_data_connector/import/base.rb
+++ b/app/services/core_data_connector/import/base.rb
@@ -10,6 +10,7 @@ module CoreDataConnector
         @import_id = import_id
 
         @connection = ActiveRecord::Base.connection
+        @csv_headers = CSV.foreach(filepath).first
         @table_name = create_table_name
         @user_defined_columns = load_user_defined_columns
       end
@@ -123,9 +124,7 @@ module CoreDataConnector
       def load_user_defined_columns
         columns = []
 
-        headers = CSV.foreach(filepath).first
-
-        headers.each do |header|
+        @csv_headers.each do |header|
           next unless ImportAnalyze::Helper.is_user_defined_column?(header)
 
           uuid = ImportAnalyze::Helper.column_name_to_uuid(header)

--- a/app/services/core_data_connector/import/places.rb
+++ b/app/services/core_data_connector/import/places.rb
@@ -40,6 +40,7 @@ module CoreDataConnector
 
           UPDATE core_data_connector_place_geometries place_geometries
              SET geometry = st_makepoint(z_places.longitude, z_places.latitude),
+                 properties = z_places.properties,
                  updated_at = current_timestamp
             FROM #{table_name} z_places
            WHERE z_places.place_id = place_geometries.place_id
@@ -52,20 +53,20 @@ module CoreDataConnector
           insert_places AS (
 
           INSERT INTO core_data_connector_places (
-            project_model_id, 
-            uuid, 
+            project_model_id,
+            uuid,
             z_place_id, 
             user_defined,
             import_id,
-            created_at, 
+            created_at,
             updated_at
           )
-          SELECT z_places.project_model_id, 
-                 z_places.uuid, 
-                 z_places.id, 
+          SELECT z_places.project_model_id,
+                 z_places.uuid,
+                 z_places.id,
                  z_places.user_defined,
                  z_places.import_id,
-                 current_timestamp, 
+                 current_timestamp,
                  current_timestamp
             FROM #{table_name} z_places
            WHERE z_places.place_id IS NULL
@@ -75,8 +76,8 @@ module CoreDataConnector
 
           insert_place_geometries AS (
 
-          INSERT INTO core_data_connector_place_geometries (place_id, geometry, created_at, updated_at)
-          SELECT insert_places.place_id, st_makepoint(z_places.longitude, z_places.latitude), current_timestamp, current_timestamp
+          INSERT INTO core_data_connector_place_geometries (place_id, geometry, properties, created_at, updated_at)
+          SELECT insert_places.place_id, st_makepoint(z_places.longitude, z_places.latitude), z_places.properties, current_timestamp, current_timestamp
             FROM insert_places
             JOIN #{table_name} z_places ON z_places.id = insert_places.z_place_id
           RETURNING id
@@ -145,8 +146,10 @@ module CoreDataConnector
         execute <<-SQL.squish
           UPDATE #{table_name} z_places
              SET place_id = places.id,
-                 user_defined = places.user_defined
+                 user_defined = places.user_defined,
+                 properties = COALESCE(z_places.properties, place_geometries.properties, '{}'::jsonb)
             FROM core_data_connector_places places
+            LEFT JOIN core_data_connector_place_geometries place_geometries ON place_geometries.place_id = places.id
            WHERE places.uuid = z_places.uuid
              AND z_places.uuid IS NOT NULL
         SQL
@@ -180,8 +183,12 @@ module CoreDataConnector
            type: 'DECIMAL',
            copy: true
          }, {
+          name: 'properties',
+          type: 'JSONB',
+          copy: @csv_headers.include?('properties')
+        }, {
            name: 'place_id',
-           type: 'INTEGER',
+           type: 'INTEGER'
         }, {
            name: 'primary_name',
            type: 'VARCHAR'

--- a/app/services/core_data_connector/search/place.rb
+++ b/app/services/core_data_connector/search/place.rb
@@ -32,6 +32,10 @@ module CoreDataConnector
           end
         end
 
+        search_attribute(:properties) do
+          place_geometry&.properties
+        end
+
         search_attribute(:coordinates) do
           # Return if the "geometry_center" attribute is not defined
           next unless self.respond_to?(:geometry_center) && geometry_center.present?

--- a/db/migrate/20260402204230_add_properties_to_place_geometries.rb
+++ b/db/migrate/20260402204230_add_properties_to_place_geometries.rb
@@ -1,0 +1,5 @@
+class AddPropertiesToPlaceGeometries < ActiveRecord::Migration[8.0]
+  def change
+    add_column :core_data_connector_place_geometries, :properties, :jsonb, default: {}
+  end
+end

--- a/lib/typesense/search.rb
+++ b/lib/typesense/search.rb
@@ -78,6 +78,12 @@ module Typesense
           facet: false,
           optional: true
         }, {
+          name: 'properties',
+          type: 'object',
+          index: false,
+          facet: false,
+          optional: true
+        }, {
           name: 'coordinates',
           type: 'geopoint',
           facet: false,


### PR DESCRIPTION
# Summary

This PR:

* adds a new `properties` JSON column to the `place_geometry` table
  * for now, `properties` field will only contain `certainty_radius`, which tells Core Data's map form and CDP's map components to render a shaded circle around the point to indicate the fuzziness of the place, but we can add similar types of data to it in the future (Jamie wants custom map point colors or icons, for example)
* adds the `properties` column to the place export service
* adds support for the `properties` column to the place import service
  * this was a bit tricky because it needs to be optional to avoid having to update both the FCCs to use the new column. It works in my testing with and without `properties` so I *think* I got the code right but it doesn't look like we've ever had a non-UDF optional column so I'm still a bit nervous about it.
* adds `properties` to the Typesense indexing service