### PR TITLE
Prevent Clerk from Messing up password digests for local mode

### DIFF
--- a/app/services/core_data_connector/users/clerk_migration.rb
+++ b/app/services/core_data_connector/users/clerk_migration.rb
@@ -1,4 +1,6 @@
-require 'clerk'
+if ENV['VITE_AUTH_PROVIDER'] == 'clerk'
+  require 'clerk'
+end
 
 module CoreDataConnector
   module Users


### PR DESCRIPTION
Requiring clerk seems to mix in some rails magic related to password encryption. Any password encryted in this situation gets corrupted. @camdendotlol was able to reproduce this affect on his local. He had already determined this and guarded against it in clerk_authenticatable.rb, but there was another instance of requiring Clerk in clerk_migration.rb. 
