### PR TITLE
Allow Reconciliation API filtering by project_model_id (CDC #613)

### DIFF
--- a/app/serializers/core_data_connector/reconcile/projects_serializer.rb
+++ b/app/serializers/core_data_connector/reconcile/projects_serializer.rb
@@ -15,32 +15,34 @@ module CoreDataConnector
       end
 
       def render_manifest(project)
+        # construct default types for filtered queries based on project models
+        default_types = []
+        models_by_class = project.project_models
+          .group_by(&:model_class)
+          .sort_by do |model_class_name, models|
+            # sort by min :order of all models of this model_class, to match fairdata ui
+            min_order = models.filter_map(&:order).min || Float::INFINITY
+            [min_order, model_class_name]
+          end
+        models_by_class.each do |model_class_name, models|
+          # add "All" option if there's more than one model with this model_class
+          if models.size > 1
+            default_types << {
+              id: "type:#{model_class_name}",
+              name: "#{model_class_name.demodulize} | All #{model_class_name.demodulize.pluralize}"
+            }
+          end
+          # add each model on this project as an option
+          models.sort_by { |m| [m.order || Float::INFINITY, m.name.downcase] }.each do |pm|
+            default_types << {
+              id: "model:#{pm.id}",
+              name: "#{model_class_name.demodulize} | #{pm.name}"
+            }
+          end
+        end
+
         {
-          defaultTypes: [{
-            id: CoreDataConnector::Event.to_s,
-            name: CoreDataConnector::Event.name.demodulize,
-          }, {
-            id: CoreDataConnector::Instance.to_s,
-            name: CoreDataConnector::Instance.name.demodulize,
-          }, {
-            id: CoreDataConnector::Item.to_s,
-            name: CoreDataConnector::Item.name.demodulize,
-          }, {
-            id: CoreDataConnector::Organization.to_s,
-            name: CoreDataConnector::Organization.name.demodulize,
-          }, {
-            id: CoreDataConnector::Person.to_s,
-            name: CoreDataConnector::Person.name.demodulize,
-          }, {
-            id: CoreDataConnector::Place.to_s,
-            name: CoreDataConnector::Place.name.demodulize,
-          }, {
-            id: CoreDataConnector::Taxonomy.to_s,
-            name: CoreDataConnector::Taxonomy.name.demodulize,
-          }, {
-            id: CoreDataConnector::Work.to_s,
-            name: CoreDataConnector::Work.name.demodulize,
-          }],
+          defaultTypes: default_types,
           identifierSpace: "#{ENV['HOSTNAME']}/core_data/public/v1",
           name: I18n.t('services.reconcile.name'),
           schemaSpace: "#{ENV['HOSTNAME']}/core_data/reconcile",

--- a/app/services/core_data_connector/reconcile/manager.rb
+++ b/app/services/core_data_connector/reconcile/manager.rb
@@ -28,8 +28,28 @@ module CoreDataConnector
 
           # Append "filter_by" parameter, if present
           if query[:type].present?
-            types = Array.wrap(query[:type]).join(',')
-            search[:filter_by] = "type:[#{types}]"
+            types = Array.wrap(query[:type])
+
+            # filter by project model ID and/or model_class
+            project_model_ids = []
+            class_names = []
+            types.each do |t|
+              if t.start_with?('model:')
+                project_model_ids << t.split(':', 2).last
+              elsif t.start_with?('type:')
+                class_names << t.split(':', 2).last
+              else
+                class_names << t
+              end
+            end
+
+            # collect into typesense filters
+            filters = []
+            filters << "type:[#{class_names.join(',')}]" if class_names.any?
+            filters << "project_model_id:[#{project_model_ids.join(',')}]" if project_model_ids.any?
+
+            # join by typesense OR
+            search[:filter_by] = filters.join(' || ') if filters.any?
           end
 
           # Append "limit" parameter, if present
@@ -53,14 +73,26 @@ module CoreDataConnector
 
       def transform_result(result)
         klass = result['document']['type'].constantize
+        project_model_id = result['document']['project_model_id']
 
         attributes = {
           score: result['text_match'],
           match: false,
-          type: [{
-            id: klass.to_s,
-            name: klass.name.demodulize
-          }]
+          type: [
+            {
+              id: "type:#{klass.to_s}",
+              name: klass.name.demodulize
+            },
+            {
+              id: "model:#{project_model_id}",
+              name: "#{klass.name.demodulize} model #{project_model_id}"
+            },
+            # retain bare model_class string for backwards compatibility
+            {
+              id: klass.to_s,
+              name: klass.name.demodulize
+            }
+          ]
         }
 
         all_attributes = result['document'].merge(attributes).symbolize_keys


### PR DESCRIPTION
### In this PR

Per performant-software/core-data-cloud#613:
- Set `defaultTypes` in the reconciliation manifest to include project models as options
- Also include options for "all" entries of any model_class that has more than one model in the project
- Handle the new syntax for differentiating these (prepended `type:` or `model:`) in the type filter passed to the API, and send it correctly to typesense
   - Include backwards compatibility for just bare type strings so that this doesn't introduce a breaking change