### PR TITLE
Fix issue with redirect URL id (CDC #545)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ bundle exec rake typesense:reconcile:index -- --host=host --port=port --protocol
 
 ### Update Project
 
-In order to make requests to the Reconciliation API, the project record must be updated with Typesense credentials. This can be configured in the project's "Project Settings" form in the Core Data user interface.
+In order to make requests to the Reconciliation API, the project record must be updated with Typesense credentials. This can be configured in the project's "Project Settings" form in the Core Data user interface. The Typesense API key needs at least `"collections:get"`, `"documents:search"`, and `"documents:get"` permissions.
 
 ### Requests
 

--- a/app/controllers/core_data_connector/reconcile/projects_controller.rb
+++ b/app/controllers/core_data_connector/reconcile/projects_controller.rb
@@ -37,14 +37,15 @@ module CoreDataConnector
         render plain: 'Invalid credentials', status: :forbidden and return unless valid_credentials? credentials
 
         # attempt to connect to and get the record from typesense
-        record_id = params[:record_id]
+        record_uuid = params[:record_id]
         client = Typesense.create_client(**credentials.except(:collection_name))
         collection = credentials[:collection_name]
 
         begin
           # build and redirect to the core-data-cloud redirect URL
-          record = client.collections[collection].documents[record_id].retrieve
+          record = client.collections[collection].documents[record_uuid].retrieve
           project_model_id = record['project_model_id']
+          record_id = document['record_id']
           redirect_url = "#{ENV['HOSTNAME']}/projects/#{project.id}/#{project_model_id}/#{record_id}"
 
           redirect_to redirect_url, allow_other_host: true


### PR DESCRIPTION
### In this PR

Per https://github.com/performant-software/core-data-cloud/issues/545:
- Fix an issue where the view URL would redirect to the edit page with a record's UUID instead of database ID