### PR TITLE
Update Clerk migration task to take user input for orgs

### DIFF
--- a/app/services/core_data_connector/users/clerk_migration.rb
+++ b/app/services/core_data_connector/users/clerk_migration.rb
@@ -23,7 +23,7 @@ module CoreDataConnector
           org_domains[name] = org.id
         end
 
-        User.where(sso_id: nil).limit(90).find_each do |user|
+        User.where(sso_id: nil).find_each do |user|
           begin
             sleep 2
             list_request = Clerk::Models::Operations::GetUserListRequest.new(email_address: [user.email])

--- a/app/services/core_data_connector/users/clerk_migration.rb
+++ b/app/services/core_data_connector/users/clerk_migration.rb
@@ -8,18 +8,22 @@ module CoreDataConnector
       def run
         clerk = Clerk::SDK.new(secret_key: ENV.fetch('CLERK_SECRET_KEY'))
 
-        organization_list = clerk.organizations.list(request: Clerk::Models::Operations::ListOrganizationsRequest.new)
+        organization_list_request = Clerk::Models::Operations::ListOrganizationsRequest.new(limit: 200)
+        organization_list = clerk.organizations.list(request: organization_list_request)
         organizations = organization_list.organizations.data
 
         org_domains = Hash.new
 
         organizations.each do |org|
           domain_request = Clerk::Models::Operations::ListOrganizationDomainsRequest.new(organization_id: org.id)
-          name = clerk.organization_domains.list(request: domain_request).organization_domains.data.first.name
+          domains = clerk.organization_domains.list(request: domain_request).organization_domains.data
+          next if domains.empty?
+
+          name = domains.first.name
           org_domains[name] = org.id
         end
 
-        User.where(sso_id: nil).find_each do |user|
+        User.where(sso_id: nil).limit(90).find_each do |user|
           begin
             sleep 2
             list_request = Clerk::Models::Operations::GetUserListRequest.new(email_address: [user.email])
@@ -36,7 +40,9 @@ module CoreDataConnector
 
               is_global_admin = email_domain == ENV['CLERK_MIGRATION_GLOBAL_ADMIN_DOMAIN']
 
-              private_metadata = {}
+              private_metadata = {
+                migrated_from: 'FairData'
+              }
 
               if is_global_admin
                 private_metadata[:is_global_admin] = true
@@ -72,14 +78,23 @@ module CoreDataConnector
                   role: 'org:member'
                 }
                 clerk.organization_memberships.create(body: org_member_request_body, organization_id: org_id)
-                puts "#{user.email} added to organization: #{org_id}"
+                puts "#{user.email} automatically added to organization based on email domain: #{org_id}"
               else
-                org_create_request = Clerk::Models::Operations::CreateOrganizationRequest.new(
-                  name: "#{user.name}'s Organization",
-                  created_by: clerk_user.id
-                )
-                clerk.organizations.create(request: org_create_request)
-                puts "#{user.email} created a personal organization"
+                puts "----------------------------------------"
+                puts "#{user.email} needs to be added to an organization. Please select one:"
+                organizations.each_with_index do |org, idx|
+                  puts "#{idx + 1}. #{org.name} (#{org.id})"
+                end
+
+                idx = $stdin.gets.chomp.to_i - 1
+
+                org_member_request_body = {
+                  user_id: clerk_user.id,
+                  role: 'org:member'
+                }
+                clerk.organization_memberships.create(body: org_member_request_body, organization_id: organizations[idx].id)
+
+                puts "#{user.email} added to #{organizations[idx].name}"
               end
             end
 
@@ -88,6 +103,8 @@ module CoreDataConnector
             puts "Error migrating user #{user.email}: #{e.message}"
           end
         end
+
+        puts "Migration complete! Make sure to set admin permissions to the relevant users on each organization in Clerk."
       end
 
       def reset


### PR DESCRIPTION
# Summary

The current version of the migration script creates a personal Clerk org when the user's email doesn't match the domain of any existing org. This wasn't really consistent with our permissions model since an org admin is treated as a Performant Studio subscriber in the CD login/permissions flow.

This PR updates the script to prompt for user input to determine which org to add those users to. See the screenshot below. This does make the migration a little bit more tedious but it's the most reliable way to get users into the appropriate groups.

Also some general improvements:
* include a nil check when fetching org domains so an org without a domain doesn't crash the script
* add a `migrated_from` private metadata field for users created by this script for future reference (I also included this field in the FCC 2 migration script)

## Screenshot

<img width="605" height="429" alt="Screenshot 2026-05-04 at 2 06 59 PM" src="https://github.com/user-attachments/assets/667e19ac-5203-43a1-b7f6-301bdab5d40b" />