### PR TITLE
Update FCC 1 header check

### DIFF
--- a/app/controllers/concerns/core_data_connector/clerk_authenticatable.rb
+++ b/app/controllers/concerns/core_data_connector/clerk_authenticatable.rb
@@ -71,7 +71,7 @@ module CoreDataConnector
     # Returns whether to use Clerk to authenticate the request
     def is_clerk?
       # backward compat for FCC 1's username/password login
-      return false if request.headers['server'] == 'Netlify'
+      return false if request.headers['client'] == 'faircopy-cloud-1'
 
       # backward compat for FCC 2's username/password login
       return false if request.headers['user-agent'] == 'node'


### PR DESCRIPTION
# Summary

This PR updates the Clerk bypass header check for FCC 1, supporting https://github.com/performant-software/faircopy-cloud/pull/80