### PR TITLE
Audit logging

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,7 @@ PATH
       fuzzy_dates
       jwt (~> 3.2)
       jwt_auth
+      paper_trail (>= 16.0)
       postmark-rails (~> 0.22.1)
       rack-cors (~> 3.0.0)
       rails (>= 8.1, < 9)
@@ -234,6 +235,9 @@ GEM
       racc (~> 1.4)
     pagy (5.10.1)
       activesupport
+    paper_trail (17.0.0)
+      activerecord (>= 7.1)
+      request_store (~> 1.4)
     postmark (1.25.1)
       json
     postmark-rails (0.22.1)
@@ -296,6 +300,8 @@ GEM
       psych (>= 4.0.0)
     reline (0.6.1)
       io-console (~> 0.5)
+    request_store (1.7.0)
+      rack (>= 1.4)
     rgeo (3.0.1)
     rgeo-activerecord (8.1.0)
       activerecord (>= 8.1, < 8.2)

--- a/app/controllers/core_data_connector/application_controller.rb
+++ b/app/controllers/core_data_connector/application_controller.rb
@@ -9,7 +9,7 @@ module CoreDataConnector
 
     # Actions
     skip_before_action :authenticate_request
-    before_action :handle_authentication
+    before_action :handle_authentication, :set_paper_trail_whodunnit
 
     def item_class
       "CoreDataConnector::#{controller_name.singularize.classify}".constantize
@@ -17,6 +17,16 @@ module CoreDataConnector
 
     def serializer_class
       "CoreDataConnector::#{"#{controller_name}_serializer".classify}".constantize
+    end
+
+    protected
+
+    def user_for_paper_trail
+      current_user&.id
+    end
+
+    def info_for_paper_trail
+      { request_uuid: request.uuid }
     end
 
     private

--- a/app/controllers/core_data_connector/versions_controller.rb
+++ b/app/controllers/core_data_connector/versions_controller.rb
@@ -1,0 +1,151 @@
+module CoreDataConnector
+  class VersionsController < ApplicationController
+    TRACKABLE_MODELS = %w[
+      Event
+      Instance
+      Item
+      MediaContent
+      Organization
+      Person
+      Place
+      Taxonomy
+      Work
+    ].freeze
+
+    protected
+
+    def base_query
+      scope = super
+
+      if params[:project_id].present?
+        authorize project, :show?
+
+        scope.merge(project_condition).order(created_at: :desc, id: :desc)
+      elsif is_valid?
+        authorize root_record, :show?
+
+        scope
+          .where(root_type: root_record.class.name, root_id: root_record.id)
+          .order(created_at: :desc, id: :desc)
+      else
+        Version.none
+      end
+    end
+
+    def load_records(items)
+      versions = [items].flatten
+
+      preload_user_defined_fields versions
+
+      super.merge(
+        attribute_changes: method(:attribute_changes),
+        user_defined_changes: method(:user_defined_changes)
+      )
+    end
+
+    def attribute_changes(version)
+      serialized = {}
+
+      extract_changes(version).each do |attribute, (from, to)|
+        next if attribute == 'user_defined'
+
+        serialized[attribute] = { from: from, to: to }
+      end
+
+      serialized
+    end
+
+    def user_defined_changes(version)
+      before, after = extract_changes(version)['user_defined']
+      before ||= {}
+      after ||= {}
+
+      (before.keys | after.keys).filter_map do |uuid|
+        from = before[uuid]
+        to = after[uuid]
+
+        next if from == to
+
+        field = @user_defined_fields[uuid]
+
+        {
+          uuid: uuid,
+          label: field&.column_name || uuid,
+          data_type: field&.data_type,
+          from: from,
+          to: to
+        }
+      end
+    end
+
+    private
+
+    def extract_changes(version)
+      if version.object_changes.present?
+        version.object_changes
+      elsif version.event == 'destroy' && version.object.present?
+        version.object.transform_values { |value| [value, nil] }
+      else
+        {}
+      end
+    end
+
+    def preload_user_defined_fields(versions)
+      uuids = versions.flat_map { |version| user_defined_uuids(version) }.uniq
+
+      @user_defined_fields = UserDefinedFields::UserDefinedField
+                               .where(uuid: uuids)
+                               .index_by(&:uuid)
+    end
+
+    def user_defined_uuids(version)
+      uuids = []
+
+      if version.object_changes.present?
+        before, after = version.object_changes['user_defined']
+        uuids += (before || {}).keys + (after || {}).keys
+      end
+
+      if version.object.present?
+        uuids += (version.object['user_defined'] || {}).keys
+      end
+
+      uuids
+    end
+
+    def is_valid?
+      record_class.is_a?(Class) && record_class < ApplicationRecord && record_class.include?(Auditable)
+    end
+
+    def root_record
+      @root_record ||= record_class.find(params[parent_param])
+    end
+
+    def record_class
+      @record_class ||= parent_param && "CoreDataConnector::#{parent_param.to_s.delete_suffix('_id').classify}".safe_constantize
+    end
+
+    def parent_param
+      @parent_param ||= TRACKABLE_MODELS.map { |model| :"#{model.underscore}_id" }
+                                         .find { |key| params[key].present? }
+    end
+
+    def project
+      @project ||= Project.find(params[:project_id])
+    end
+
+    # Combines each trackable model's owned records for the project into a single
+    # (root_type = X AND root_id IN (...)) OR (...) condition.
+    def project_condition
+      TRACKABLE_MODELS
+        .map { |model| trackable_condition(model) }
+        .reduce(:or)
+    end
+
+    def trackable_condition(model)
+      klass = "CoreDataConnector::#{model}".constantize
+
+      Version.where(root_type: klass.name, root_id: klass.owned_records_by_project(project.id).select(:id))
+    end
+  end
+end

--- a/app/controllers/core_data_connector/versions_controller.rb
+++ b/app/controllers/core_data_connector/versions_controller.rb
@@ -24,8 +24,7 @@ module CoreDataConnector
         scope = scope.where(project_id: project.id)
       elsif is_valid?
         authorize root_record, :show?
-        scope = scope.where(root_type:
-                              root_record.class.name, root_id: root_record.id)
+        scope = scope.merge(Version.for_record(root_record))
       else
         return Version.none
       end

--- a/app/controllers/core_data_connector/versions_controller.rb
+++ b/app/controllers/core_data_connector/versions_controller.rb
@@ -12,7 +12,7 @@ module CoreDataConnector
       Work
     ].freeze
 
-    preloads :user, root: :primary_name
+    preloads :user
 
     protected
 
@@ -21,7 +21,7 @@ module CoreDataConnector
 
       if params[:project_id].present?
         authorize project, :show?
-        scope = scope.merge(project_condition)
+        scope = scope.where(project_id: project.id)
       elsif is_valid?
         authorize root_record, :show?
         scope = scope.where(root_type:
@@ -132,20 +132,6 @@ module CoreDataConnector
 
     def project
       @project ||= Project.find(params[:project_id])
-    end
-
-    # Combines each trackable model's owned records for the project into a single
-    # (root_type = X AND root_id IN (...)) OR (...) condition.
-    def project_condition
-      TRACKABLE_MODELS
-        .map { |model| trackable_condition(model) }
-        .reduce(:or)
-    end
-
-    def trackable_condition(model)
-      klass = "CoreDataConnector::#{model}".constantize
-
-      Version.where(root_type: klass.name, root_id: klass.owned_records_by_project(project.id).select(:id))
     end
   end
 end

--- a/app/controllers/core_data_connector/versions_controller.rb
+++ b/app/controllers/core_data_connector/versions_controller.rb
@@ -12,6 +12,8 @@ module CoreDataConnector
       Work
     ].freeze
 
+    preloads :user, root: :primary_name
+
     protected
 
     def base_query
@@ -19,23 +21,21 @@ module CoreDataConnector
 
       if params[:project_id].present?
         authorize project, :show?
-
-        scope.merge(project_condition).order(created_at: :desc, id: :desc)
+        scope = scope.merge(project_condition)
       elsif is_valid?
         authorize root_record, :show?
-
-        scope
-          .where(root_type: root_record.class.name, root_id: root_record.id)
-          .order(created_at: :desc, id: :desc)
+        scope = scope.where(root_type:
+                              root_record.class.name, root_id: root_record.id)
       else
-        Version.none
+        return Version.none
       end
+
+      params[:sort_by].present? ? scope :
+        scope.order(created_at: :desc, id: :desc)
     end
 
     def load_records(items)
-      versions = [items].flatten
-
-      preload_user_defined_fields versions
+      preload_user_defined_fields [items].flatten
 
       super.merge(
         attribute_changes: method(:attribute_changes),

--- a/app/controllers/core_data_connector/versions_controller.rb
+++ b/app/controllers/core_data_connector/versions_controller.rb
@@ -1,17 +1,5 @@
 module CoreDataConnector
   class VersionsController < ApplicationController
-    TRACKABLE_MODELS = %w[
-      Event
-      Instance
-      Item
-      MediaContent
-      Organization
-      Person
-      Place
-      Taxonomy
-      Work
-    ].freeze
-
     preloads :user
 
     protected
@@ -113,7 +101,7 @@ module CoreDataConnector
     end
 
     def is_valid?
-      record_class.is_a?(Class) && record_class < ApplicationRecord && record_class.include?(Auditable)
+      record_class.present?
     end
 
     def root_record
@@ -121,12 +109,32 @@ module CoreDataConnector
     end
 
     def record_class
-      @record_class ||= parent_param && "CoreDataConnector::#{parent_param.to_s.delete_suffix('_id').classify}".safe_constantize
+      resolve_parent
+      @record_class
     end
 
     def parent_param
-      @parent_param ||= TRACKABLE_MODELS.map { |model| :"#{model.underscore}_id" }
-                                         .find { |key| params[key].present? }
+      resolve_parent
+      @parent_param
+    end
+
+    def resolve_parent
+      return if defined?(@resolved_parent)
+      @resolved_parent = true
+
+      @parent_param = params.keys
+                            .map(&:to_sym)
+                            .select { |key| key.to_s.end_with?('_id') && params[key].present? }
+                            .find do |key|
+                              klass = audit_root_class(key)
+                              @record_class = klass if klass
+                              klass
+                            end
+    end
+
+    def audit_root_class(param)
+      klass = "CoreDataConnector::#{param.to_s.delete_suffix('_id').classify}".safe_constantize
+      klass if klass.is_a?(Class) && klass.respond_to?(:audit_root?) && klass.audit_root?
     end
 
     def project

--- a/app/models/concerns/core_data_connector/auditable.rb
+++ b/app/models/concerns/core_data_connector/auditable.rb
@@ -9,10 +9,30 @@ module CoreDataConnector
           meta: {
             root_type: ->(record) { record.audit_root&.class&.name },
             root_id: ->(record) { record.audit_root&.id },
+            root_display_name: ->(record) { record.audit_root&.display_name },
+            root_uuid: ->(record) { record.audit_root&.uuid },
+            root_project_model_id: ->(record) { record.audit_root&.project_model_id },
+            project_id: ->(record) { record.audit_root&.project_id },
             meta: ->(record) { record.audit_metadata }
           },
           **options,
-          ignore: [:id, :created_at, :updated_at, :uuid].concat(options[:ignore] || []),
+          ignore: [
+            :id,
+            :created_at,
+            :updated_at,
+            :uuid,
+            :import_id,
+            :project_model_id,
+            :z_event_id,
+            :z_instance_id,
+            :z_item_id,
+            :z_media_content_id,
+            :z_organization_id,
+            :z_person_id,
+            :z_place_id,
+            :z_taxonomy_id,
+            :z_work_id
+          ].concat(options[:ignore] || []),
         )
 
         if root

--- a/app/models/concerns/core_data_connector/auditable.rb
+++ b/app/models/concerns/core_data_connector/auditable.rb
@@ -3,16 +3,12 @@ module CoreDataConnector
     extend ActiveSupport::Concern
 
     class_methods do
-      def track_changes(root: nil, **options)
+      def track_changes(root: nil, roots: nil, **options)
         has_paper_trail(
           versions: { class_name: 'CoreDataConnector::Version' },
           meta: {
-            root_type: ->(record) { record.audit_root&.class&.name },
-            root_id: ->(record) { record.audit_root&.id },
-            root_display_name: ->(record) { record.audit_root&.display_name },
-            root_uuid: ->(record) { record.audit_root&.uuid },
-            root_project_model_id: ->(record) { record.audit_root&.project_model_id },
-            project_id: ->(record) { record.audit_root&.project_id },
+            roots: ->(record) { record.audit_roots_data },
+            project_id: ->(record) { record.audit_roots.first&.project_id },
             meta: ->(record) { record.audit_metadata }
           },
           **options,
@@ -35,17 +31,45 @@ module CoreDataConnector
           ].concat(options[:ignore] || []),
         )
 
-        if root
-          define_method(:audit_root) { root.call(self) }
-        else
-          define_method(:audit_root) { self }
+        after_commit :backfill_audit_roots_data, on: :create
+
+        if roots
+          define_method(:audit_roots) { Array(roots.call(self)).compact }
+        elsif root
+          define_method(:audit_roots) { [root.call(self)].compact }
         end
+      end
+    end
+
+    def audit_roots
+      [self]
+    end
+
+    def audit_roots_data
+      audit_roots.map do |record|
+        {
+          type: record.class.name,
+          id: record.id,
+          display_name: record.display_name,
+          uuid: record.uuid,
+          project_model_id: record.project_model_id
+        }
       end
     end
 
     # Additional model-specific data to store alongside each version
     def audit_metadata
       nil
+    end
+
+    private
+
+    # Fill in root data after record creation
+    def backfill_audit_roots_data
+      data = self.class.find_by(id: id)&.audit_roots_data
+      return if data.blank?
+
+      versions.where(event: 'create').update_all(roots: data)
     end
   end
 end

--- a/app/models/concerns/core_data_connector/auditable.rb
+++ b/app/models/concerns/core_data_connector/auditable.rb
@@ -6,13 +6,13 @@ module CoreDataConnector
       def track_changes(root: nil, **options)
         has_paper_trail(
           versions: { class_name: 'CoreDataConnector::Version' },
-          ignore: [:updated_at],
           meta: {
             root_type: ->(record) { record.audit_root&.class&.name },
             root_id: ->(record) { record.audit_root&.id },
             meta: ->(record) { record.audit_metadata }
           },
-          **options
+          **options,
+          ignore: [:id, :created_at, :updated_at, :uuid].concat(options[:ignore] || []),
         )
 
         if root

--- a/app/models/concerns/core_data_connector/auditable.rb
+++ b/app/models/concerns/core_data_connector/auditable.rb
@@ -1,0 +1,31 @@
+module CoreDataConnector
+  module Auditable
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def track_changes(root: nil, **options)
+        has_paper_trail(
+          versions: { class_name: 'CoreDataConnector::Version' },
+          ignore: [:updated_at],
+          meta: {
+            root_type: ->(record) { record.audit_root&.class&.name },
+            root_id: ->(record) { record.audit_root&.id },
+            meta: ->(record) { record.audit_metadata }
+          },
+          **options
+        )
+
+        if root
+          define_method(:audit_root) { root.call(self) }
+        else
+          define_method(:audit_root) { self }
+        end
+      end
+    end
+
+    # Additional model-specific data to store alongside each version
+    def audit_metadata
+      nil
+    end
+  end
+end

--- a/app/models/concerns/core_data_connector/auditable.rb
+++ b/app/models/concerns/core_data_connector/auditable.rb
@@ -37,7 +37,14 @@ module CoreDataConnector
           define_method(:audit_roots) { Array(roots.call(self)).compact }
         elsif root
           define_method(:audit_roots) { [root.call(self)].compact }
+        else
+          @audit_root = true
         end
+      end
+
+      # Returns whether this model is a top-level trackable record
+      def audit_root?
+        @audit_root
       end
     end
 

--- a/app/models/core_data_connector/event.rb
+++ b/app/models/core_data_connector/event.rb
@@ -12,7 +12,11 @@ module CoreDataConnector
     include Reconcile::Event
     include Relateable
     include Search::Event
+    include Auditable
     include UserDefinedFields::Fieldable
+
+    # Audit logging
+    track_changes
 
     # Fuzzy dates
     has_fuzzy_dates :start_date, :end_date

--- a/app/models/core_data_connector/instance.rb
+++ b/app/models/core_data_connector/instance.rb
@@ -13,6 +13,10 @@ module CoreDataConnector
     include Relateable
     include UserDefinedFields::Fieldable
     include Search::Instance
+    include Auditable
+
+    # Audit logging
+    track_changes
 
     # Nameable table
     name_table :source_names, as: :nameable

--- a/app/models/core_data_connector/item.rb
+++ b/app/models/core_data_connector/item.rb
@@ -14,6 +14,10 @@ module CoreDataConnector
     include Relateable
     include UserDefinedFields::Fieldable
     include Search::Item
+    include Auditable
+
+    # Audit logging
+    track_changes
 
     # Nameable table
     name_table :source_names, as: :nameable

--- a/app/models/core_data_connector/media_content.rb
+++ b/app/models/core_data_connector/media_content.rb
@@ -10,8 +10,12 @@ module CoreDataConnector
     include Ownable
     include Relateable
     include Search::MediaContent
+    include Auditable
     include TripleEyeEffable::Resourceable
     include UserDefinedFields::Fieldable
+
+    # Audit logging
+    track_changes
 
     # Delegates
     delegate :storage_key, to: :project, allow_nil: true

--- a/app/models/core_data_connector/organization.rb
+++ b/app/models/core_data_connector/organization.rb
@@ -12,7 +12,11 @@ module CoreDataConnector
     include Reconcile::Organization
     include Relateable
     include Search::Organization
+    include Auditable
     include UserDefinedFields::Fieldable
+
+    # Audit logging
+    track_changes
 
     # Delegates
     delegate :name, to: :primary_name, allow_nil: true

--- a/app/models/core_data_connector/organization_name.rb
+++ b/app/models/core_data_connector/organization_name.rb
@@ -1,5 +1,12 @@
 module CoreDataConnector
   class OrganizationName < ApplicationRecord
+    # Includes
+    include Auditable
+
+    # Audit logging
+    track_changes root: ->(organization_name) { organization_name.organization }
+
+    # Relationships
     belongs_to :organization
   end
 end

--- a/app/models/core_data_connector/organization_name.rb
+++ b/app/models/core_data_connector/organization_name.rb
@@ -4,7 +4,7 @@ module CoreDataConnector
     include Auditable
 
     # Audit logging
-    track_changes root: ->(organization_name) { organization_name.organization }
+    track_changes root: ->(organization_name) { organization_name.organization }, ignore: [:organization_id]
 
     # Relationships
     belongs_to :organization

--- a/app/models/core_data_connector/person.rb
+++ b/app/models/core_data_connector/person.rb
@@ -12,7 +12,11 @@ module CoreDataConnector
     include Reconcile::Person
     include Relateable
     include Search::Person
+    include Auditable
     include UserDefinedFields::Fieldable
+
+    # Audit logging
+    track_changes
 
     # Delegates
     delegate :first_name, :middle_name, :last_name, to: :primary_name, allow_nil: true

--- a/app/models/core_data_connector/person_name.rb
+++ b/app/models/core_data_connector/person_name.rb
@@ -4,7 +4,7 @@ module CoreDataConnector
     include Auditable
 
     # Audit logging
-    track_changes root: ->(person_name) { person_name.person }
+    track_changes root: ->(person_name) { person_name.person }, ignore: [:person_id]
 
     # Relationships
     belongs_to :person

--- a/app/models/core_data_connector/person_name.rb
+++ b/app/models/core_data_connector/person_name.rb
@@ -1,5 +1,12 @@
 module CoreDataConnector
   class PersonName < ApplicationRecord
+    # Includes
+    include Auditable
+
+    # Audit logging
+    track_changes root: ->(person_name) { person_name.person }
+
+    # Relationships
     belongs_to :person
   end
 end

--- a/app/models/core_data_connector/place.rb
+++ b/app/models/core_data_connector/place.rb
@@ -14,7 +14,11 @@ module CoreDataConnector
     include Reconcile::Place
     include Relateable
     include Search::Place
+    include Auditable
     include UserDefinedFields::Fieldable
+
+    # Audit logging
+    track_changes
 
     # Relationships
     has_one :place_geometry, dependent: :destroy

--- a/app/models/core_data_connector/place_geometry.rb
+++ b/app/models/core_data_connector/place_geometry.rb
@@ -1,5 +1,11 @@
 module CoreDataConnector
   class PlaceGeometry < ApplicationRecord
+    # Includes
+    include Auditable
+
+    # todo: we can't directly log geometry updates, but we
+    # should store some sort of event in Papertrail.
+
     # Relationships
     belongs_to :place
 
@@ -8,6 +14,13 @@ module CoreDataConnector
 
     # Callbacks
     before_save :set_geometry
+
+    # Stores a GeoJSON snapshot of the geometry on each version.
+    def audit_metadata
+      return nil if geometry.blank?
+
+      { geometry: to_geojson }
+    end
 
     # Returns the "geometry" as GeoJSON
     def to_geojson

--- a/app/models/core_data_connector/place_geometry.rb
+++ b/app/models/core_data_connector/place_geometry.rb
@@ -3,8 +3,12 @@ module CoreDataConnector
     # Includes
     include Auditable
 
-    # todo: we can't directly log geometry updates, but we
-    # should store some sort of event in Papertrail.
+    # Audit logging. Geometries are too large to store in the audit log, but
+    # every geometry update destroys the existing place_geometry record
+    # and creates a new one, so that event should appear in the log.
+    track_changes root: ->(place_geometry) { place_geometry.place },
+                  ignore: [:place_id],
+                  skip: [:geometry]
 
     # Relationships
     belongs_to :place
@@ -14,13 +18,6 @@ module CoreDataConnector
 
     # Callbacks
     before_save :set_geometry
-
-    # Stores a GeoJSON snapshot of the geometry on each version.
-    def audit_metadata
-      return nil if geometry.blank?
-
-      { geometry: to_geojson }
-    end
 
     # Returns the "geometry" as GeoJSON
     def to_geojson

--- a/app/models/core_data_connector/place_layer.rb
+++ b/app/models/core_data_connector/place_layer.rb
@@ -2,6 +2,12 @@ module CoreDataConnector
   class PlaceLayer < ApplicationRecord
     LAYER_TYPES = %w(geojson raster georeference)
 
+    # Includes
+    include Auditable
+
+    # Audit logging
+    track_changes root: ->(place_layer) { place_layer.place }
+
     # Relationships
     belongs_to :place
 

--- a/app/models/core_data_connector/place_layer.rb
+++ b/app/models/core_data_connector/place_layer.rb
@@ -6,7 +6,7 @@ module CoreDataConnector
     include Auditable
 
     # Audit logging
-    track_changes root: ->(place_layer) { place_layer.place }
+    track_changes root: ->(place_layer) { place_layer.place }, ignore: [:place_id]
 
     # Relationships
     belongs_to :place

--- a/app/models/core_data_connector/place_name.rb
+++ b/app/models/core_data_connector/place_name.rb
@@ -6,7 +6,7 @@ module CoreDataConnector
     include Auditable
 
     # Audit logging
-    track_changes root: ->(place_name) { place_name.place }
+    track_changes root: ->(place_name) { place_name.place }, ignore: [:place_id]
 
     # Relationships
     belongs_to :place

--- a/app/models/core_data_connector/place_name.rb
+++ b/app/models/core_data_connector/place_name.rb
@@ -2,6 +2,12 @@ module CoreDataConnector
   class PlaceName < ApplicationRecord
     self.primary_key = :id
 
+    # Includes
+    include Auditable
+
+    # Audit logging
+    track_changes root: ->(place_name) { place_name.place }
+
     # Relationships
     belongs_to :place
   end

--- a/app/models/core_data_connector/relationship.rb
+++ b/app/models/core_data_connector/relationship.rb
@@ -2,7 +2,10 @@ module CoreDataConnector
   class Relationship < ApplicationRecord
     # Includes
     include Export::Relationship
+    include Auditable
     include UserDefinedFields::Fieldable
+
+    # Todo: audit log relationships
 
     # Relationships
     belongs_to :project_model_relationship

--- a/app/models/core_data_connector/relationship.rb
+++ b/app/models/core_data_connector/relationship.rb
@@ -5,7 +5,8 @@ module CoreDataConnector
     include Auditable
     include UserDefinedFields::Fieldable
 
-    # Todo: audit log relationships
+    track_changes roots: ->(relationship) { [relationship.primary_record, relationship.related_record] },
+                  only: [:user_defined]
 
     # Relationships
     belongs_to :project_model_relationship

--- a/app/models/core_data_connector/source_name.rb
+++ b/app/models/core_data_connector/source_name.rb
@@ -1,5 +1,12 @@
 module CoreDataConnector
   class SourceName < ApplicationRecord
+    # Includes
+    include Auditable
+
+    # Audit logging
+    track_changes root: ->(source_name) { source_name.nameable }
+
+    # Relationships
     belongs_to :nameable, polymorphic: true
   end
 end

--- a/app/models/core_data_connector/source_name.rb
+++ b/app/models/core_data_connector/source_name.rb
@@ -4,7 +4,7 @@ module CoreDataConnector
     include Auditable
 
     # Audit logging
-    track_changes root: ->(source_name) { source_name.nameable }
+    track_changes root: ->(source_name) { source_name.nameable }, ignore: [:nameable_id, :nameable_type]
 
     # Relationships
     belongs_to :nameable, polymorphic: true

--- a/app/models/core_data_connector/taxonomy.rb
+++ b/app/models/core_data_connector/taxonomy.rb
@@ -12,6 +12,10 @@ module CoreDataConnector
     include Relateable
     include UserDefinedFields::Fieldable
     include Search::Taxonomy
+    include Auditable
+
+    # Audit logging
+    track_changes
 
     # User defined fields parent
     resolve_defineable -> (taxonomy) { taxonomy.project_model }

--- a/app/models/core_data_connector/version.rb
+++ b/app/models/core_data_connector/version.rb
@@ -9,12 +9,5 @@ module CoreDataConnector
     def self.for_record(record)
       where('roots @> ?', [{ type: record.class.name, id: record.id }].to_json)
     end
-
-    # Group by request_uuid so we can combine changes to multiple tables that were semantically
-    # part of the same record action. (e.g. place name + geometry)
-    def self.changesets
-      order(created_at: :desc, id: :desc)
-        .group_by { |version| version.request_uuid }
-    end
   end
 end

--- a/app/models/core_data_connector/version.rb
+++ b/app/models/core_data_connector/version.rb
@@ -4,11 +4,10 @@ module CoreDataConnector
     self.table_name = 'core_data_connector_versions'
 
     # Relationships
-    belongs_to :root, polymorphic: true, optional: true
     has_one :user, foreign_key: :id, primary_key: :whodunnit
 
     def self.for_record(record)
-      where(root_type: record.class.name, root_id: record.id)
+      where('roots @> ?', [{ type: record.class.name, id: record.id }].to_json)
     end
 
     # Group by request_uuid so we can combine changes to multiple tables that were semantically

--- a/app/models/core_data_connector/version.rb
+++ b/app/models/core_data_connector/version.rb
@@ -1,0 +1,21 @@
+module CoreDataConnector
+  class Version < ApplicationRecord
+    include PaperTrail::VersionConcern
+    self.table_name = 'core_data_connector_versions'
+
+    # Relationships
+    belongs_to :root, polymorphic: true, optional: true
+    has_one :user, foreign_key: :id, primary_key: :whodunnit
+
+    def self.for_record(record)
+      where(root_type: record.class.name, root_id: record.id)
+    end
+
+    # Group by request_uuid so we can combine changes to multiple tables that were semantically
+    # part of the same record action. (e.g. place name + geometry)
+    def self.changesets
+      order(created_at: :desc, id: :desc)
+        .group_by { |version| version.request_uuid }
+    end
+  end
+end

--- a/app/models/core_data_connector/web_identifier.rb
+++ b/app/models/core_data_connector/web_identifier.rb
@@ -5,7 +5,7 @@ module CoreDataConnector
     include Auditable
 
     # Audit logging
-    track_changes root: ->(web_identifier) { web_identifier.identifiable }
+    track_changes root: ->(web_identifier) { web_identifier.identifiable }, ignore: [:identifiable_id]
 
     # Relationships
     belongs_to :identifiable, polymorphic: true

--- a/app/models/core_data_connector/web_identifier.rb
+++ b/app/models/core_data_connector/web_identifier.rb
@@ -2,6 +2,10 @@ module CoreDataConnector
   class WebIdentifier < ApplicationRecord
     # Includes
     include Export::WebIdentifier
+    include Auditable
+
+    # Audit logging
+    track_changes root: ->(web_identifier) { web_identifier.identifiable }
 
     # Relationships
     belongs_to :identifiable, polymorphic: true

--- a/app/models/core_data_connector/work.rb
+++ b/app/models/core_data_connector/work.rb
@@ -13,6 +13,10 @@ module CoreDataConnector
     include Relateable
     include UserDefinedFields::Fieldable
     include Search::Work
+    include Auditable
+
+    # Audit logging
+    track_changes
 
     # Nameable table
     name_table :source_names, as: :nameable

--- a/app/serializers/core_data_connector/versions_serializer.rb
+++ b/app/serializers/core_data_connector/versions_serializer.rb
@@ -1,0 +1,12 @@
+module CoreDataConnector
+  class VersionsSerializer < BaseSerializer
+    index_attributes :id, :event, :item_id, :request_uuid, :created_at, user: UsersSerializer
+
+    index_attributes(:record_type) { |version| version.item_type.demodulize }
+    index_attributes(:attributes) { |version, _current_user, options| options[:attribute_changes].call(version) }
+    index_attributes(:user_defined) { |version, _current_user, options| options[:user_defined_changes].call(version) }
+    index_attributes(:metadata) { |version| version.meta }
+
+    show_attributes(*index_attributes)
+  end
+end

--- a/app/serializers/core_data_connector/versions_serializer.rb
+++ b/app/serializers/core_data_connector/versions_serializer.rb
@@ -1,6 +1,6 @@
 module CoreDataConnector
   class VersionsSerializer < BaseSerializer
-    index_attributes :id, :event, :item_id, :request_uuid, :created_at, :root_id, user: UsersSerializer
+    index_attributes :id, :uuid, :event, :item_id, :request_uuid, :created_at, :root_id, user: UsersSerializer
 
     ROOT_ATTRIBUTES = {
       root_display_name: :display_name,

--- a/app/serializers/core_data_connector/versions_serializer.rb
+++ b/app/serializers/core_data_connector/versions_serializer.rb
@@ -1,11 +1,22 @@
 module CoreDataConnector
   class VersionsSerializer < BaseSerializer
-    index_attributes :id, :event, :item_id, :request_uuid, :created_at, user: UsersSerializer
+    index_attributes :id, :event, :item_id, :request_uuid, :created_at, :root_id, user: UsersSerializer
+
+    ROOT_ATTRIBUTES = {
+      root_display_name: :display_name,
+      root_uuid: :uuid,
+      root_project_model_id: :project_model_id
+    }.freeze
 
     index_attributes(:record_type) { |version| version.item_type.demodulize }
+    index_attributes(:root_record_type) { |version| version.root_type&.demodulize }
     index_attributes(:attributes) { |version, _current_user, options| options[:attribute_changes].call(version) }
     index_attributes(:user_defined) { |version, _current_user, options| options[:user_defined_changes].call(version) }
     index_attributes(:metadata) { |version| version.meta }
+
+    ROOT_ATTRIBUTES.each do |key, attribute|
+      index_attributes(key) { |version| version.root&.public_send(attribute) }
+    end
 
     show_attributes(*index_attributes)
   end

--- a/app/serializers/core_data_connector/versions_serializer.rb
+++ b/app/serializers/core_data_connector/versions_serializer.rb
@@ -1,22 +1,13 @@
 module CoreDataConnector
   class VersionsSerializer < BaseSerializer
-    index_attributes :id, :uuid, :event, :item_id, :request_uuid, :created_at, :root_id, user: UsersSerializer
-
-    ROOT_ATTRIBUTES = {
-      root_display_name: :display_name,
-      root_uuid: :uuid,
-      root_project_model_id: :project_model_id
-    }.freeze
+    index_attributes :id, :uuid, :event, :item_id, :request_uuid, :created_at, :root_id,
+                     :root_display_name, :root_uuid, :root_project_model_id, user: UsersSerializer
 
     index_attributes(:record_type) { |version| version.item_type.demodulize }
     index_attributes(:root_record_type) { |version| version.root_type&.demodulize }
     index_attributes(:attributes) { |version, _current_user, options| options[:attribute_changes].call(version) }
     index_attributes(:user_defined) { |version, _current_user, options| options[:user_defined_changes].call(version) }
     index_attributes(:metadata) { |version| version.meta }
-
-    ROOT_ATTRIBUTES.each do |key, attribute|
-      index_attributes(key) { |version| version.root&.public_send(attribute) }
-    end
 
     show_attributes(*index_attributes)
   end

--- a/app/serializers/core_data_connector/versions_serializer.rb
+++ b/app/serializers/core_data_connector/versions_serializer.rb
@@ -1,10 +1,20 @@
 module CoreDataConnector
   class VersionsSerializer < BaseSerializer
-    index_attributes :id, :uuid, :event, :item_id, :request_uuid, :created_at, :root_id,
-                     :root_display_name, :root_uuid, :root_project_model_id, user: UsersSerializer
+    index_attributes :id, :uuid, :event, :item_id, :request_uuid, :created_at, user: UsersSerializer
 
     index_attributes(:record_type) { |version| version.item_type.demodulize }
-    index_attributes(:root_record_type) { |version| version.root_type&.demodulize }
+
+    index_attributes(:roots) do |version|
+      Array(version.roots).map do |root|
+        {
+          record_type: root['type']&.demodulize,
+          id: root['id'],
+          display_name: root['display_name'],
+          uuid: root['uuid'],
+          project_model_id: root['project_model_id']
+        }
+      end
+    end
     index_attributes(:attributes) { |version, _current_user, options| options[:attribute_changes].call(version) }
     index_attributes(:user_defined) { |version, _current_user, options| options[:user_defined_changes].call(version) }
     index_attributes(:metadata) { |version| version.meta }

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -8,26 +8,30 @@ concern :mergeable do
   post :merge, on: :collection
 end
 
-resources :events, concerns: [:manifestable, :mergeable]
+concern :versionable do
+  resources :versions, only: [:index]
+end
 
-resources :instances, concerns: [:manifestable, :mergeable]
+resources :events, concerns: [:manifestable, :mergeable, :versionable]
 
-resources :items, concerns: [:manifestable, :mergeable] do
+resources :instances, concerns: [:manifestable, :mergeable, :versionable]
+
+resources :items, concerns: [:manifestable, :mergeable, :versionable] do
   get :analyze_import, on: :member
   post :import, on: :member
 end
 
 resources :jobs, only: [:destroy, :index]
 
-resources :media_contents, concerns: [:manifestable, :mergeable] do
+resources :media_contents, concerns: [:manifestable, :mergeable, :versionable] do
   post :upload, on: :collection
 end
 
-resources :organizations, concerns: [:manifestable, :mergeable]
+resources :organizations, concerns: [:manifestable, :mergeable, :versionable]
 
-resources :people, concerns: [:manifestable, :mergeable]
+resources :people, concerns: [:manifestable, :mergeable, :versionable]
 
-resources :places, concerns: [:manifestable, :mergeable]
+resources :places, concerns: [:manifestable, :mergeable, :versionable]
 
 resources :project_models do
   get :model_classes, on: :collection
@@ -35,7 +39,7 @@ end
 
 resources :project_model_accesses, only: :index
 
-resources :projects do
+resources :projects, concerns: [:versionable] do
   post :analyze_import, on: :member
   post :clear, on: :member
   get :export_configuration, on: :member
@@ -53,7 +57,7 @@ resources :relationships do
   post :upload, on: :collection
 end
 
-resources :taxonomies, concerns: [:manifestable, :mergeable]
+resources :taxonomies, concerns: [:manifestable, :mergeable, :versionable]
 
 resources :user_projects do
   post :invite, on: :member
@@ -71,5 +75,5 @@ end
 
 resources :web_identifiers
 
-resources :works, concerns: [:manifestable, :mergeable]
+resources :works, concerns: [:manifestable, :mergeable, :versionable]
 

--- a/core_data_connector.gemspec
+++ b/core_data_connector.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activerecord-postgis-adapter', '~> 11.1'
   spec.add_dependency 'fuzzy_dates'
   spec.add_dependency 'jwt', '~> 3.2'
+  spec.add_dependency 'paper_trail', '>= 16.0'
   spec.add_dependency 'jwt_auth'
   spec.add_dependency 'postmark-rails', '~> 0.22.1'
   spec.add_dependency 'rack-cors', '~> 3.0.0'

--- a/db/migrate/20260715000000_create_core_data_connector_versions.rb
+++ b/db/migrate/20260715000000_create_core_data_connector_versions.rb
@@ -1,6 +1,7 @@
 class CreateCoreDataConnectorVersions < ActiveRecord::Migration[8.1]
   def change
     create_table :core_data_connector_versions do |t|
+      t.uuid :uuid, default: 'gen_random_uuid()', null: false
       t.string :item_type, null: false
       t.bigint :item_id, null: false
       t.string :event, null: false

--- a/db/migrate/20260715000000_create_core_data_connector_versions.rb
+++ b/db/migrate/20260715000000_create_core_data_connector_versions.rb
@@ -8,11 +8,7 @@ class CreateCoreDataConnectorVersions < ActiveRecord::Migration[8.1]
       t.string :whodunnit
       t.jsonb :object
       t.jsonb :object_changes
-      t.string :root_type
-      t.bigint :root_id
-      t.string :root_display_name
-      t.uuid :root_uuid
-      t.bigint :root_project_model_id
+      t.jsonb :roots
       t.bigint :project_id
       t.jsonb :meta
       t.string :request_uuid
@@ -20,7 +16,7 @@ class CreateCoreDataConnectorVersions < ActiveRecord::Migration[8.1]
     end
 
     add_index :core_data_connector_versions, [:item_type, :item_id]
-    add_index :core_data_connector_versions, [:root_type, :root_id]
+    add_index :core_data_connector_versions, :roots, using: :gin, opclass: :jsonb_path_ops, name: 'index_cdc_versions_on_roots'
     add_index :core_data_connector_versions, [:project_id, :created_at, :id], order: { created_at: :desc, id: :desc }
     add_index :core_data_connector_versions, :request_uuid
     add_index :core_data_connector_versions, :whodunnit

--- a/db/migrate/20260715000000_create_core_data_connector_versions.rb
+++ b/db/migrate/20260715000000_create_core_data_connector_versions.rb
@@ -1,0 +1,22 @@
+class CreateCoreDataConnectorVersions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :core_data_connector_versions do |t|
+      t.string :item_type, null: false
+      t.bigint :item_id, null: false
+      t.string :event, null: false
+      t.string :whodunnit
+      t.jsonb :object
+      t.jsonb :object_changes
+      t.string :root_type
+      t.bigint :root_id
+      t.jsonb :meta
+      t.string :request_uuid
+      t.datetime :created_at
+    end
+
+    add_index :core_data_connector_versions, [:item_type, :item_id]
+    add_index :core_data_connector_versions, [:root_type, :root_id]
+    add_index :core_data_connector_versions, :request_uuid
+    add_index :core_data_connector_versions, :whodunnit
+  end
+end

--- a/db/migrate/20260715000000_create_core_data_connector_versions.rb
+++ b/db/migrate/20260715000000_create_core_data_connector_versions.rb
@@ -10,6 +10,10 @@ class CreateCoreDataConnectorVersions < ActiveRecord::Migration[8.1]
       t.jsonb :object_changes
       t.string :root_type
       t.bigint :root_id
+      t.string :root_display_name
+      t.uuid :root_uuid
+      t.bigint :root_project_model_id
+      t.bigint :project_id
       t.jsonb :meta
       t.string :request_uuid
       t.datetime :created_at
@@ -17,6 +21,7 @@ class CreateCoreDataConnectorVersions < ActiveRecord::Migration[8.1]
 
     add_index :core_data_connector_versions, [:item_type, :item_id]
     add_index :core_data_connector_versions, [:root_type, :root_id]
+    add_index :core_data_connector_versions, [:project_id, :created_at, :id], order: { created_at: :desc, id: :desc }
     add_index :core_data_connector_versions, :request_uuid
     add_index :core_data_connector_versions, :whodunnit
   end

--- a/lib/core_data_connector.rb
+++ b/lib/core_data_connector.rb
@@ -1,4 +1,5 @@
 require 'activerecord-postgis-adapter'
+require 'paper_trail'
 require 'core_data_connector/version'
 require 'core_data_connector/engine'
 require 'rgeo/active_record'


### PR DESCRIPTION
# Summary

This PR adds audit logs via PaperTrail.

* All editable models, including top-level records like Event and Place as well as joined records like PersonName and PlaceGeometry, are hooked up to Papertrail and receive a `CoreDataConnector::Version` record when they're created, changed, or deleted.
* Each top-level model has an endpoint at `/core_data/{model}/{id}/versions` that renders a JSON list of versions for the record, including joined models like names, etc.
* All version history for a project can be viewed via the `/core_data/projects/{id}/versions` endpoint, which joins all of the above for every record owned by the project, including deleted records.

I will add proper testing notes on the corresponding frontend PR.