### PR TITLE
`view` endpoint and property in Reconciliation API (CDC #545)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,29 +101,24 @@ Data can be indexed into a Typesense search index using the following commands. 
 
 #### Create a new collection
 ```bash
-bundle exec rake typesense:reconcile:create -- -h host -p port -r protocol -a api_key -c collection_name
+bundle exec rake typesense:reconcile:create -- --host=host --port=port --protocol=protocol --api-key=api_key --collection-name=collection_name
 ```
 
 #### Delete a collection
 ```bash
-bundle exec rake typesense:reconcile:delete -- -h host -p port -r protocol -a api_key -c collection_name
+bundle exec rake typesense:reconcile:delete -- --host=host --port=port --protocol=protocol --api-key=api_key --collection-name=collection_name
 ```
 
 #### Index documents into a collection
 ```bash
-bundle exec rake typesense:reconcile:index -- -h host -p port -r protocol -a api_key -c collection_name -m model_ids --polygons
+bundle exec rake typesense:reconcile:index -- --host=host --port=port --protocol=protocol --api-key=api_key --collection-name=collection_name --project-id=project_id
 ```
 
 **Note:** This task expects the entire collection to be indexed. Any records not included in the batch will be removed from the index.
 
-#### Update a collection
-```bash
-bundle exec rake typesense:reconcile:update -- -h host -p port -r protocol -a api_key -c collection_name
-```
-
 ### Update Project
 
-In order to make requests to the Reconciliation API, the project record must be updated with Typesense credentials.
+In order to make requests to the Reconciliation API, the project record must be updated with Typesense credentials. This can be configured in the project's "Project Settings" form in the Core Data user interface.
 
 ### Requests
 
@@ -135,6 +130,11 @@ GET /core_data/reconcile/projects/:id
 
 ```
 POST /core_data/reconcile/projects/:id
+```
+
+The Reconciliation API response for a project includes a `view` property indicating how to structure a view URI. The view URI for an individual record will simply redirect to the CMS edit page for that record:
+```
+GET /core_data/reconcile/projects/:id/view/:record_id
 ```
 
 ## Public API

--- a/app/controllers/core_data_connector/reconcile/projects_controller.rb
+++ b/app/controllers/core_data_connector/reconcile/projects_controller.rb
@@ -12,7 +12,7 @@ module CoreDataConnector
         serializer = ProjectsSerializer.new
 
         # Per the spec, a request to the API without any parameters should return the service manifest
-        render json: serializer.render_manifest, status: :ok and return unless params[:queries].present?
+        render json: serializer.render_manifest(project), status: :ok and return unless params[:queries].present?
 
         # Allow request body to be sent as application/json or x-www-form-urlencoded
         if params[:queries].is_a?(String)
@@ -25,6 +25,32 @@ module CoreDataConnector
         items = manager.send_request(queries, credentials)
 
         render json: serializer.render_multiple(items), status: :ok
+      end
+
+      def view
+        # "view" endpoint for redirection to record's edit page
+
+        # Validate that the requested project contains the necessary credentials to call the API
+        project = Project.find(params[:id])
+        credentials = project.reconciliation_credentials&.symbolize_keys
+
+        render plain: 'Invalid credentials', status: :forbidden and return unless valid_credentials? credentials
+
+        # attempt to connect to and get the record from typesense
+        record_id = params[:record_id]
+        client = Typesense.create_client(**credentials.except(:collection_name))
+        collection = credentials[:collection_name]
+
+        begin
+          # build and redirect to the core-data-cloud redirect URL
+          record = client.collections[collection].documents[record_id].retrieve
+          project_model_id = record['project_model_id']
+          redirect_url = "#{ENV['HOSTNAME']}/projects/#{project.id}/#{project_model_id}/#{record_id}"
+
+          redirect_to redirect_url, allow_other_host: true
+        rescue ::Typesense::Error::ObjectNotFound
+          render plain: 'Record not found', status: :not_found
+        end
       end
 
       private

--- a/app/serializers/core_data_connector/reconcile/projects_serializer.rb
+++ b/app/serializers/core_data_connector/reconcile/projects_serializer.rb
@@ -14,7 +14,7 @@ module CoreDataConnector
         end
       end
 
-      def render_manifest
+      def render_manifest(project)
         {
           defaultTypes: [{
             id: CoreDataConnector::Event.to_s,
@@ -44,7 +44,10 @@ module CoreDataConnector
           identifierSpace: "#{ENV['HOSTNAME']}/core_data/public/v1",
           name: I18n.t('services.reconcile.name'),
           schemaSpace: "#{ENV['HOSTNAME']}/core_data/reconcile",
-          versions: %w(0.1 0.2)
+          versions: %w(0.1 0.2),
+          view: {
+            url: "#{ENV['HOSTNAME']}/core_data/reconcile/projects/#{project.id}/view/{{id}}"
+          }
         }
       end
 

--- a/app/services/core_data_connector/reconcile/base.rb
+++ b/app/services/core_data_connector/reconcile/base.rb
@@ -48,6 +48,7 @@ module CoreDataConnector
         # Include the ID attributes as a string by default
         reconcile_attribute(:id) { uuid }
         reconcile_attribute(:record_id) { id.to_s }
+        reconcile_attribute(:project_model_id) { project_model_id.to_s }
         reconcile_attribute :uuid
         reconcile_attribute(:type) { self.class.to_s }
 

--- a/app/services/core_data_connector/reconcile/manager.rb
+++ b/app/services/core_data_connector/reconcile/manager.rb
@@ -27,7 +27,10 @@ module CoreDataConnector
           search = { collection:, q: query[:query] }
 
           # Append "filter_by" parameter, if present
-          search[:filter_by] = "type:#{query[:type]}" if query[:type].present?
+          if query[:type].present?
+            types = Array.wrap(query[:type]).join(',')
+            search[:filter_by] = "type:[#{types}]"
+          end
 
           # Append "limit" parameter, if present
           search[:limit] = query[:limit] if query[:limit].present?

--- a/config/routes/reconcile.rb
+++ b/config/routes/reconcile.rb
@@ -3,4 +3,5 @@
 namespace :reconcile do
   get 'projects/:id', to: 'projects#show'
   post 'projects/:id', to: 'projects#show'
+  get 'projects/:id/view/:record_id', to: 'projects#view'
 end


### PR DESCRIPTION
### In this PR

Per performant-software/core-data-cloud#545:
- Add a `/view/:record_id` endpoint to the Reconciliation API for an individual record, which simply redirects to the Core Data frontend admin edit form for that record
   - Index `project_model_id` in the Typesense Reconciliation index for use in the redirect
- Add a `view` property to the Reconciliation API project manifest, which tells consumers how to structure the URL for that endpoint (requires passing the project into the method that generates the manifest)
- Update readme with the new endpoint and fix some errors in the existing ones
   - Also use the full long names for arguments and the `=` operator to prevent rake errors
- Update the logic for filtering based on the `:type` parameter to accept an array or string, per Reconciliation API spec