### PR TITLE
Audit log fixes and improvements

### DIFF
--- a/app/controllers/core_data_connector/versions_controller.rb
+++ b/app/controllers/core_data_connector/versions_controller.rb
@@ -22,11 +22,15 @@ module CoreDataConnector
     end
 
     def load_records(items)
-      preload_user_defined_fields [items].flatten
+      versions = [items].flatten
+
+      preload_user_defined_fields versions
+      preload_project_models versions
 
       super.merge(
         attribute_changes: method(:attribute_changes),
-        user_defined_changes: method(:user_defined_changes)
+        user_defined_changes: method(:user_defined_changes),
+        project_model_name: method(:project_model_name)
       )
     end
 
@@ -83,6 +87,20 @@ module CoreDataConnector
       @user_defined_fields = UserDefinedFields::UserDefinedField
                                .where(uuid: uuids)
                                .index_by(&:uuid)
+    end
+
+    def preload_project_models(versions)
+      ids = versions.flat_map { |version| project_model_ids(version) }.uniq
+
+      @project_models = ProjectModel.where(id: ids).index_by(&:id)
+    end
+
+    def project_model_ids(version)
+      Array(version.roots).filter_map { |root| root['project_model_id'] }
+    end
+
+    def project_model_name(project_model_id)
+      @project_models[project_model_id]&.name
     end
 
     def user_defined_uuids(version)

--- a/app/controllers/core_data_connector/versions_controller.rb
+++ b/app/controllers/core_data_connector/versions_controller.rb
@@ -25,13 +25,28 @@ module CoreDataConnector
       versions = [items].flatten
 
       preload_user_defined_fields versions
-      preload_project_models versions
+      preload_roots versions
 
       super.merge(
         attribute_changes: method(:attribute_changes),
         user_defined_changes: method(:user_defined_changes),
-        project_model_name: method(:project_model_name)
+        root_data: method(:root_data)
       )
+    end
+
+    def root_data(root)
+      record = @roots[root_key(root)]
+      project_model_id = record&.project_model_id || root['project_model_id']
+
+      {
+        record_type: root['type']&.demodulize,
+        id: root['id'],
+        uuid: record&.uuid || root['uuid'],
+        display_name: record&.display_name || root['display_name'],
+        project_model_id: project_model_id,
+        project_model_name: @project_models[project_model_id]&.name,
+        deleted: record.nil?
+      }
     end
 
     def attribute_changes(version)
@@ -89,18 +104,44 @@ module CoreDataConnector
                                .index_by(&:uuid)
     end
 
-    def preload_project_models(versions)
-      ids = versions.flat_map { |version| project_model_ids(version) }.uniq
+    def preload_roots(versions)
+      roots = versions.flat_map { |version| Array(version.roots) }
+
+      @roots = {}
+
+      roots.group_by { |root| root['type'] }.each do |type, group|
+        klass = root_class(type)
+        next if klass.nil?
+
+        scope = klass.where(id: group.map { |root| root['id'] }.uniq)
+
+        if klass.respond_to?(:get_names_table) && klass.get_names_table.present?
+          scope = scope.includes(:primary_name)
+        end
+
+        scope.each { |record| @roots[[type, record.id]] = record }
+      end
+
+      preload_project_models roots
+    end
+
+    def preload_project_models(roots)
+      ids = roots.filter_map do |root|
+        @roots[root_key(root)]&.project_model_id || root['project_model_id']
+      end.uniq
 
       @project_models = ProjectModel.where(id: ids).index_by(&:id)
     end
 
-    def project_model_ids(version)
-      Array(version.roots).filter_map { |root| root['project_model_id'] }
+    def root_key(root)
+      [root['type'], root['id']]
     end
 
-    def project_model_name(project_model_id)
-      @project_models[project_model_id]&.name
+    # Guards against types stored on older versions that have since been renamed
+    # or removed.
+    def root_class(type)
+      klass = type&.safe_constantize
+      klass if klass.is_a?(Class) && klass < ActiveRecord::Base
     end
 
     def user_defined_uuids(version)

--- a/app/models/concerns/core_data_connector/auditable.rb
+++ b/app/models/concerns/core_data_connector/auditable.rb
@@ -71,6 +71,7 @@ module CoreDataConnector
 
     private
 
+    # Fill in root data after record creation
     def backfill_audit_roots_data
       incomplete = versions.where(event: 'create').reject { |version| audit_roots_complete?(version) }
       return if incomplete.blank?

--- a/app/models/concerns/core_data_connector/auditable.rb
+++ b/app/models/concerns/core_data_connector/auditable.rb
@@ -71,12 +71,19 @@ module CoreDataConnector
 
     private
 
-    # Fill in root data after record creation
     def backfill_audit_roots_data
+      incomplete = versions.where(event: 'create').reject { |version| audit_roots_complete?(version) }
+      return if incomplete.blank?
+
       data = self.class.find_by(id: id)&.audit_roots_data
       return if data.blank?
 
-      versions.where(event: 'create').update_all(roots: data)
+      versions.where(id: incomplete.map(&:id)).update_all(roots: data)
+    end
+
+    def audit_roots_complete?(version)
+      roots = Array(version.roots)
+      roots.present? && roots.all? { |root| root['uuid'].present? }
     end
   end
 end

--- a/app/serializers/core_data_connector/versions_serializer.rb
+++ b/app/serializers/core_data_connector/versions_serializer.rb
@@ -4,14 +4,15 @@ module CoreDataConnector
 
     index_attributes(:record_type) { |version| version.item_type.demodulize }
 
-    index_attributes(:roots) do |version|
+    index_attributes(:roots) do |version, _current_user, options|
       Array(version.roots).map do |root|
         {
           record_type: root['type']&.demodulize,
           id: root['id'],
           display_name: root['display_name'],
           uuid: root['uuid'],
-          project_model_id: root['project_model_id']
+          project_model_id: root['project_model_id'],
+          project_model_name: options[:project_model_name]&.call(root['project_model_id'])
         }
       end
     end

--- a/app/serializers/core_data_connector/versions_serializer.rb
+++ b/app/serializers/core_data_connector/versions_serializer.rb
@@ -5,16 +5,7 @@ module CoreDataConnector
     index_attributes(:record_type) { |version| version.item_type.demodulize }
 
     index_attributes(:roots) do |version, _current_user, options|
-      Array(version.roots).map do |root|
-        {
-          record_type: root['type']&.demodulize,
-          id: root['id'],
-          display_name: root['display_name'],
-          uuid: root['uuid'],
-          project_model_id: root['project_model_id'],
-          project_model_name: options[:project_model_name]&.call(root['project_model_id'])
-        }
-      end
+      Array(version.roots).map { |root| options[:root_data].call(root) }
     end
     index_attributes(:attributes) { |version, _current_user, options| options[:attribute_changes].call(version) }
     index_attributes(:user_defined) { |version, _current_user, options| options[:user_defined_changes].call(version) }


### PR DESCRIPTION
# Summary

This PR makes the two backend-related changes from https://github.com/performant-software/core-data-cloud/issues/655:

* include the project model name in the serializer payload
* refactor how the `roots` field is handled in the controller/serializer:
  * track whether the root record is *currently* deleted using a new `deleted` boolean
  * `roots` are always the latest version of the record unless it has been deleted, in which case stored data is used (the actual serialized record is stored under `object` so this doesn't affect any potential future restore feature)