### PR TITLE
Add `faircopy_cloud_project_id` field to `project` schema

### DIFF
--- a/app/models/concerns/core_data_connector/fcc_importable.rb
+++ b/app/models/concerns/core_data_connector/fcc_importable.rb
@@ -8,6 +8,11 @@ module CoreDataConnector
         project = project_model.project
         return nil unless project_model.id == project.faircopy_cloud_project_model_id
 
+        # We assume that if a project ID is configured, that means we should use it; in other words, use the FCC2 URL format
+        if project.faircopy_cloud_project_id?
+          return "#{project.faircopy_cloud_url}/#{project.faircopy_cloud_project_id}/tei_documents/#{faircopy_cloud_id}/csv"
+        end
+
         "#{project.faircopy_cloud_url}/documents/#{faircopy_cloud_id}/csv"
       end
     end

--- a/app/policies/core_data_connector/project_policy.rb
+++ b/app/policies/core_data_connector/project_policy.rb
@@ -103,6 +103,7 @@ module CoreDataConnector
         :description,
         :discoverable,
         :faircopy_cloud_url,
+        :faircopy_cloud_project_id,
         :faircopy_cloud_project_model_id,
         :map_library_url,
         reconciliation_credentials: {}

--- a/app/serializers/core_data_connector/projects_serializer.rb
+++ b/app/serializers/core_data_connector/projects_serializer.rb
@@ -1,9 +1,9 @@
 module CoreDataConnector
   class ProjectsSerializer < BaseSerializer
-    index_attributes :id, :name, :description, :discoverable, :faircopy_cloud_url, :map_library_url,
+    index_attributes :id, :name, :description, :discoverable, :faircopy_cloud_url, :faircopy_cloud_project_id, :map_library_url,
                      :faircopy_cloud_project_model_id, :archived
 
-    show_attributes :id, :name, :description, :discoverable, :faircopy_cloud_url, :map_library_url,
+    show_attributes :id, :name, :description, :discoverable, :faircopy_cloud_url, :faircopy_cloud_project_id, :map_library_url,
                     :faircopy_cloud_project_model_id, :archived, :reconciliation_credentials,
                     :use_storage_key, :uuid
   end

--- a/db/migrate/20260416013801_add_fcc2_project_id_to_projects.rb
+++ b/db/migrate/20260416013801_add_fcc2_project_id_to_projects.rb
@@ -1,0 +1,5 @@
+class AddFcc2ProjectIdToProjects < ActiveRecord::Migration[8.0]
+  def change
+    add_column :core_data_connector_projects, :faircopy_cloud_project_id, :integer
+  end
+end


### PR DESCRIPTION
### In this PR
- Adds a `faircopy_cloud_project_id` field to the `project` schema;
- Updates the function for generating the FairCopy Cloud URL for importing CSV files to use the new FCC2 URL format in the case that a project ID is provided.