### PR TITLE
Add more `sleep` calls to Clerk migration script

### DIFF
--- a/app/services/core_data_connector/users/clerk_migration.rb
+++ b/app/services/core_data_connector/users/clerk_migration.rb
@@ -10,6 +10,7 @@ module CoreDataConnector
 
         organization_list_request = Clerk::Models::Operations::ListOrganizationsRequest.new(limit: 200)
         organization_list = clerk.organizations.list(request: organization_list_request)
+        sleep 1
         organizations = organization_list.organizations.data
 
         org_domains = Hash.new
@@ -17,6 +18,7 @@ module CoreDataConnector
         organizations.each do |org|
           domain_request = Clerk::Models::Operations::ListOrganizationDomainsRequest.new(organization_id: org.id)
           domains = clerk.organization_domains.list(request: domain_request).organization_domains.data
+          sleep 1
           next if domains.empty?
 
           name = domains.first.name
@@ -25,9 +27,9 @@ module CoreDataConnector
 
         User.where(sso_id: nil).find_each do |user|
           begin
-            sleep 2
             list_request = Clerk::Models::Operations::GetUserListRequest.new(email_address: [user.email])
             clerk_users = clerk.users.list(request: list_request)
+            sleep 1
             clerk_user = clerk_users.user_list.first
 
             is_new_user = false
@@ -57,6 +59,7 @@ module CoreDataConnector
               )
 
               response = clerk.users.create(request: create_request)
+              sleep 1
               clerk_user = response.user
               puts "#{user.email} created in Clerk"
             end
@@ -68,6 +71,7 @@ module CoreDataConnector
             else
               membership_request = Clerk::Models::Operations::ListOrganizationMembershipsRequest.new(organization_id: org_id)
               memberships = clerk.organization_memberships.list(request: membership_request)
+              sleep 1
               needs_membership = !memberships.organization_memberships.data.any? { |m| m.organization.id == org_id }
             end
 
@@ -78,6 +82,7 @@ module CoreDataConnector
                   role: 'org:member'
                 }
                 clerk.organization_memberships.create(body: org_member_request_body, organization_id: org_id)
+                sleep 1
                 puts "#{user.email} automatically added to organization based on email domain: #{org_id}"
               else
                 puts "----------------------------------------"
@@ -93,6 +98,7 @@ module CoreDataConnector
                   role: 'org:member'
                 }
                 clerk.organization_memberships.create(body: org_member_request_body, organization_id: organizations[idx].id)
+                sleep 1
 
                 puts "#{user.email} added to #{organizations[idx].name}"
               end

--- a/app/services/core_data_connector/users/clerk_migration.rb
+++ b/app/services/core_data_connector/users/clerk_migration.rb
@@ -16,6 +16,7 @@ module CoreDataConnector
         org_domains = Hash.new
 
         organizations.each do |org|
+          puts "Fetching metadata for organization: #{org.name} (#{org.id})"
           domain_request = Clerk::Models::Operations::ListOrganizationDomainsRequest.new(organization_id: org.id)
           domains = clerk.organization_domains.list(request: domain_request).organization_domains.data
           sleep 1
@@ -25,8 +26,9 @@ module CoreDataConnector
           org_domains[name] = org.id
         end
 
-        User.where(sso_id: nil).find_each do |user|
+        User.where(sso_id: nil).limit(90).find_each do |user|
           begin
+            puts "----------------------------------------"
             list_request = Clerk::Models::Operations::GetUserListRequest.new(email_address: [user.email])
             clerk_users = clerk.users.list(request: list_request)
             sleep 1
@@ -85,7 +87,6 @@ module CoreDataConnector
                 sleep 1
                 puts "#{user.email} automatically added to organization based on email domain: #{org_id}"
               else
-                puts "----------------------------------------"
                 puts "#{user.email} needs to be added to an organization. Please select one:"
                 organizations.each_with_index do |org, idx|
                   puts "#{idx + 1}. #{org.name} (#{org.id})"
@@ -105,6 +106,9 @@ module CoreDataConnector
             end
 
             user.update!(sso_id: clerk_user.id)
+          rescue Clerk::Models::Errors::ClerkErrors => e
+            puts "Clerk API error while migrating #{user.email}: #{e.message}"
+            puts e.errors.map { |error| "#{error.code}: #{error.message}" }.join("\n")
           rescue StandardError => e
             puts "Error migrating user #{user.email}: #{e.message}"
           end

--- a/app/services/core_data_connector/users/clerk_migration.rb
+++ b/app/services/core_data_connector/users/clerk_migration.rb
@@ -26,7 +26,7 @@ module CoreDataConnector
           org_domains[name] = org.id
         end
 
-        User.where(sso_id: nil).limit(90).find_each do |user|
+        User.where(sso_id: nil).find_each do |user|
           begin
             puts "----------------------------------------"
             list_request = Clerk::Models::Operations::GetUserListRequest.new(email_address: [user.email])


### PR DESCRIPTION
# Summary

On staging, Clerk account creation was failing for a subset of Performant accounts. I think this is due to running into some sort of rate limit with Clerk. This PR:

* adds `sleep` calls after every Clerk API request to make sure we don't run into rate limits
* improves the logging so we hopefully get more specific info from Clerk about what the actual error is