### PR TITLE
Add names to merge history

### DIFF
--- a/app/models/concerns/core_data_connector/display_nameable.rb
+++ b/app/models/concerns/core_data_connector/display_nameable.rb
@@ -1,0 +1,25 @@
+module CoreDataConnector
+  module DisplayNameable
+    extend ActiveSupport::Concern
+
+    def display_name
+      name_from_nameable.presence ||
+        name_from_attributes.presence
+    end
+
+    private
+
+    def name_from_nameable
+      return unless self.class.respond_to?(:get_names_table)
+      return if self.class.get_names_table.blank?
+
+      primary_name&.name.presence
+    end
+
+    def name_from_attributes
+      return self[:name].to_s if self[:name].present?
+
+      nil
+    end
+  end
+end

--- a/app/models/core_data_connector/event.rb
+++ b/app/models/core_data_connector/event.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class Event < ApplicationRecord
     # Includes
+    include DisplayNameable
     include Export::Event
     include FuzzyDates::FuzzyDateable
     include Identifiable

--- a/app/models/core_data_connector/instance.rb
+++ b/app/models/core_data_connector/instance.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class Instance < ApplicationRecord
     # Includes
+    include DisplayNameable
     include Export::Instance
     include Identifiable
     include ImportAnalyze::Instance

--- a/app/models/core_data_connector/item.rb
+++ b/app/models/core_data_connector/item.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class Item < ApplicationRecord
     # Includes
+    include DisplayNameable
     include Export::Item
     include FccImportable
     include Identifiable

--- a/app/models/core_data_connector/media_content.rb
+++ b/app/models/core_data_connector/media_content.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class MediaContent < ApplicationRecord
     # Includes
+    include DisplayNameable
     include Export::MediaContent
     include Identifiable
     include ImportAnalyze::MediaContent

--- a/app/models/core_data_connector/organization.rb
+++ b/app/models/core_data_connector/organization.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class Organization < ApplicationRecord
     # Includes
+    include DisplayNameable
     include Export::Organization
     include Identifiable
     include ImportAnalyze::Organization

--- a/app/models/core_data_connector/person.rb
+++ b/app/models/core_data_connector/person.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class Person < ApplicationRecord
     # Includes
+    include DisplayNameable
     include Export::Person
     include Identifiable
     include ImportAnalyze::Person
@@ -24,6 +25,10 @@ module CoreDataConnector
 
     def full_name
       [first_name, middle_name, last_name].compact.join(' ')
+    end
+
+    def display_name
+      full_name
     end
   end
 end

--- a/app/models/core_data_connector/place.rb
+++ b/app/models/core_data_connector/place.rb
@@ -3,6 +3,7 @@ module CoreDataConnector
     self.primary_key = :id
 
     # Includes
+    include DisplayNameable
     include Export::Place
     include Identifiable
     include ImportAnalyze::Place

--- a/app/models/core_data_connector/taxonomy.rb
+++ b/app/models/core_data_connector/taxonomy.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class Taxonomy < ApplicationRecord
     # Includes
+    include DisplayNameable
     include Export::Taxonomy
     include Identifiable
     include ImportAnalyze::Taxonomy

--- a/app/models/core_data_connector/work.rb
+++ b/app/models/core_data_connector/work.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class Work < ApplicationRecord
     # Includes
+    include DisplayNameable
     include Export::Work
     include Identifiable
     include ImportAnalyze::Work

--- a/app/serializers/core_data_connector/record_merges_serializer.rb
+++ b/app/serializers/core_data_connector/record_merges_serializer.rb
@@ -1,6 +1,6 @@
 module CoreDataConnector
   class RecordMergesSerializer < BaseSerializer
-    index_attributes :id, :merged_uuid, :created_at
-    show_attributes :id, :merged_uuid, :created_at
+    index_attributes :id, :merged_uuid, :merged_name, :created_at
+    show_attributes :id, :merged_uuid, :merged_name, :created_at
   end
 end

--- a/app/services/core_data_connector/merge/merger.rb
+++ b/app/services/core_data_connector/merge/merger.rb
@@ -46,7 +46,15 @@ module CoreDataConnector
           record.record_merges.each { |record_merge| add_item(record_merges, record_merge, MERGE_ATTRIBUTES) }
 
           # Create a record_merge for the merged record(s)
-          record_merges << RecordMerge.new(merged_uuid: record.uuid) unless record.uuid == new_record.uuid
+          unless record.uuid == new_record.uuid
+            puts "MERGING #{record.uuid} INTO #{new_record.uuid}"
+            puts record.inspect
+            puts record.display_name.inspect
+            record_merges << RecordMerge.new(
+              merged_uuid: record.uuid,
+              merged_name: record.display_name
+            )
+          end
 
           # Append the relationships from the merged record(s) to the new record
           record.relationships.each { |relationship| add_item(relationships, relationship, RELATIONSHIP_ATTRIBUTES) }

--- a/app/services/core_data_connector/merge/merger.rb
+++ b/app/services/core_data_connector/merge/merger.rb
@@ -47,9 +47,6 @@ module CoreDataConnector
 
           # Create a record_merge for the merged record(s)
           unless record.uuid == new_record.uuid
-            puts "MERGING #{record.uuid} INTO #{new_record.uuid}"
-            puts record.inspect
-            puts record.display_name.inspect
             record_merges << RecordMerge.new(
               merged_uuid: record.uuid,
               merged_name: record.display_name

--- a/db/migrate/20260514201613_add_merged_name_to_record_merges.rb
+++ b/db/migrate/20260514201613_add_merged_name_to_record_merges.rb
@@ -1,0 +1,5 @@
+class AddMergedNameToRecordMerges < ActiveRecord::Migration[8.0]
+  def change
+    add_column :core_data_connector_record_merges, :merged_name, :string
+  end
+end


### PR DESCRIPTION
# Summary

This PR:

- adds a new `DisplayNameable` concern that introduces a `display_name` method for all models
- adds a new `merged_name` field to the `record_merges` table, populated by the `display_name` method

I don't love having to create a new concern for this, especially since `Nameable` already exists but means something else. It seems like having the ability to just get a straightforward name for any record will be helpful in the future though.