### PR TITLE
Accept Clerk Bearer tokens from the pstudio CLI

### DIFF
--- a/app/controllers/concerns/core_data_connector/clerk_authenticatable.rb
+++ b/app/controllers/concerns/core_data_connector/clerk_authenticatable.rb
@@ -9,7 +9,7 @@ module CoreDataConnector
     private
 
     def authenticate_clerk_request
-      token = request.cookies["__session"]
+      token = clerk_token
       return render_unauthorized unless token.present?
 
       clerk_session = clerk_client.verify_token(token)
@@ -46,6 +46,21 @@ module CoreDataConnector
       user.save!
 
       user
+    end
+
+    # The Clerk-issued JWT to verify: the __session cookie set by a browser,
+    # or a Bearer token from a non-browser client (the pstudio CLI's OAuth
+    # login). Both are Clerk JWTs, verified the same way against Clerk's JWKS;
+    # sub is the Clerk user id in either case.
+    def clerk_token
+      request.cookies["__session"].presence || bearer_token
+    end
+
+    def bearer_token
+      header = request.headers["Authorization"]
+      return nil unless header&.start_with?("Bearer ")
+
+      header.split(" ", 2).last
     end
 
     def get_clerk_data(clerk_id)


### PR DESCRIPTION
A developer who signs in through the pstudio command-line tool gets a Clerk token, but the connector reads Clerk tokens only from the `__session` browser cookie. The command-line tool has no cookie, so it sends the token in an `Authorization: Bearer` header and gets a 401.

This is a change to `clerk_authenticatable`, which lets the connector read the token from either place, so a signed-in developer can call the FairData API. It is the connector half of the plan in core-data-cloud#646.

The token is verified as before against Clerk's published public keys, and the existing logic then maps it to a User record — including creating the user on first sign-in. This is a draft, but if it looks ok, we could deploy to staging and I'll test.