### PR TITLE
Frontend joins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gem 'faker', '~> 3.2.1'
 gem 'fuzzy_dates', git: 'https://github.com/performant-software/fuzzy-dates.git', tag: 'v0.1.1'
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.3'
-gem 'resource_api', git: 'https://github.com/performant-software/resource-api.git', tag: 'v0.5.15'
+gem 'resource_api', git: 'https://github.com/performant-software/resource-api.git', tag: 'v0.5.16'
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.2.7'
 gem 'user_defined_fields', git: 'https://github.com/performant-software/user-defined-fields.git', tag: 'v0.1.15'
 gem 'sqlite3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,8 +18,8 @@ GIT
 
 GIT
   remote: https://github.com/performant-software/resource-api.git
-  revision: 2307a221fec5a06949dc039537d4b24cbcf8b649
-  tag: v0.5.15
+  revision: d4d79db42c12991dd5c6262b711d6789f6838062
+  tag: v0.5.16
   specs:
     resource_api (0.1.0)
       pagy (~> 5.10)

--- a/app/controllers/concerns/core_data_connector/related_columnable.rb
+++ b/app/controllers/concerns/core_data_connector/related_columnable.rb
@@ -1,36 +1,21 @@
 module CoreDataConnector
   module RelatedColumnable
     extend ActiveSupport::Concern
-    def index
-      query = base_query
-      query = build_query(query)
-      query = apply_search(query)
-      query = apply_filters(query)
-      query = apply_sort(query)
-
-      list, items = pagy(query, items: per_page, page: params[:page])
-      metadata = pagy_metadata(list)
-
-      items = hydrate_related_columns(items)
-      preloads(items)
-
-      render json: build_index_response(items, metadata), status: :ok
-    end
 
     protected
 
-    def hydrate_related_columns(items)
+    def prepare_items(items)
       cols = permitted_related_columns
       return items if cols.empty? || items.empty?
 
       ids = items.map(&:id)
-      rehydrated = CoreDataConnector::RecordTableQuery.new(
+      prepared = CoreDataConnector::RecordTableQuery.new(
         source_model:    item_class,
         related_columns: cols
       ).call(item_class.where(id: ids)).index_by(&:id)
 
       # Preserve the order pagy gave us (which respects apply_sort)
-      ids.map { |id| rehydrated[id] }.compact
+      ids.map { |id| prepared[id] }.compact
     end
 
     def permitted_related_columns

--- a/app/controllers/concerns/core_data_connector/related_columnable.rb
+++ b/app/controllers/concerns/core_data_connector/related_columnable.rb
@@ -19,6 +19,16 @@ module CoreDataConnector
 
     protected
 
+    # def apply_related_columns(query)
+    #   cols = permitted_related_columns
+    #   return query if cols.empty?
+    #
+    #   CoreDataConnector::RecordTableQuery.new(
+    #     source_model:    item_class,
+    #     related_columns: cols
+    #   ).call(query)
+    # end
+
     def hydrate_related_columns(items)
       cols = permitted_related_columns
       return items if cols.empty? || items.empty?

--- a/app/controllers/concerns/core_data_connector/related_columnable.rb
+++ b/app/controllers/concerns/core_data_connector/related_columnable.rb
@@ -1,0 +1,58 @@
+module CoreDataConnector
+  module RelatedColumnable
+    extend ActiveSupport::Concern
+    def index
+      query = base_query
+      query = build_query(query)
+      query = apply_search(query)
+      query = apply_filters(query)
+      query = apply_sort(query)
+
+      list, items = pagy(query, items: per_page, page: params[:page])
+      metadata = pagy_metadata(list)
+
+      items = hydrate_related_columns(items)
+      preloads(items)
+
+      render json: build_index_response(items, metadata), status: :ok
+    end
+
+    protected
+
+    def hydrate_related_columns(items)
+      cols = permitted_related_columns
+      return items if cols.empty? || items.empty?
+
+      ids = items.map(&:id)
+      rehydrated = CoreDataConnector::RecordTableQuery.new(
+        source_model:    item_class,
+        related_columns: cols
+      ).call(item_class.where(id: ids)).index_by(&:id)
+
+      # Preserve the order pagy gave us (which respects apply_sort)
+      ids.map { |id| rehydrated[id] }.compact
+    end
+
+    def permitted_related_columns
+      @permitted_related_columns ||= begin
+                                       raw = params[:related_columns]
+                                       # next [] if raw.blank?
+
+                                       Array(raw).map { |c| c.respond_to?(:permit) ? c.permit(:pmr_id, :field) : c }
+                                                 .map { |c| { pmr_id: c[:pmr_id].to_i, field: c[:field].to_s } }
+                                                 .reject { |c| c[:pmr_id].zero? || c[:field].empty? }
+                                     end
+    end
+
+    def related_column_aliases
+      permitted_related_columns.each_with_index.map do |c, i|
+        "rel_#{c[:pmr_id]}_#{c[:field].gsub(/\W/, '_')}_#{i}"
+      end
+    end
+
+    # Override the gem's hook so the serializer gets the alias list
+    def load_records(items)
+      super.merge(related_column_aliases: related_column_aliases)
+    end
+  end
+end

--- a/app/controllers/concerns/core_data_connector/related_columnable.rb
+++ b/app/controllers/concerns/core_data_connector/related_columnable.rb
@@ -35,22 +35,27 @@ module CoreDataConnector
 
     def permitted_related_columns
       @permitted_related_columns ||= begin
-                                       raw = params[:related_columns]
-                                       # next [] if raw.blank?
+                                       raw = params[:join_columns]
 
-                                       Array(raw).map { |c| c.respond_to?(:permit) ? c.permit(:pmr_id, :field) : c }
-                                                 .map { |c| { pmr_id: c[:pmr_id].to_i, field: c[:field].to_s } }
-                                                 .reject { |c| c[:pmr_id].zero? || c[:field].empty? }
+                                       base_columns = Array(raw).map do |c|
+                                         split = c.split('_')
+                                         next unless split.length == 3
+
+                                         { pmr_id: split[1].to_i, field: split[2] }
+                                       end
+
+                                       base_columns.map { |c| c.respond_to?(:permit) ? c.permit(:pmr_id, :field) : c }
+                                                   .map { |c| { pmr_id: c[:pmr_id], field: c[:field].to_s } }
+                                                   .reject { |c| c[:pmr_id].zero? || c[:field].empty? }
                                      end
     end
 
     def related_column_aliases
-      permitted_related_columns.each_with_index.map do |c, i|
-        "rel_#{c[:pmr_id]}_#{c[:field].gsub(/\W/, '_')}_#{i}"
+      permitted_related_columns.map do |c|
+        "rel_#{c[:pmr_id]}_#{c[:field].gsub(/\W/, '_')}"
       end
     end
 
-    # Override the gem's hook so the serializer gets the alias list
     def load_records(items)
       super.merge(related_column_aliases: related_column_aliases)
     end

--- a/app/controllers/concerns/core_data_connector/related_columnable.rb
+++ b/app/controllers/concerns/core_data_connector/related_columnable.rb
@@ -19,16 +19,6 @@ module CoreDataConnector
 
     protected
 
-    # def apply_related_columns(query)
-    #   cols = permitted_related_columns
-    #   return query if cols.empty?
-    #
-    #   CoreDataConnector::RecordTableQuery.new(
-    #     source_model:    item_class,
-    #     related_columns: cols
-    #   ).call(query)
-    # end
-
     def hydrate_related_columns(items)
       cols = permitted_related_columns
       return items if cols.empty? || items.empty?

--- a/app/controllers/concerns/core_data_connector/related_columnable.rb
+++ b/app/controllers/concerns/core_data_connector/related_columnable.rb
@@ -45,7 +45,6 @@ module CoreDataConnector
                                        end
 
                                        base_columns.map { |c| c.respond_to?(:permit) ? c.permit(:pmr_id, :field) : c }
-                                                   .map { |c| { pmr_id: c[:pmr_id], field: c[:field].to_s } }
                                                    .reject { |c| c[:pmr_id].zero? || c[:field].empty? }
                                      end
     end

--- a/app/controllers/core_data_connector/application_controller.rb
+++ b/app/controllers/core_data_connector/application_controller.rb
@@ -4,6 +4,9 @@ module CoreDataConnector
     include JwtAuth::Authenticateable
     include ClerkAuthenticatable
 
+    # Errors
+    rescue_from ArgumentError, with: :render_bad_request
+
     # Actions
     skip_before_action :authenticate_request
     before_action :handle_authentication
@@ -28,6 +31,10 @@ module CoreDataConnector
 
     def log_error(error)
       Rails.logger.error (["#{self.class} - #{error.class}: #{error.message}", error.backtrace]).join("\n")
+    end
+
+    def render_bad_request(error)
+      render json: { errors: [{ base: error.message }] }, status: :bad_request
     end
   end
 end

--- a/app/controllers/core_data_connector/events_controller.rb
+++ b/app/controllers/core_data_connector/events_controller.rb
@@ -4,6 +4,7 @@ module CoreDataConnector
     include ManifestableController
     include MergeableController
     include OwnableController
+    include RelatedColumnable
     include UserDefinedFields::Queryable
 
     # Preloads

--- a/app/controllers/core_data_connector/instances_controller.rb
+++ b/app/controllers/core_data_connector/instances_controller.rb
@@ -5,6 +5,7 @@ module CoreDataConnector
     include MergeableController
     include NameableController
     include OwnableController
+    include RelatedColumnable
     include UserDefinedFields::Queryable
 
     # Preloads

--- a/app/controllers/core_data_connector/items_controller.rb
+++ b/app/controllers/core_data_connector/items_controller.rb
@@ -6,6 +6,7 @@ module CoreDataConnector
     include MergeableController
     include NameableController
     include OwnableController
+    include RelatedColumnable
     include UserDefinedFields::Queryable
 
     # Preloads

--- a/app/controllers/core_data_connector/media_contents_controller.rb
+++ b/app/controllers/core_data_connector/media_contents_controller.rb
@@ -6,6 +6,7 @@ module CoreDataConnector
     include ManifestableController
     include MergeableController
     include OwnableController
+    include RelatedColumnable
     include TripleEyeEffable::ResourceableController
     include UserDefinedFields::Queryable
 

--- a/app/controllers/core_data_connector/organizations_controller.rb
+++ b/app/controllers/core_data_connector/organizations_controller.rb
@@ -5,6 +5,7 @@ module CoreDataConnector
     include MergeableController
     include NameableController
     include OwnableController
+    include RelatedColumnable
     include UserDefinedFields::Queryable
 
     # Preloads

--- a/app/controllers/core_data_connector/people_controller.rb
+++ b/app/controllers/core_data_connector/people_controller.rb
@@ -5,6 +5,7 @@ module CoreDataConnector
     include MergeableController
     include NameableController
     include OwnableController
+    include RelatedColumnable
     include UserDefinedFields::Queryable
 
     # Preloads

--- a/app/controllers/core_data_connector/places_controller.rb
+++ b/app/controllers/core_data_connector/places_controller.rb
@@ -5,6 +5,7 @@ module CoreDataConnector
     include MergeableController
     include NameableController
     include OwnableController
+    include RelatedColumnable
     include UserDefinedFields::Queryable
 
     # Preloads

--- a/app/controllers/core_data_connector/taxonomies_controller.rb
+++ b/app/controllers/core_data_connector/taxonomies_controller.rb
@@ -4,6 +4,7 @@ module CoreDataConnector
     include ManifestableController
     include MergeableController
     include OwnableController
+    include RelatedColumnable
     include UserDefinedFields::Queryable
 
     # Search attributes

--- a/app/controllers/core_data_connector/works_controller.rb
+++ b/app/controllers/core_data_connector/works_controller.rb
@@ -5,6 +5,7 @@ module CoreDataConnector
     include MergeableController
     include NameableController
     include OwnableController
+    include RelatedColumnable
     include UserDefinedFields::Queryable
 
     # Preloads

--- a/app/models/concerns/core_data_connector/nameable.rb
+++ b/app/models/concerns/core_data_connector/nameable.rb
@@ -26,7 +26,11 @@ module CoreDataConnector
         @names_table
       end
 
-      def name_column
+      def name_column(table_alias = nil)
+        if table_alias
+          return "#{table_alias}.name"
+        end
+
         "name"
       end
 

--- a/app/models/concerns/core_data_connector/nameable.rb
+++ b/app/models/concerns/core_data_connector/nameable.rb
@@ -19,10 +19,19 @@ module CoreDataConnector
         self.send(:accepts_nested_attributes_for, name.to_sym, allow_destroy: true)
 
         @names_table = name
+        @nameable_attribute = options[:as] if options && options[:as]
       end
 
       def get_names_table
         @names_table
+      end
+
+      def name_column
+        "name"
+      end
+
+      def nameable_attribute
+        @nameable_attribute
       end
     end
 

--- a/app/models/core_data_connector/person.rb
+++ b/app/models/core_data_connector/person.rb
@@ -20,6 +20,10 @@ module CoreDataConnector
     # Nameable table
     name_table :person_names
 
+    def self.name_column
+      "CONCAT_WS(' ', first_name, middle_name, last_name)"
+    end
+
     # User defined fields parent
     resolve_defineable -> (person) { person.project_model }
 

--- a/app/models/core_data_connector/person.rb
+++ b/app/models/core_data_connector/person.rb
@@ -20,8 +20,12 @@ module CoreDataConnector
     # Nameable table
     name_table :person_names
 
-    def self.name_column
-      "CONCAT_WS(' ', first_name, middle_name, last_name)"
+    def self.name_column(table_alias = nil)
+      if table_alias
+        "CONCAT_WS(' ', #{table_alias}.first_name, #{table_alias}.middle_name, #{table_alias}.last_name)"
+      else
+        "CONCAT_WS(' ', first_name, middle_name, last_name)"
+      end
     end
 
     # User defined fields parent

--- a/app/queries/core_data_connector/record_table_query.rb
+++ b/app/queries/core_data_connector/record_table_query.rb
@@ -2,7 +2,7 @@ module CoreDataConnector
   class RecordTableQuery
     def initialize(source_model:, related_columns: [])
       @source_model     = source_model
-      @related_columns  = related_columns   # [{ pmr_id:, field: }, ...]
+      @related_columns  = related_columns
     end
 
     def call(base_scope = nil)
@@ -19,12 +19,11 @@ module CoreDataConnector
     private
 
     def build_builders
-      @related_columns.each_with_index.map do |col, i|
+      @related_columns.map do |col|
         CoreDataConnector::RelatedColumnJoinBuilder.new(
           source_model: @source_model,
           project_model_relationship_id: col[:pmr_id],
-          field: col[:field],
-          alias_suffix: i.to_s
+          field: col[:field]
         )
       end
     end

--- a/app/queries/core_data_connector/record_table_query.rb
+++ b/app/queries/core_data_connector/record_table_query.rb
@@ -1,0 +1,60 @@
+module CoreDataConnector
+  class RecordTableQuery
+    def initialize(source_model:, related_columns: [])
+      @source_model     = source_model
+      @related_columns  = related_columns   # [{ pmr_id:, field: }, ...]
+    end
+
+    def call(base_scope = nil)
+      scope    = base_scope || @source_model.all
+      builders = build_builders
+
+      builders.each { |b| b.joins.each { |j| scope = scope.joins(j) } }
+
+      scope = apply_selects(scope, builders)
+      scope = apply_grouping(scope, builders) if builders.any?(&:requires_aggregation?)
+      scope
+    end
+
+    private
+
+    def build_builders
+      @related_columns.each_with_index.map do |col, i|
+        CoreDataConnector::RelatedColumnJoinBuilder.new(
+          source_model: @source_model,
+          project_model_relationship_id: col[:pmr_id],
+          field: col[:field],
+          alias_suffix: i.to_s
+        )
+      end
+    end
+
+    def apply_selects(scope, builders)
+      selects = ["#{@source_model.table_name}.*"]
+      builders.each do |b|
+        if b.requires_aggregation?
+          expr = strip_alias(b.select_fragment)
+          selects << "string_agg(DISTINCT (#{expr})::text, ', ' " \
+            "ORDER BY (#{expr})::text) AS #{b.column_alias}"
+        else
+          selects << b.select_fragment
+        end
+      end
+      scope.select(selects.join(', '))
+    end
+
+    def apply_grouping(scope, builders)
+      # PG lets you GROUP BY the PK and select any other column from that table.
+      # But columns from non-aggregated joined tables must be in GROUP BY explicitly.
+      group_cols = ["#{@source_model.table_name}.id"]
+      builders.reject(&:requires_aggregation?).each do |b|
+        group_cols << strip_alias(b.select_fragment)
+      end
+      scope.group(group_cols.join(', '))
+    end
+
+    def strip_alias(fragment)
+      fragment.sub(/\s+AS\s+\S+\z/, '')
+    end
+  end
+end

--- a/app/queries/core_data_connector/record_table_query.rb
+++ b/app/queries/core_data_connector/record_table_query.rb
@@ -33,8 +33,11 @@ module CoreDataConnector
       builders.each do |b|
         if b.requires_aggregation?
           expr = strip_alias(b.select_fragment)
-          selects << "string_agg(DISTINCT (#{expr})::text, ', ' " \
-            "ORDER BY (#{expr})::text) AS #{b.column_alias}"
+          selects << "array_to_string((array_agg(DISTINCT (#{expr})::text " \
+            "ORDER BY (#{expr})::text))[1:9], ', ') " \
+            "|| CASE WHEN count(DISTINCT (#{expr})::text) > 9 " \
+            "THEN ', ' || (count(DISTINCT (#{expr})::text) - 9) || ' more' ELSE '' END " \
+            "AS #{b.column_alias}"
         else
           selects << b.select_fragment
         end

--- a/app/queries/core_data_connector/related_column_join_builder.rb
+++ b/app/queries/core_data_connector/related_column_join_builder.rb
@@ -15,7 +15,7 @@ module CoreDataConnector
     def select_fragment
       if @field == 'name'
         if target_model.respond_to?(:name_column)
-          "#{name_alias}.#{target_model.name_column} AS #{column_alias}"
+          "#{target_model.name_column(name_alias)} AS #{column_alias}"
         else
           "#{target_alias}.name AS #{column_alias}"
         end

--- a/app/queries/core_data_connector/related_column_join_builder.rb
+++ b/app/queries/core_data_connector/related_column_join_builder.rb
@@ -7,12 +7,19 @@ module CoreDataConnector
     end
 
     def joins
-      [relationship_join, target_join]
+      j = [relationship_join, target_join]
+      j << name_join if @field == 'name' && target_model.respond_to?(:get_names_table)
+      j
     end
 
     def select_fragment
-      # todo: handle name joins
-      if user_defined_field?
+      if @field == 'name'
+        if target_model.respond_to?(:name_column)
+          "#{name_alias}.#{target_model.name_column} AS #{column_alias}"
+        else
+          "#{target_alias}.name AS #{column_alias}"
+        end
+      elsif user_defined_field?
         key = @field.sub('udf.', '')
         "(#{target_alias}.user_defined ->> #{quote(key)}) AS #{column_alias}"
       else
@@ -55,6 +62,7 @@ module CoreDataConnector
 
     def rel_alias    = "rel_#{@pmr_id}"
     def target_alias = "tgt_#{@pmr_id}"
+    def name_alias   = "name_#{@pmr_id}"
 
     def relationship_join
       src_id, src_type =
@@ -81,6 +89,31 @@ module CoreDataConnector
                                                 "AND #{rel_alias}.#{tgt_type} = ?",
                                               target_model.name
                                             ])
+    end
+
+    def name_join
+      names_association = target_model.get_names_table
+      names_model = target_model.reflect_on_association(names_association)&.klass
+      names_table = names_model.table_name
+      nameable_attribute = target_model.nameable_attribute
+
+      if nameable_attribute
+        target_id_column = "#{nameable_attribute}_id"
+        target_type_column = "#{nameable_attribute}_type"
+      else
+        target_id_column = "#{target_model.name.demodulize.underscore}_id"
+        target_type_column = nil
+      end
+
+      sql = "LEFT JOIN #{names_table} #{name_alias} " \
+            "ON #{name_alias}.#{target_id_column} = #{target_alias}.id " \
+            "AND #{name_alias}.primary = #{ActiveRecord::Base.connection.quoted_true}"
+
+      if target_type_column
+        sql << ActiveRecord::Base.sanitize_sql_array([" AND #{name_alias}.#{target_type_column} = ?", target_model.name])
+      end
+
+      sql
     end
 
     def user_defined_field?

--- a/app/queries/core_data_connector/related_column_join_builder.rb
+++ b/app/queries/core_data_connector/related_column_join_builder.rb
@@ -1,12 +1,9 @@
 module CoreDataConnector
   class RelatedColumnJoinBuilder
-    attr_reader :alias_suffix
-
-    def initialize(source_model:, project_model_relationship_id:, field:, alias_suffix:)
+    def initialize(source_model:, project_model_relationship_id:, field:)
       @source_model = source_model
       @pmr_id       = project_model_relationship_id
       @field        = field
-      @alias_suffix = alias_suffix
     end
 
     def joins
@@ -14,8 +11,9 @@ module CoreDataConnector
     end
 
     def select_fragment
+      # todo: handle name joins
       if user_defined_field?
-        key = @field.sub('user_defined.', '')
+        key = @field.sub('udf.', '')
         "(#{target_alias}.user_defined ->> #{quote(key)}) AS #{column_alias}"
       else
         validate_column!
@@ -24,7 +22,7 @@ module CoreDataConnector
     end
 
     def column_alias
-      @column_alias ||= "rel_#{@pmr_id}_#{@field.gsub(/\W/, '_')}_#{@alias_suffix}"
+      @column_alias ||= "rel_#{@pmr_id}_#{@field.gsub(/\W/, '_')}"
     end
 
     def requires_aggregation?
@@ -55,8 +53,8 @@ module CoreDataConnector
                            : pmr.primary_model.model_class).constantize
     end
 
-    def rel_alias    = "rel_#{@alias_suffix}"
-    def target_alias = "tgt_#{@alias_suffix}"
+    def rel_alias    = "rel_#{@pmr_id}"
+    def target_alias = "tgt_#{@pmr_id}"
 
     def relationship_join
       src_id, src_type =
@@ -86,7 +84,7 @@ module CoreDataConnector
     end
 
     def user_defined_field?
-      @field.start_with?('user_defined.')
+      @field.start_with?('udf.')
     end
 
     def validate_column!

--- a/app/queries/core_data_connector/related_column_join_builder.rb
+++ b/app/queries/core_data_connector/related_column_join_builder.rb
@@ -1,0 +1,101 @@
+module CoreDataConnector
+  class RelatedColumnJoinBuilder
+    attr_reader :alias_suffix
+
+    def initialize(source_model:, project_model_relationship_id:, field:, alias_suffix:)
+      @source_model = source_model
+      @pmr_id       = project_model_relationship_id
+      @field        = field
+      @alias_suffix = alias_suffix
+    end
+
+    def joins
+      [relationship_join, target_join]
+    end
+
+    def select_fragment
+      if user_defined_field?
+        key = @field.sub('user_defined.', '')
+        "(#{target_alias}.user_defined ->> #{quote(key)}) AS #{column_alias}"
+      else
+        validate_column!
+        "#{target_alias}.#{@field} AS #{column_alias}"
+      end
+    end
+
+    def column_alias
+      @column_alias ||= "rel_#{@pmr_id}_#{@field.gsub(/\W/, '_')}_#{@alias_suffix}"
+    end
+
+    def requires_aggregation?
+      direction == :forward ? pmr.multiple : pmr.inverse_multiple
+    end
+
+    private
+
+    def pmr
+      @pmr ||= ProjectModelRelationship
+                 .includes(:primary_model, :related_model)
+                 .find(@pmr_id)
+    end
+
+    def direction
+      @direction ||=
+        if pmr.primary_model.model_class == @source_model.name
+          :forward
+        elsif pmr.related_model.model_class == @source_model.name
+          :inverse
+        else
+          raise ArgumentError, "PMR #{@pmr_id} does not involve #{@source_model.name}"
+        end
+    end
+
+    def target_model
+      @target_model ||= (direction == :forward ? pmr.related_model.model_class
+                           : pmr.primary_model.model_class).constantize
+    end
+
+    def rel_alias    = "rel_#{@alias_suffix}"
+    def target_alias = "tgt_#{@alias_suffix}"
+
+    def relationship_join
+      src_id, src_type =
+        direction == :forward ? %w[primary_record_id primary_record_type]
+          : %w[related_record_id related_record_type]
+
+      ActiveRecord::Base.sanitize_sql_array([
+                                              "LEFT JOIN core_data_connector_relationships #{rel_alias} " \
+                                                "ON #{rel_alias}.#{src_type} = ? " \
+                                                "AND #{rel_alias}.#{src_id} = #{@source_model.table_name}.id " \
+                                                "AND #{rel_alias}.project_model_relationship_id = ?",
+                                              @source_model.name, @pmr_id
+                                            ])
+    end
+
+    def target_join
+      tgt_id, tgt_type =
+        direction == :forward ? %w[related_record_id related_record_type]
+          : %w[primary_record_id primary_record_type]
+
+      ActiveRecord::Base.sanitize_sql_array([
+                                              "LEFT JOIN #{target_model.table_name} #{target_alias} " \
+                                                "ON #{target_alias}.id = #{rel_alias}.#{tgt_id} " \
+                                                "AND #{rel_alias}.#{tgt_type} = ?",
+                                              target_model.name
+                                            ])
+    end
+
+    def user_defined_field?
+      @field.start_with?('user_defined.')
+    end
+
+    def validate_column!
+      return if target_model.column_names.include?(@field)
+      raise ArgumentError, "Unknown column #{@field} on #{target_model.name}"
+    end
+
+    def quote(value)
+      ActiveRecord::Base.connection.quote(value)
+    end
+  end
+end

--- a/app/serializers/concerns/core_data_connector/related_columns_serializable.rb
+++ b/app/serializers/concerns/core_data_connector/related_columns_serializable.rb
@@ -1,0 +1,19 @@
+module CoreDataConnector
+  module RelatedColumnsSerializable
+    def render_index(items)
+      serialized = super
+      return serialized if serialized.blank?
+
+      aliases = options[:related_column_aliases] || []
+      return serialized if aliases.empty?
+
+      [items].flatten.each_with_index do |item, i|
+        aliases.each do |alias_name|
+          serialized[i][alias_name.to_sym] = item[alias_name]
+        end
+      end
+
+      serialized
+    end
+  end
+end

--- a/app/serializers/core_data_connector/events_serializer.rb
+++ b/app/serializers/core_data_connector/events_serializer.rb
@@ -2,6 +2,7 @@ module CoreDataConnector
   class EventsSerializer < BaseSerializer
     include OwnableSerializer
     include UserDefinedFields::FieldableSerializer
+    include RelatedColumnsSerializable
 
     index_attributes :id, :name, :description, start_date: FuzzyDates::FuzzyDateSerializer, end_date: FuzzyDates::FuzzyDateSerializer
     show_attributes :id, :name, :description, start_date: FuzzyDates::FuzzyDateSerializer, end_date: FuzzyDates::FuzzyDateSerializer

--- a/app/serializers/core_data_connector/instances_serializer.rb
+++ b/app/serializers/core_data_connector/instances_serializer.rb
@@ -2,6 +2,7 @@ module CoreDataConnector
   class InstancesSerializer < BaseSerializer
     include OwnableSerializer
     include UserDefinedFields::FieldableSerializer
+    include RelatedColumnsSerializable
 
     index_attributes :id, :name
     show_attributes :id, :name, source_names: [:id, :name, :primary]

--- a/app/serializers/core_data_connector/items_serializer.rb
+++ b/app/serializers/core_data_connector/items_serializer.rb
@@ -2,6 +2,7 @@ module CoreDataConnector
   class ItemsSerializer < BaseSerializer
     include OwnableSerializer
     include UserDefinedFields::FieldableSerializer
+    include RelatedColumnsSerializable
 
     index_attributes :id, :name
     show_attributes :id, :name, :faircopy_cloud_id, source_names: [:id, :name, :primary]

--- a/app/serializers/core_data_connector/organizations_serializer.rb
+++ b/app/serializers/core_data_connector/organizations_serializer.rb
@@ -2,6 +2,7 @@ module CoreDataConnector
   class OrganizationsSerializer < BaseSerializer
     include OwnableSerializer
     include UserDefinedFields::FieldableSerializer
+    include RelatedColumnsSerializable
 
     index_attributes :id, :name
     show_attributes :id, :name, :description, organization_names: [:id, :name, :primary]

--- a/app/serializers/core_data_connector/people_serializer.rb
+++ b/app/serializers/core_data_connector/people_serializer.rb
@@ -2,6 +2,7 @@ module CoreDataConnector
   class PeopleSerializer < BaseSerializer
     include OwnableSerializer
     include UserDefinedFields::FieldableSerializer
+    include RelatedColumnsSerializable
 
     index_attributes :id, :first_name, :middle_name, :last_name
     show_attributes :id, :first_name, :middle_name, :last_name, :biography, person_names: [:id, :first_name, :middle_name, :last_name, :primary]

--- a/app/serializers/core_data_connector/places_serializer.rb
+++ b/app/serializers/core_data_connector/places_serializer.rb
@@ -3,7 +3,6 @@ module CoreDataConnector
     include OwnableSerializer
     include UserDefinedFields::FieldableSerializer
     include RelatedColumnsSerializable
-    include RelatedColumnsSerializable
 
     index_attributes :id, :name
     show_attributes :id, :name, place_names: [:id, :name, :primary], place_geometry: PlaceGeometriesSerializer,

--- a/app/serializers/core_data_connector/places_serializer.rb
+++ b/app/serializers/core_data_connector/places_serializer.rb
@@ -2,6 +2,7 @@ module CoreDataConnector
   class PlacesSerializer < BaseSerializer
     include OwnableSerializer
     include UserDefinedFields::FieldableSerializer
+    include RelatedColumnsSerializable
 
     index_attributes :id, :name
     show_attributes :id, :name, place_names: [:id, :name, :primary], place_geometry: PlaceGeometriesSerializer,

--- a/app/serializers/core_data_connector/places_serializer.rb
+++ b/app/serializers/core_data_connector/places_serializer.rb
@@ -3,6 +3,7 @@ module CoreDataConnector
     include OwnableSerializer
     include UserDefinedFields::FieldableSerializer
     include RelatedColumnsSerializable
+    include RelatedColumnsSerializable
 
     index_attributes :id, :name
     show_attributes :id, :name, place_names: [:id, :name, :primary], place_geometry: PlaceGeometriesSerializer,

--- a/app/serializers/core_data_connector/project_models_serializer.rb
+++ b/app/serializers/core_data_connector/project_models_serializer.rb
@@ -4,7 +4,7 @@ module CoreDataConnector
     include UserDefinedFields::DefineableSerializer
 
     index_attributes :id, :uuid, :project_id, :name, :name_singular, :model_class, :model_class_view, :slug, :order,
-                     project: ProjectsSerializer
+                     project: ProjectsSerializer, user_defined_fields: UserDefinedFields::UserDefinedFieldsSerializer
 
     index_attributes(:has_shares) do |project_model|
       !project_model.project_model_shares.empty?
@@ -21,7 +21,8 @@ module CoreDataConnector
                                                           primary_model: ProjectModelsSerializer,
                                                           user_defined_fields: UserDefinedFields::UserDefinedFieldsSerializer],
                     project_model_accesses: [:id, :project_id, project: ProjectsSerializer],
-                    project_model_shares: [:id, :project_model_access_id, project_model_access: ProjectModelAccessesSerializer]
+                    project_model_shares: [:id, :project_model_access_id, project_model_access: ProjectModelAccessesSerializer],
+                    user_defined_fields: UserDefinedFields::UserDefinedFieldsSerializer
 
     show_attributes(:has_shares) do |project_model|
       !project_model.project_model_shares.empty?

--- a/app/serializers/core_data_connector/taxonomies_serializer.rb
+++ b/app/serializers/core_data_connector/taxonomies_serializer.rb
@@ -2,6 +2,7 @@ module CoreDataConnector
   class TaxonomiesSerializer < BaseSerializer
     include OwnableSerializer
     include UserDefinedFields::FieldableSerializer
+    include RelatedColumnsSerializable
 
     index_attributes :id, :name
     show_attributes :id, :name

--- a/app/serializers/core_data_connector/works_serializer.rb
+++ b/app/serializers/core_data_connector/works_serializer.rb
@@ -2,6 +2,7 @@ module CoreDataConnector
   class WorksSerializer < BaseSerializer
     include OwnableSerializer
     include UserDefinedFields::FieldableSerializer
+    include RelatedColumnsSerializable
 
     index_attributes :id, :name
     show_attributes :id, :name, source_names: [:id, :name, :primary]


### PR DESCRIPTION
# Summary

This PR adds the ability to request joined columns via the API.

Columns are requested through a new param called `join_columns` in the format `rel_<relationship_id>_<field_name>`. For example, let's say you have a relationship of ID 50 between people and places. Calling the `people` endpoint with `join_columns=rel_50_name` joins the `name` column of the places side of the relationship. Calling the `places` endpoint with `join_columns=rel_50_name` joins the `name` column for people.

The important part for performance is that nothing is joined if not requested in the params. I'm pretty sure I've got the error states covered (columns the user doesn't have permission to access + relationships that are not actually related to the current model).

The `RelatedColumnable` concern overrides the `index` method from `resource-api` so that's something to keep an eye on in the future if `resource-api` ever changes.

There are two types of fields supported:
* `name` is a special field name here that functions similar to the existing `display_name` attribute but in pure SQL. It will return a concatenated full name for people and the primary name for sources.
* User-defined fields are supported with the syntax `udf.<uuid>`, so e.g. `rel_50_udf.2cfd23a8_6121_40cd_9847_a4572bee8bbe`
* Non-name system fields such as event dates are not currently supported

